### PR TITLE
TAM-1974: Fix Access Keys search functionality

### DIFF
--- a/src/server/HSMServer/Controllers/AccessKeysController.cs
+++ b/src/server/HSMServer/Controllers/AccessKeysController.cs
@@ -192,7 +192,7 @@ namespace HSMServer.Controllers
         {
             return new()
             {
-                Keys = GetAvailableAccessKeys().Where(x => x.Id.ToString().Contains(searchKey)).ToList(),
+                Keys = GetAvailableAccessKeys().Where(x => x.DisplayName.Contains(searchKey, StringComparison.OrdinalIgnoreCase) || x.Id.ToString().Contains(searchKey)).ToList(),
                 FullTable = true
             };
         }

--- a/src/server/HSMServer/Controllers/AccessKeysController.cs
+++ b/src/server/HSMServer/Controllers/AccessKeysController.cs
@@ -192,7 +192,7 @@ namespace HSMServer.Controllers
         {
             return new()
             {
-                Keys = GetAvailableAccessKeys().Where(x => (x.DisplayName ?? string.Empty).Contains(searchKey, StringComparison.OrdinalIgnoreCase) || x.Id.ToString().Contains(searchKey)).ToList(),
+                Keys = GetAvailableAccessKeys().Where(x => (x.DisplayName ?? string.Empty).Contains(searchKey, StringComparison.OrdinalIgnoreCase) || x.Id.ToString().Contains(searchKey, StringComparison.OrdinalIgnoreCase)).ToList(),
                 FullTable = true
             };
         }

--- a/src/server/HSMServer/Controllers/AccessKeysController.cs
+++ b/src/server/HSMServer/Controllers/AccessKeysController.cs
@@ -192,7 +192,7 @@ namespace HSMServer.Controllers
         {
             return new()
             {
-                Keys = GetAvailableAccessKeys().Where(x => x.DisplayName.Contains(searchKey, StringComparison.OrdinalIgnoreCase) || x.Id.ToString().Contains(searchKey)).ToList(),
+                Keys = GetAvailableAccessKeys().Where(x => (x.DisplayName ?? string.Empty).Contains(searchKey, StringComparison.OrdinalIgnoreCase) || x.Id.ToString().Contains(searchKey)).ToList(),
                 FullTable = true
             };
         }

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.25</Version>
+    <Version>3.40.26</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/server/HSMServer/Views/AccessKeys/Index.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/Index.cshtml
@@ -26,8 +26,9 @@
             </div>
         </div>
         <div class="container row my-1 pe-0">
-            <div class="col-4 p-0">
-                <input id="searchKey" type="text" class="form-control" placeholder="Filter by key"/>
+            <div class="position-relative col-4 p-0">
+                <input id="searchKey" type="text" class="form-control pe-4" placeholder="Filter by Name and key" onkeydown="if(event.key === 'Enter') { event.preventDefault(); searchKey(); }" oninput="toggleClearButton()"/>
+                <button id="clearSearchBtn" type="button" class="btn-close position-absolute top-50 end-0 translate-middle-y me-2" style="font-size: 0.65rem; display: none;" onclick="clearSearch()"></button>
             </div>
             <div class="d-flex justify-content-between col">
                 <button onclick="searchKey()" type="button" class="btn btn-secondary ms-1">
@@ -77,6 +78,11 @@
     
     function searchKey() {
         const keyToSearch = document.getElementById("searchKey").value;
+        if (keyToSearch) {
+            history.pushState({ searchKey: keyToSearch }, '', '?searchKey=' + encodeURIComponent(keyToSearch));
+        } else {
+            history.replaceState({}, '', window.location.pathname);
+        }
         $.ajax({
                type: 'GET',
                url: getSearchKeyResult + "?searchKey=" + keyToSearch,
@@ -87,6 +93,33 @@
                     document.querySelectorAll("#accessTable tr").length <= 1 ? $('#accessKeysTable').html("<div><h2><strong>Keys not found</strong></h2></div>") : this;
                }
         });
