### PR TITLE
TAM-1987: Fix tree collapse on F5

### DIFF
--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.21</Version>
+    <Version>3.40.23</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/server/HSMServer/Views/Shared/_Layout.cshtml
+++ b/src/server/HSMServer/Views/Shared/_Layout.cshtml
@@ -94,35 +94,36 @@
                                         </li>
 
 
-                                        <li class="nav-item dropdown">
+                                                                                <li class="nav-item dropdown">
                                             <a class="nav-link dropdown-toggle" href="#" id="optionsDropdown" role="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                                                 Configuration
                                             </a>
                                             <ul class="dropdown-menu" aria-labelledby="optionsDropdown">
                                                 <li>
                                                     <a class="dropdown-item" href="@Url.Action(ViewConstants.IndexAction, ViewConstants.AccessKeysController)">
-                                                        Access keys
+                                                        <i class="fas fa-key me-2"></i>Access keys
                                                     </a>
                                                 </li>
                                                 @if (UserRoleHelper.IsUsersPageAllowed((User)Context.User))
                                                 {
                                                     <li>
                                                         <a class="dropdown-item" href="@Url.Action(ViewConstants.UsersAction, ViewConstants.AccountController)">
-                                                            Users
+                                                            <i class="fas fa-users me-2"></i>Users
                                                         </a>
                                                     </li>
                                                 }
+                                                <li><hr class="dropdown-divider"></li>
                                                 @if (UserRoleHelper.IsConfigurationPageAllowed((User)Context.User))
                                                 {
                                                     <li>
                                                         <a class="dropdown-item" href="@Url.Action(ViewConstants.IndexAction, ViewConstants.ConfigurationController)">
-                                                            Settings
+                                                            <i class="fas fa-cog me-2"></i>Settings
                                                         </a>
                                                     </li>
                                                 }
                                                 <li>
                                                     <a class="dropdown-item" target="_blank" href="https://@(Context.Request.Host.Value.Replace("44333", "44330") + ViewConstants.ApiSwagger)">
-                                                        API
+                                                        <i class="fas fa-plug me-2"></i>API
                                                     </a>
                                                 </li>
                                             </ul>

--- a/src/server/HSMServer/Views/Tree/_Layout.cshtml
+++ b/src/server/HSMServer/Views/Tree/_Layout.cshtml
@@ -155,11 +155,11 @@
         container: document.getElementById('accessKeys_modal')
     });
 
-    setTimeout(updateTreeTimer, getCurrentUpdateTreeInterval());
-
-    document.addEventListener('DOMContentLoaded', () => {
+        document.addEventListener('DOMContentLoaded', () => {
 
         initializeTree();
+
+        setTimeout(updateTreeTimer, getCurrentUpdateTreeInterval());
 
         scrollHandlers.restoreTreeScroll();
 

--- a/src/server/HSMServer/wwwroot/src/js/tree.js
+++ b/src/server/HSMServer/wwwroot/src/js/tree.js
@@ -14,6 +14,7 @@ var searchServerRefresh = false;
 var emptySearch = false;
 var prevState = undefined;
 
+let isInitialLoad = true;
 let lastActivity = Date.now();
 let isCheckingActive = false;
 let wasNotified = false;
@@ -106,6 +107,11 @@ function refreshTreeHandler(e, data) {
 
     if (isRefreshing) {
         console.log('refreshTreeHandler: Refresh already in progress, skipping');
+        return;
+    }
+
+    if (isInitialLoad) {
+        console.log('refreshTreeHandler: Skipping during initial load');
         return;
     }
 
@@ -258,10 +264,12 @@ function initializeTreeInternal() {
                         console.error('Error restoring tree state:', e);
                     }
                 }
-                else {
+                                else {
                     console.warn('Tree state not found in localStorage');
                 }
             }
+
+            isInitialLoad = false;
         }, 300);
     });
 


### PR DESCRIPTION
Fix race condition where updateTreeTimer triggers refresh before jsTree finishes loading initial data and restoring state from localStorage. Added isInitialLoad flag to block refresh during initial tree load. Bump version to 3.40.23.