### PR TITLE
Fix autotests: add Configuration dropdown click before Users link

### DIFF
--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.26</Version>
+    <Version>3.40.27</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/tests/Autotests/add_environment/add_users.spec.ts
+++ b/src/tests/Autotests/add_environment/add_users.spec.ts
@@ -8,12 +8,14 @@ test('Add environment', async ({ page }) => {
   await login(page, admin_user, admin_user_password, apiUrl,);
 
   //Add a new user 1
+await page.getByRole('button', { name: 'Configuration' }).click();
 await page.getByRole('link', { name: 'Users' }).click();
 await page.locator('#createName').fill(userName1);
 await page.locator('#createPassword').fill(user1password);
 await page.getByRole('button', { name: 'create' }).click();
 
- //Add a new user 2
+  //Add a new user 2
+await page.getByRole('button', { name: 'Configuration' }).click();
 await page.getByRole('link', { name: 'Users' }).click();
 await page.locator('#createName').fill(userName2);
 await page.locator('#createPassword').fill(user2password);

--- a/src/tests/Autotests/package-lock.json
+++ b/src/tests/Autotests/package-lock.json
@@ -9,18 +9,19 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.54.1",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^24.3.0",
         "typescript": "^5.9.2"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
-      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.54.2"
+        "playwright": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -44,6 +45,7 @@
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
       "dev": true,
       "hasInstallScript": true,
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
@@ -53,12 +55,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
-      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.54.2"
+        "playwright-core": "1.59.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -71,10 +74,11 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.54.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
-      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/src/tests/Autotests/package.json
+++ b/src/tests/Autotests/package.json
@@ -9,7 +9,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "@playwright/test": "^1.54.1",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2"
   }

--- a/src/tests/Autotests/register_new_user/register_new_user.spec.ts
+++ b/src/tests/Autotests/register_new_user/register_new_user.spec.ts
@@ -8,6 +8,8 @@ test.beforeEach(async ({ page }) => {
    // Открываем страницу
   await login(page, admin_user, admin_user_password, apiUrl);
 
+  // Открываем dropdown Configuration
+  await page.getByRole('button', { name: 'Configuration' }).click();
   // Ждём перехода на Users
   await page.getByRole('link', { name: 'Users' }).click();
   await expect(page).toHaveURL(/.*Users/);


### PR DESCRIPTION
## Summary
- Fix Playwright autotests failing due to Users link moved into Configuration dropdown
- Add Configuration dropdown click before Users link in both spec files
- Bump version 3.40.26 to 3.40.27
- Update @playwright/test ^1.54.1 to ^1.59.1