### PR TITLE
TAM-2041: Update Rate sensor value column header format

### DIFF
--- a/src/server/HSMServer/Model/History/Personal/HistoryTables/HistoryTableViewModel.cs
+++ b/src/server/HSMServer/Model/History/Personal/HistoryTables/HistoryTableViewModel.cs
@@ -73,10 +73,9 @@ namespace HSMServer.Model.History
                     return "Value";
 
                 var displayName = _model.DisplayUnit.Value.GetDisplayName();
+                var perSecName = RateDisplayUnit.PerSecond.GetDisplayName();
 
-                return _model.DisplayUnit.Value == RateDisplayUnit.PerSecond
-                    ? displayName
-                    : $"{displayName} / ({RateDisplayUnit.PerSecond.GetDisplayName()})";
+                return $"Value ({displayName} / {perSecName})";
             }
         }
 


### PR DESCRIPTION
## Summary
- Change Rate sensor value column header from `# per min / (# per sec)` to `Value (# per min / # per sec)` format
- Always include `Value` prefix and show both display unit and per-sec unit in parentheses