### PR TITLE
fix: address alert schedule bugs from TAM-2032 review

### DIFF
--- a/src/server/HSMServer.Core/AlertSchedule/AlertScheduleParser.cs
+++ b/src/server/HSMServer.Core/AlertSchedule/AlertScheduleParser.cs
@@ -343,7 +343,8 @@ namespace HSMServer.Core.Schedule
 
         public void WriteYaml(IEmitter emitter, object value, Type type, ObjectSerializer serializer)
         {
-            throw new NotImplementedException();
+            var timeSpan = (TimeSpan)value;
+            emitter.Emit(new Scalar(timeSpan.ToString(@"hh\:mm")));
         }
     }
 

--- a/src/server/HSMServer.Core/AlertSchedule/AlertScheduleProvider.cs
+++ b/src/server/HSMServer.Core/AlertSchedule/AlertScheduleProvider.cs
@@ -133,8 +133,9 @@ namespace HSMServer.Core.Schedule
                     {
                         schedule = _parser.Parse(entity);
                     }
-                    catch
+                    catch (Exception ex)
                     {
+                        _logger.Error(ex, $"Failed to parse AlertSchedule {new Guid(entity.Id)} ('{entity.Name}'). A stub schedule will be used.");
                         schedule = new AlertSchedule()
                         {
                             Id = new Guid(entity.Id),

--- a/src/server/HSMServer.Core/Model/Policies/AlertSchedule.cs
+++ b/src/server/HSMServer.Core/Model/Policies/AlertSchedule.cs
@@ -63,8 +63,11 @@ namespace HSMServer.Core.Model.Policies
         private DateTime ConvertUtcToLocalTime(DateTime utcDateTime)
         {
             var timezone = TimeZoneInfo.FindSystemTimeZoneById(Timezone);
+            var utc = utcDateTime.Kind == DateTimeKind.Local
+                ? utcDateTime.ToUniversalTime()
+                : DateTime.SpecifyKind(utcDateTime, DateTimeKind.Utc);
 
-            return TimeZoneInfo.ConvertTimeFromUtc(utcDateTime, timezone);
+            return TimeZoneInfo.ConvertTimeFromUtc(utc, timezone);
         }
 
         private DaySchedule GetDaySchedule(DayOfWeek dayOfWeek)


### PR DESCRIPTION
## Summary

Three bugs from the post-merge review of TAM-2032 (Alert Schedules) that weren't fixed before merge:

- **Silent exception swallowing** in `LoadSchedulesFromDatabase`: `catch` block now logs the error via `_logger.Error` before falling back to a stub schedule
- **`TimeSpanYamlConverter.WriteYaml` (4-arg overload)** was throwing `NotImplementedException`; now mirrors the 3-arg overload
- **`ConvertUtcToLocalTime`** would throw `ArgumentException` if passed a `DateTimeKind.Local` datetime (which `TimeZoneInfo.ConvertTimeFromUtc` rejects); now normalizes to UTC first

## Test plan

- [ ] Save an alert schedule with time windows and verify serialization round-trips correctly (TimeSpan converter)
- [ ] Corrupt a schedule entry in DB and restart server — verify error is logged, stub is used, server starts normally
- [ ] Verify sensor value timestamps with `Kind=Unspecified` or `Kind=Local` are correctly converted to the schedule's timezone

🤖 Generated with [Claude Code](https://claude.com/claude-code)