+    }
+
+    window.addEventListener('popstate', function(e) {
+        const keyToSearch = e.state && e.state.searchKey ? e.state.searchKey : '';
+        document.getElementById('searchKey').value = keyToSearch;
+        $.ajax({
+               type: 'GET',
+               url: getSearchKeyResult + "?searchKey=" + keyToSearch,
+               cache: false,
+               async: true,
+               success: function (viewData) {
+                    $('#accessKeysTable').html(viewData)
+               }
+        });
+    });
+    
+    function toggleClearButton() {
+        const input = document.getElementById("searchKey");
+        const btn = document.getElementById("clearSearchBtn");
+        btn.style.display = input.value.length > 0 ? "block" : "none";
+    }
+
+    function clearSearch() {
+        document.getElementById("searchKey").value = "";
+        document.getElementById("clearSearchBtn").style.display = "none";
+        history.replaceState({}, '', window.location.pathname);
+        allProductsChanged();
     }
     
     function createAccessKey() {

--- a/src/server/HSMServer/Views/AccessKeys/Index.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/Index.cshtml
@@ -144,9 +144,11 @@
         const params = new URLSearchParams(window.location.search);
         const initialSearchKey = params.get('searchKey') || '';
         if (initialSearchKey && searchInput) {
-                    searchInput.value = initialSearchKey;
-                    toggleClearButton();
-                }
+                            searchInput.value = initialSearchKey;
+                            toggleClearButton();
+                            history.replaceState({ searchKey: initialSearchKey }, '', window.location.search);
+                            fetchSearchResults(initialSearchKey);
+                        }
         
         if (searchInput) {
             searchInput.addEventListener('keydown', function(e) {

--- a/src/server/HSMServer/Views/AccessKeys/Index.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/Index.cshtml
@@ -27,16 +27,16 @@
         </div>
         <div class="container row my-1 pe-0">
             <div class="position-relative col-4 p-0">
-                <input id="searchKey" type="text" class="form-control pe-4" placeholder="Filter by Name and key" onkeydown="if(event.key === 'Enter') { event.preventDefault(); searchKey(); }" oninput="toggleClearButton()"/>
-                <button id="clearSearchBtn" type="button" class="btn-close position-absolute top-50 end-0 translate-middle-y me-2" style="font-size: 0.65rem; display: none;" onclick="clearSearch()"></button>
+                <input id="searchKey" type="text" class="form-control pe-4" placeholder="Filter by Name and key"/>
+                <button id="clearSearchBtn" type="button" class="btn-close position-absolute top-50 end-0 translate-middle-y me-2 clear-search-btn"></button>
             </div>
             <div class="d-flex justify-content-between col">
-                <button onclick="searchKey()" type="button" class="btn btn-secondary ms-1">
+                <button id="searchButton" type="button" class="btn btn-secondary ms-1">
                     <i type="button" class="fas fa-search"></i>
                 </button>
                 @if ((User as User).IsAdmin)
                 {
-                    <button onclick="createAccessKey()" class="btn btn-link me-0 pe-0">
+                    <button id="createAccessKeyButton" class="btn btn-link me-0 pe-0">
                        <i class="fa-solid fa-key"></i>
                         Add key
                     </button>
@@ -57,6 +57,13 @@
 @await Html.PartialAsync("_AccessKeysModal")
 
 
+<style>
+    .clear-search-btn {
+        font-size: 0.65rem;
+        display: none;
+    }
+</style>
+
 <script>
     var clipboard = new ClipboardJS('[id^="copy_"]');
 
@@ -76,6 +83,22 @@
         });
     }
     
+    function fetchSearchResults(keyToSearch) {
+        $.ajax({
+            type: 'GET',
+            url: getSearchKeyResult + "?searchKey=" + encodeURIComponent(keyToSearch),
+            cache: false,
+            async: true,
+            success: function (viewData) {
+                $('#accessKeysTable').html(viewData);
+                // "Keys not found" check
+                if (document.querySelectorAll("#accessTable tr").length <= 1) {
+                    $('#accessKeysTable').html("<div><h2><strong>Keys not found</strong></h2></div>");
+                }
+            }
+        });
+    }
+    
     function searchKey() {
         const keyToSearch = document.getElementById("searchKey").value;
         if (keyToSearch) {
@@ -83,30 +106,14 @@
         } else {
             history.replaceState({}, '', window.location.pathname);
         }
-        $.ajax({
-               type: 'GET',
-               url: getSearchKeyResult + "?searchKey=" + keyToSearch,
-               cache: false,
-               async: true,
-               success: function (viewData) {
-                    $('#accessKeysTable').html(viewData)
-                    document.querySelectorAll("#accessTable tr").length <= 1 ? $('#accessKeysTable').html("<div><h2><strong>Keys not found</strong></h2></div>") : this;
-               }
-        });
+        fetchSearchResults(keyToSearch);
     }
 
     window.addEventListener('popstate', function(e) {
         const keyToSearch = e.state && e.state.searchKey ? e.state.searchKey : '';
         document.getElementById('searchKey').value = keyToSearch;
-        $.ajax({
-               type: 'GET',
-               url: getSearchKeyResult + "?searchKey=" + keyToSearch,
-               cache: false,
-               async: true,
-               success: function (viewData) {
-                    $('#accessKeysTable').html(viewData)
-               }
-        });
+        toggleClearButton();
+        fetchSearchResults(keyToSearch);
     });
     
     function toggleClearButton() {
@@ -125,6 +132,40 @@
     function createAccessKey() {
        let newAccessKeyURL = "@Url.Action(nameof(AccessKeysController.NewServerAccessKey), ViewConstants.AccessKeysController)";
     
-       showNewAccessKeyModal(`${newAccessKeyURL}`, true);   
+       showNewAccessKeyModal(`${newAccessKeyURL}`, true);
     }
+
+    // Event listeners setup
+    document.addEventListener('DOMContentLoaded', function() {
+        const searchInput = document.getElementById('searchKey');
+        const searchButton = document.getElementById('searchButton');
+        const clearSearchBtn = document.getElementById('clearSearchBtn');
+        const createAccessKeyButton = document.getElementById('createAccessKeyButton');
+        
+        if (searchInput) {
+            searchInput.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter') {
+                    e.preventDefault();
+                    searchKey();
+                }
+            });
+            
+            searchInput.addEventListener('input', toggleClearButton);
+        }
+        
+        if (searchButton) {
+            searchButton.addEventListener('click', searchKey);
+        }
+        
+        if (clearSearchBtn) {
+            clearSearchBtn.addEventListener('click', clearSearch);
+        }
+        
+        if (createAccessKeyButton) {
+            createAccessKeyButton.addEventListener('click', createAccessKey);
+        }
+        
+        // Initialize clear button state
+        toggleClearButton();
+    });
 </script>

