### PR TITLE
TAM-2041: Rate sensor - display unit as table column header

### DIFF
--- a/_fix_valuecolumn.js
+++ b/_fix_valuecolumn.js
@@ -1,0 +1,4 @@
+const fs = require('fs');
+const path = 'src/server/HSMServer/Model/History/Personal/HistoryTables/HistoryTableViewModel.cs';
+let content = fs.readFileSync(path, 'utf8');
+

--- a/_fix_valuecolumn.js
+++ b/_fix_valuecolumn.js
@@ -1,4 +1,0 @@
-const fs = require('fs');
-const path = 'src/server/HSMServer/Model/History/Personal/HistoryTables/HistoryTableViewModel.cs';
-let content = fs.readFileSync(path, 'utf8');
-

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.23</Version>
+    <Version>3.40.24</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/server/HSMServer/Model/History/Personal/HistoryTables/HistoryTableViewModel.cs
+++ b/src/server/HSMServer/Model/History/Personal/HistoryTables/HistoryTableViewModel.cs
@@ -65,6 +65,21 @@ namespace HSMServer.Model.History
 
         public SensorType SensorType => _model.Type;
 
+        public string ValueColumnName
+        {
+            get
+            {
+                if (_model.Type != SensorType.Rate || !_model.DisplayUnit.HasValue)
+                    return "Value";
+
+                var displayName = _model.DisplayUnit.Value.GetDisplayName();
+
+                return _model.DisplayUnit.Value == RateDisplayUnit.PerSecond
+                    ? displayName
+                    : $"{displayName} / ({RateDisplayUnit.PerSecond.GetDisplayName()})";
+            }
+        }
+
 
         internal HistoryTableViewModel(BaseSensorModel model)
         {

--- a/src/server/HSMServer/Views/SensorHistory/_SensorValuesTable.cshtml
+++ b/src/server/HSMServer/Views/SensorHistory/_SensorValuesTable.cshtml
@@ -91,7 +91,7 @@ else
                 else
                 {
                     <th id="aggregatedValuesCount_header" class="d-none">Aggregated values count</th>
-                    <th>Value</th>
+                    <th>@Model.ValueColumnName</th>
                     @if (Model.IsEma)
                     {
                         <th>EMA (Value)</th>


### PR DESCRIPTION
For Rate sensors, replace Value column header with the selected Display Unit (e.g. # per sec). If Display Unit is not PerSecond, show format: unit / (# per sec). Bump version to 3.40.24.