### PR TITLE
NullRefException for string sensor value with Value = null

### DIFF
--- a/src/server/HSMServer.Core/Model/Policies/StringValueLengthPolicy.cs
+++ b/src/server/HSMServer.Core/Model/Policies/StringValueLengthPolicy.cs
@@ -16,7 +16,7 @@
 
         internal override ValidationResult Validate(StringValue value)
         {
-            if (value.Value.Length > MaxStringLength)
+            if (value.Value?.Length > MaxStringLength)
                 return _tooLongStringSensor;
 
             return ValidationResult.Ok;

--- a/src/server/HSMServer.Core/Model/SensorValues/BaseValue.cs
+++ b/src/server/HSMServer.Core/Model/SensorValues/BaseValue.cs
@@ -57,6 +57,6 @@ namespace HSMServer.Core.Model
         public T Value { get; init; }
 
         [JsonIgnore]
-        public override string ShortInfo => Value.ToString();
+        public override string ShortInfo => Value?.ToString();
     }
 }

--- a/src/server/HSMServer/Model/History/HistoryValueViewModel.cs
+++ b/src/server/HSMServer/Model/History/HistoryValueViewModel.cs
@@ -29,7 +29,7 @@ namespace HSMServer.Model.History
         private static SimpleSensorValueViewModel Create<T>(BaseValue<T> value) =>
             new()
             {
-                Value = value.Value.ToString(),
+                Value = value.Value?.ToString(),
                 Time = value.Time,
                 Status = value.Status.ToClient(),
                 Comment = value.Comment,


### PR DESCRIPTION
```
Unhandled exception. System.NullReferenceException: Object reference not set to an instance of an object.
   at HSMServer.Core.Model.StringValueLengthPolicy.Validate(StringValue value) in /app/src/server/HSMServer.Core/Model/Policies/StringValueLengthPolicy.cs:line 22
   at HSMServer.Core.Model.BaseSensorModel`1.Validate(T value) in /app/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs:line 83
   at HSMServer.Core.Model.BaseSensorModel`1.TryValidate(BaseValue value, T& typedValue) in /app/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs:line 72
   at HSMServer.Core.Model.BaseSensorModel`1.TryAddValue(BaseValue value, BaseValue& cachedValue) in /app/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs:line 24
   at HSMServer.Core.Cache.TreeValuesCache.AddNewSensorValue(StoreInfo storeInfo)
   at HSMServer.Core.Cache.TreeValuesCache.UpdatesQueueNewItemsHandler(IEnumerable`1 storeInfos) in /app/src/server/HSMServer.Core/Cache/TreeValuesCache.cs:line 372
   at HSMServer.Core.SensorsUpdatesQueue.UpdatesQueue.RunManageThread(Object _) in /app/src/server/HSMServer.Core/SensorsUpdatesQueue/UpdatesQueue.cs:line 50
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_1(Object state)
   at System.Threading.ThreadPoolWorkQueue.Dispatch()
   at System.Threading.PortableThreadPool.WorkerThread.WorkerThreadStart()
```