### PR TITLE
Show error when alert template fails to save

### DIFF
--- a/src/server/HSMServer.Core/Cache/ITreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/ITreeValuesCache.cs
@@ -109,7 +109,7 @@ namespace HSMServer.Core.Cache
 
         List<AlertTemplateModel> GetAlertTemplateModels();
 
-        Task AddAlertTemplateAsync(AlertTemplateModel model, CancellationToken tocken = default);
+        Task<(bool Success, string Error)> AddAlertTemplateAsync(AlertTemplateModel model, CancellationToken tocken = default);
 
         AlertTemplateModel GetAlertTemplate(Guid id);
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1226,9 +1226,12 @@ namespace HSMServer.Core.Cache
         }
 
 
-        public async Task AddAlertTemplateAsync(AlertTemplateModel alertTemplateModel, CancellationToken token = default)
+        public async Task<(bool Success, string Error)> AddAlertTemplateAsync(AlertTemplateModel alertTemplateModel, CancellationToken token = default)
         {
             var products = GetProducts().Where(x => x.FolderId == alertTemplateModel.FolderId).ToList();
+
+            if (products.Count == 0)
+                return (false, "No products found in the selected folder.");
 
             var first = products.FirstOrDefault();
 
@@ -1243,6 +1246,8 @@ namespace HSMServer.Core.Cache
 
                 await ProcessRequestAsync(product.Id, request, ct);
             });
+
+            return (true, null);
         }
 
         private void AddAlertTemplate(AddAlertTemplateRequest request)

--- a/src/server/HSMServer/Controllers/AlertTemplatesController.cs
+++ b/src/server/HSMServer/Controllers/AlertTemplatesController.cs
@@ -175,7 +175,11 @@ namespace HSMServer.Controllers
             if (ModelState.IsValid)
             {
                 var model = data.ToModel();
-                await _cache.AddAlertTemplateAsync(model);
+                var (success, error) = await _cache.AddAlertTemplateAsync(model);
+
+                if (!success)
+                    return Json(new { success = false, error = error });
+
                 return Ok();
             }
 

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.28</Version>
+    <Version>3.40.29</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -112,6 +112,16 @@
                 if (!viewData){
                     window.location.href = '@Html.Raw(Url.Action(nameof(AlertTemplatesController.Index), ViewConstants.AlertTemplatesController))';
                 }
+                else if (typeof viewData === 'object' && viewData.success === false) {
+                    showConfirmationModal(
+                        'Failed to save template',
+                        viewData.error,
+                        () => {},
+                        () => { window.location.href = '@Html.Raw(Url.Action(nameof(AlertTemplatesController.Index), ViewConstants.AlertTemplatesController))'; },
+                        'Edit',
+                        'Discard'
+                    );
+                }
                 else {
                     $("#addAlertTemplate_form").html(viewData);
                     initForm();


### PR DESCRIPTION
## Summary

- When saving an alert template with a folder that has no products, the template silently failed to create without any error message
- AddAlertTemplateAsync now returns (bool Success, string Error) and detects when no products exist in the selected folder
- Frontend shows a confirmation modal with the error message, allowing the user to continue editing or discard changes
- Bumped version to 3.40.29