--- a/src/server/HSMServer/Views/AccessKeys/Index.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/Index.cshtml
@@ -73,7 +73,7 @@
             cache: false,
             async: true,
             success: function (viewData) {
-                $('#accessKeysTable').html(viewData);
+                $('#accessKeysTable').replaceWith(viewData);
             }
         });
     }
@@ -85,8 +85,8 @@
             cache: false,
             async: true,
             success: function (viewData) {
-                $('#accessKeysTable').html(viewData);
-                // "Keys not found" check
+                $('#accessKeysTable').replaceWith(viewData);
+                // "Keys not found" check - #accessTable is the parent container
                 if (document.querySelectorAll("#accessTable tr").length <= 1) {
                     $('#accessKeysTable').html("<div><h2><strong>Keys not found</strong></h2></div>");
                 }

--- a/src/server/HSMServer/Views/AccessKeys/Index.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/Index.cshtml
@@ -102,7 +102,10 @@
     function searchKey() {
         const keyToSearch = document.getElementById("searchKey").value;
         if (keyToSearch) {
-            history.pushState({ searchKey: keyToSearch }, '', '?searchKey=' + encodeURIComponent(keyToSearch));
+            // Avoid pushing duplicate history entries
+            if (!history.state || history.state.searchKey !== keyToSearch) {
+                history.pushState({ searchKey: keyToSearch }, '', '?searchKey=' + encodeURIComponent(keyToSearch));
+            }
         } else {
             history.replaceState({}, '', window.location.pathname);
         }
@@ -126,7 +129,7 @@
         document.getElementById("searchKey").value = "";
         document.getElementById("clearSearchBtn").style.display = "none";
         history.replaceState({}, '', window.location.pathname);
-        allProductsChanged();
+        fetchSearchResults('');
     }
     
     function createAccessKey() {
@@ -141,6 +144,15 @@
         const searchButton = document.getElementById('searchButton');
         const clearSearchBtn = document.getElementById('clearSearchBtn');
         const createAccessKeyButton = document.getElementById('createAccessKeyButton');
+        
+        // Handle initial page load with search query parameter
+        const params = new URLSearchParams(window.location.search);
+        const initialSearchKey = params.get('searchKey') || '';
+        if (initialSearchKey && searchInput) {
+            searchInput.value = initialSearchKey;
+            toggleClearButton();
+            fetchSearchResults(initialSearchKey);
+        }
         
         if (searchInput) {
             searchInput.addEventListener('keydown', function(e) {

--- a/src/server/HSMServer/Views/AccessKeys/Index.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/Index.cshtml
@@ -28,7 +28,7 @@
         <div class="container row my-1 pe-0">
             <div class="position-relative col-4 p-0">
                 <input id="searchKey" type="text" class="form-control pe-4" placeholder="Filter by Name and key"/>
-                <button id="clearSearchBtn" type="button" class="btn-close position-absolute top-50 end-0 translate-middle-y me-2 clear-search-btn"></button>
+                <button id="clearSearchBtn" type="button" class="btn-close position-absolute top-50 end-0 translate-middle-y me-2" style="font-size: 0.65rem; display: none;"></button>
             </div>
             <div class="d-flex justify-content-between col">
                 <button id="searchButton" type="button" class="btn btn-secondary ms-1">
@@ -57,12 +57,7 @@
 @await Html.PartialAsync("_AccessKeysModal")
 
 
-<style>
-    .clear-search-btn {
-        font-size: 0.65rem;
-        display: none;
-    }
-</style>
+
 
 <script>
     var clipboard = new ClipboardJS('[id^="copy_"]');
@@ -149,10 +144,9 @@
         const params = new URLSearchParams(window.location.search);
         const initialSearchKey = params.get('searchKey') || '';
         if (initialSearchKey && searchInput) {
-            searchInput.value = initialSearchKey;
-            toggleClearButton();
-            fetchSearchResults(initialSearchKey);
-        }
+                    searchInput.value = initialSearchKey;
+                    toggleClearButton();
+                }
         
         if (searchInput) {
             searchInput.addEventListener('keydown', function(e) {


### PR DESCRIPTION
## Changes: 1. Enter key triggers search. 2. Search by DisplayName (case-insensitive) and Id (was Id-only). 3. History API - Back button returns to Access Keys tab with correct search state. 4. Clear button (X) inside search field to reset search. 5. Placeholder changed to name and key. Bump version to 3.40.26.