### PR TITLE
Refactor: Extract CollectorLifecycle state machine + QueueState

### DIFF
--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -86,7 +86,9 @@ Note the asymmetry between `Status` and `CanAcceptData` after `Dispose()`:
 
 ### Dispose racing Stop
 
-If `Dispose()` is called while a `Stop()` is in flight, the disposer captures the in-flight task (`_currentStopTask`) and awaits it instead of issuing a duplicate `StopAsync`. The original `Stop()` is responsible for firing `ToStopped` and calling `CompleteStop`. `_dataSender.Dispose()` is only invoked after the in-flight stop completes, preventing `ObjectDisposedException` in queue processors that are still draining.
+If `Dispose()` is called while a `Stop()` is in flight, the disposer captures the in-flight processor stop task (`_currentProcessorStopTask`) and awaits it instead of issuing a duplicate `StopAsync`. The original `Stop()` is responsible for firing `ToStopped` and calling `CompleteStop`. `_dataSender.Dispose()` is only invoked after the in-flight stop completes, preventing `ObjectDisposedException` in queue processors that are still draining.
+
+If `Stop()` or `Dispose()` races with `Start()` while sensor initialization is already in flight, the stopping path waits for `_currentStartInitTask` before stopping and disposing components. It does not wait for the user-supplied pre-init `customStartingTask`; if stop/dispose happens while that task is pending, the later `Start()` continuation observes that lifecycle is no longer starting/running and exits without entering initialization.
 
 ### Queue state machine
 

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -1,0 +1,117 @@
+# DataCollector Overview
+
+> Owner: collector | Last reviewed: 2026-05-26 | Canonical: yes
+
+## Purpose
+
+`HSMDataCollector` is a NuGet library embedded into .NET applications to collect monitoring data and send it to HSMServer. It targets both `net8.0` and `net472`.
+
+## Architecture
+
+```
+User Application
+    |
+    v
+DataCollector (public API)
+    |
+    +-- SensorsStorage (creates/manages sensors)
+    |       |
+    |       +-- MonitoringSensorBase<T> (bar, rate, function sensors)
+    |       +-- SensorInstant<T> (instant, file sensors)
+    |       +-- Default sensors (CPU, RAM, disk, threads, GC, service status)
+    |
+    +-- DataProcessor (data pipeline orchestrator)
+    |       |
+    |       +-- DataQueueProcessor (regular sensor values)
+    |       +-- PriorityDataQueueProcessor (priority values)
+    |       +-- FileQueueProcessor (file sensor values)
+    |       +-- CommandQueueProcessor (server commands)
+    |       +-- MessageDeduplicator (error deduplication)
+    |
+    +-- CollectorScheduler (static timer wheel)
+    |       |
+    |       +-- ScheduledTask (per-sensor periodic action)
+    |
+    +-- HsmHttpsClient (HTTP transport)
+            |
+            +-- Polly retry pipeline
+            +-- DataHandlers / CommandHandler (endpoint routing)
+```
+
+## Lifecycle
+
+```
+[Stopped] --Start()--> [Starting] --InitAsync()--> [Running]
+[Starting] --error--> [Stopped]
+[Starting] --Stop()--> [Stopping]
+[Running] --Stop()---> [Stopping] --StopAsync()--> [Stopped]
+[Any non-Disposed] --Dispose()--> [Disposed] (terminal)
+```
+
+Allowed transitions:
+
+| From | To | Trigger |
+|---|---|---|
+| Stopped | Starting | `Start()` |
+| Starting | Running | start completed |
+| Starting | Stopping | `Stop()` during start |
+| Starting | Stopped | error during start |
+| Running | Stopping | `Stop()` |
+| Stopping | Stopped | stop completed |
+| Any except Disposed | Disposed | `Dispose()` |
+
+State is managed by `CollectorLifecycle` (internal), shared between `DataCollector` and `DataProcessor`.
+
+Key rules:
+- `Dispose()` works from any state, is idempotent, never throws. Terminal state is `Disposed`.
+- `Start()` is rejected if already running or disposed
+- `Stop()` can be called during Starting (cancels initialization)
+- Values are dropped (not queued) while collector is stopped
+- Values CAN be enqueued during Stopping (sensors flush their last values)
+- Lifecycle events (`ToStarting`, `ToRunning`, etc.) isolate subscriber exceptions
+- `Dispose()` from active states fires `ToStopping`/`ToStopped` for backward compatibility
+
+### Data gating
+
+`CanAcceptData` returns true during `Starting`, `Running`, and `Stopping` states. This allows sensors to flush pending values during stop. `CanStartNewSensors` returns true only during `Starting` and `Running` (and not when disposed).
+
+### Queue state machine
+
+Each `QueueProcessorBase` maintains its own `QueueState` (Stopped/Running/Stopping). If `StopAsync` times out (IDataSender ignores cancellation), the queue stays in `Stopping` and blocks subsequent `Start()` until the background task completes.
+
+## Features
+
+| Feature | Folder | Description |
+|---|---|---|
+| Scheduling | [`scheduling/`](./scheduling/feature.md) | CollectorScheduler timer wheel, ScheduledTask |
+| Data Pipeline | [`data-pipeline/`](./data-pipeline/feature.md) | Queue processors, batching, overflow handling |
+| HTTP Client | [`http-client/`](./http-client/feature.md) | HTTPS transport, Polly retry, TLS configuration |
+| Sensors | [`sensors/`](./sensors/feature.md) | Sensor types: bar, rate, function, instant, file |
+| Default Sensors | [`default-sensors/`](./default-sensors/feature.md) | Built-in system metrics (CPU, RAM, disk, threads, etc.) |
+| Error Handling | [`error-handling/`](./error-handling/feature.md) | Exception isolation, MessageDeduplicator, diagnostic sensors |
+
+## Thread Safety Model
+
+- All public sensor methods (`AddValue`, `SendValue`) can be called from any thread
+- `CollectorScheduler` fires callbacks on ThreadPool threads
+- `CollectorLifecycle` uses a single `lock` for atomic state transitions (shared by DataCollector and DataProcessor)
+- `QueueProcessorBase` uses its own `lock` for queue lifecycle (Start/Stop) + `Interlocked` for queue count
+- Shared mutable state uses: `Interlocked` (counters, flags), `Volatile` (reads/writes), `lock` (complex operations)
+- `Channel<T>` for value queuing; tracked count via `Interlocked` (not channel internal count)
+
+## Configuration
+
+`CollectorOptions` (all with sensible defaults):
+- `ServerAddress`, `Port`, `AccessKey` — connection
+- `MaxQueueSize` (20000) — max values in each queue before dropping
+- `MaxValuesInPackage` (1000) — batch size per HTTP request
+- `PackageCollectPeriod` (15s) — interval between batch sends
+- `RequestTimeout` (30s) — HTTP request timeout
+- `AllowUntrustedServerCertificate` (false) — opt-in for self-signed certs
+- `ExceptionDeduplicatorWindow` (1h) — deduplication window for error messages
+- `MaxDeduplicatedMessages` (1000) — max unique messages in deduplicator cache
+
+## Known Issues
+
+- Polly retry does not handle HTTP 4xx/5xx (`ShouldHandle` not configured) — data silently lost on server errors
+- Queue overflow drops oldest items without per-drop logging (only aggregate overflow count)

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -75,9 +75,22 @@ Key rules:
 
 `CanAcceptData` returns true during `Starting`, `Running`, and `Stopping` states. This allows sensors to flush pending values during stop. `CanStartNewSensors` returns true only during `Starting` and `Running` (and not when disposed).
 
+Note the asymmetry between `Status` and `CanAcceptData` after `Dispose()`:
+- `Status` reports `Disposed` immediately when `Dispose()` is entered.
+- `CanAcceptData` is computed from the *internal* (pre-dispose) status. While the stop is still in flight it returns true so sensors can flush final values. Once `CompleteStop` fires (`internal _status = Stopped`), `CanAcceptData` returns false.
+- Values enqueued after the sender is disposed are unreachable. The window is small (between `_lifecycle.CompleteStop()` and `_dataSender.Dispose()`); sensors should not call `SendValue` after subscribing to `ToStopped`.
+
+### Lifecycle event ordering
+
+`DataCollector` serializes the `(state-transition, lifecycle-event-raise)` pair under `_opLock` so that subscribers observe events in the same order as the underlying status changes. Subscribers should not block in handlers — `_opLock` is held while handlers run, which can stall concurrent `Start`/`Stop`/`Dispose` calls.
+
+### Dispose racing Stop
+
+If `Dispose()` is called while a `Stop()` is in flight, the disposer captures the in-flight task (`_currentStopTask`) and awaits it instead of issuing a duplicate `StopAsync`. The original `Stop()` is responsible for firing `ToStopped` and calling `CompleteStop`. `_dataSender.Dispose()` is only invoked after the in-flight stop completes, preventing `ObjectDisposedException` in queue processors that are still draining.
+
 ### Queue state machine
 
-Each `QueueProcessorBase` maintains its own `QueueState` (Stopped/Running/Stopping). If `StopAsync` times out (IDataSender ignores cancellation), the queue stays in `Stopping` and blocks subsequent `Start()` until the background task completes.
+Each `QueueProcessorBase` maintains its own `QueueState` (Stopped/Running/Stopping). If `StopAsync` times out (IDataSender ignores cancellation), the queue stays in `Stopping` and blocks subsequent `Start()` until the background task completes. As a defensive measure, `Start()` will reset and restart a queue whose `_task` exited unexpectedly while `_state` is still `Running` — this only fires if a subclass overrides `ProcessingLoop` and breaks the "loop until cancellation" contract.
 
 ## Features
 

--- a/src/collector/HSMDataCollector.IntegrationTests/Tests/LifecycleTests.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Tests/LifecycleTests.cs
@@ -99,7 +99,9 @@ namespace HSMDataCollector.IntegrationTests.Tests
 
             collector.Dispose();
 
-            Assert.Equal(CollectorStatus.Stopped, collector.Status);
+            // After Dispose, status is the terminal Disposed state (new in 3.40.32). Sensors and
+            // queues are stopped and disposed; the collector cannot be restarted.
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
         }
     }
 }

--- a/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
@@ -1,9 +1,11 @@
 using HSMDataCollector.Core;
+using HSMDataCollector.DefaultSensors;
 using HSMDataCollector.Exceptions;
 using HSMDataCollector.Options;
 using HSMDataCollector.PublicInterface;
 using HSMDataCollector.SyncQueue.Data;
 using HSMSensorDataObjects;
+using HSMSensorDataObjects.SensorRequests;
 using HSMSensorDataObjects.SensorValueRequests;
 using System;
 using System.Collections.Concurrent;
@@ -1049,6 +1051,44 @@ namespace HSMDataCollector.Tests
             }
         }
 
+        [Fact]
+        public async Task Dispose_during_start_init_waits_for_init_before_disposing_components()
+        {
+            var sender = new ProbeDataSender();
+            var collector = CreateCollector(sender);
+            var initEntered = new TaskCompletionSource<bool>();
+            var releaseInit = new TaskCompletionSource<bool>();
+            var blockingSensor = RegisterBlockingInitSensor(collector, "adversarial/dispose-during-start-init", initEntered, releaseInit);
+
+            try
+            {
+                var startTask = collector.Start();
+
+                Assert.True(await WaitOrTimeoutAsync(initEntered.Task, TimeSpan.FromSeconds(1)).ConfigureAwait(false),
+                    "Start should enter sensor InitAsync before Dispose joins it.");
+
+                var disposeTask = Task.Run(() => collector.Dispose());
+                var completedBeforeRelease = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromMilliseconds(250))).ConfigureAwait(false);
+
+                Assert.NotSame(disposeTask, completedBeforeRelease);
+                Assert.Equal(0, blockingSensor.StopCalls);
+
+                releaseInit.SetResult(true);
+
+                Assert.True(await WaitOrTimeoutAsync(disposeTask, TimeSpan.FromSeconds(2)).ConfigureAwait(false),
+                    "Dispose should complete after the in-flight start initialization finishes.");
+                await startTask.ConfigureAwait(false);
+
+                Assert.Equal(CollectorStatus.Disposed, collector.Status);
+                Assert.True(blockingSensor.StopCalls > 0);
+            }
+            finally
+            {
+                releaseInit.TrySetResult(true);
+                collector.Dispose();
+            }
+        }
+
 
         [Fact]
         public async Task Concurrent_start_and_stop_does_not_leave_queues_running_after_status_stopped()
@@ -1303,6 +1343,37 @@ namespace HSMDataCollector.Tests
             });
         }
 
+        private static BlockingInitSensor RegisterBlockingInitSensor(
+            DataCollector collector,
+            string path,
+            TaskCompletionSource<bool> initEntered,
+            TaskCompletionSource<bool> releaseInit)
+        {
+            var dataProcessor = (DataProcessor)typeof(DataCollector)
+                .GetField("_dataProcessor", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(collector);
+            var sensorsStorage = (SensorsStorage)typeof(DataCollector)
+                .GetField("_sensorsStorage", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(collector);
+
+            var sensor = new BlockingInitSensor(new InstantSensorOptions
+            {
+                ComputerName = collector.ComputerName,
+                Module = collector.Module,
+                Path = path,
+                DataProcessor = dataProcessor,
+            }, initEntered, releaseInit);
+
+            sensorsStorage.Register(sensor);
+            return sensor;
+        }
+
+        private static async Task<bool> WaitOrTimeoutAsync(Task task, TimeSpan timeout)
+        {
+            var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+            return ReferenceEquals(completed, task);
+        }
+
         private static TimeSpan GetSuiteSoakDuration()
         {
             var rawSeconds = Environment.GetEnvironmentVariable("HSM_COLLECTOR_SUITE_SOAK_SECONDS");
@@ -1335,6 +1406,37 @@ namespace HSMDataCollector.Tests
             {
                 if (!string.Equals(Environment.GetEnvironmentVariable("HSM_COLLECTOR_RUN_SUITE_SOAK"), "1", StringComparison.Ordinal))
                     Skip = "Set HSM_COLLECTOR_RUN_SUITE_SOAK=1 to run repeated suite soak tests.";
+            }
+        }
+
+        private sealed class BlockingInitSensor : SensorBase<NoDisplayUnit>
+        {
+            private readonly TaskCompletionSource<bool> _initEntered;
+            private readonly TaskCompletionSource<bool> _releaseInit;
+            private int _stopCalls;
+
+            internal BlockingInitSensor(
+                InstantSensorOptions options,
+                TaskCompletionSource<bool> initEntered,
+                TaskCompletionSource<bool> releaseInit) : base(options)
+            {
+                _initEntered = initEntered;
+                _releaseInit = releaseInit;
+            }
+
+            internal int StopCalls => Volatile.Read(ref _stopCalls);
+
+            public override async ValueTask<bool> InitAsync()
+            {
+                _initEntered.TrySetResult(true);
+                await _releaseInit.Task.ConfigureAwait(false);
+                return true;
+            }
+
+            public override ValueTask StopAsync()
+            {
+                Interlocked.Increment(ref _stopCalls);
+                return default;
             }
         }
 

--- a/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
@@ -881,7 +881,7 @@ namespace HSMDataCollector.Tests
             var exception = Record.Exception(() => collector.Dispose());
 
             Assert.Null(exception);
-            Assert.Equal(CollectorStatus.Stopped, collector.Status);
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
         }
 
         [Fact]
@@ -896,7 +896,7 @@ namespace HSMDataCollector.Tests
             var exception = await Record.ExceptionAsync(() => collector.Start()).ConfigureAwait(false);
 
             Assert.Null(exception);
-            Assert.Equal(CollectorStatus.Stopped, collector.Status);
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
         }
 
         [Fact]
@@ -911,7 +911,58 @@ namespace HSMDataCollector.Tests
             var exception = Record.Exception(() => collector.Initialize(false));
 
             Assert.Null(exception);
-            Assert.Equal(CollectorStatus.Stopped, collector.Status);
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
+        }
+
+        [Fact]
+        public async Task Dispose_from_running_fires_stopping_and_stopped_events()
+        {
+            var sender = new ProbeDataSender();
+            var collector = CreateCollector(sender);
+
+            var stoppingFired = false;
+            var stoppedFired = false;
+
+            collector.ToStopping += () => stoppingFired = true;
+            collector.ToStopped += () => stoppedFired = true;
+
+            await collector.Start().ConfigureAwait(false);
+            Assert.Equal(CollectorStatus.Running, collector.Status);
+
+            collector.Dispose();
+
+            Assert.True(stoppingFired, "ToStopping should fire during Dispose from Running.");
+            Assert.True(stoppedFired, "ToStopped should fire during Dispose from Running.");
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
+        }
+
+        [Fact]
+        public void Double_dispose_does_not_throw()
+        {
+            var sender = new ProbeDataSender();
+            var collector = CreateCollector(sender);
+
+            collector.Dispose();
+
+            var exception = Record.Exception(() => collector.Dispose());
+
+            Assert.Null(exception);
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
+        }
+
+        [Fact]
+        public async Task Stop_after_dispose_is_noop()
+        {
+            var sender = new ProbeDataSender();
+            var collector = CreateCollector(sender);
+
+            await collector.Start().ConfigureAwait(false);
+            collector.Dispose();
+
+            var exception = await Record.ExceptionAsync(() => collector.Stop()).ConfigureAwait(false);
+
+            Assert.Null(exception);
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
         }
 
         [SuiteSoakFact]

--- a/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
@@ -965,6 +965,69 @@ namespace HSMDataCollector.Tests
             Assert.Equal(CollectorStatus.Disposed, collector.Status);
         }
 
+        [Fact]
+        public async Task Dispose_concurrent_with_stop_fires_ToStopped_exactly_once()
+        {
+            for (var iteration = 0; iteration < 25; iteration++)
+            {
+                var sender = new ProbeDataSender();
+                var collector = CreateCollector(sender);
+
+                await collector.Start().ConfigureAwait(false);
+
+                var stoppingCount = 0;
+                var stoppedCount = 0;
+                collector.ToStopping += () => Interlocked.Increment(ref stoppingCount);
+                collector.ToStopped += () => Interlocked.Increment(ref stoppedCount);
+
+                // Start the Stop and let it begin draining before Dispose joins
+                var stopTask = collector.Stop();
+                collector.Dispose();
+
+                await stopTask.ConfigureAwait(false);
+
+                Assert.Equal(CollectorStatus.Disposed, collector.Status);
+                Assert.Equal(1, stoppingCount);
+                Assert.Equal(1, stoppedCount);
+            }
+        }
+
+        [Fact]
+        public async Task Concurrent_start_and_stop_keeps_event_order_consistent_with_status()
+        {
+            // Regression test for the event-ordering race: when Start and Stop race, subscribers
+            // must see events in an order consistent with the underlying state machine
+            // (no Stopping before Starting).
+            for (var iteration = 0; iteration < 50; iteration++)
+            {
+                var sender = new ProbeDataSender();
+                using (var collector = CreateCollector(sender))
+                {
+                    var events = new ConcurrentQueue<CollectorStatus>();
+                    collector.ToStarting += () => events.Enqueue(CollectorStatus.Starting);
+                    collector.ToRunning  += () => events.Enqueue(CollectorStatus.Running);
+                    collector.ToStopping += () => events.Enqueue(CollectorStatus.Stopping);
+                    collector.ToStopped  += () => events.Enqueue(CollectorStatus.Stopped);
+
+                    var startTask = Task.Run(() => collector.Start());
+                    var stopTask  = Task.Run(() => collector.Stop());
+
+                    await Task.WhenAll(startTask, stopTask).ConfigureAwait(false);
+
+                    var observed = events.ToArray();
+                    // Stopping must not appear before Starting
+                    var startingIdx = Array.IndexOf(observed, CollectorStatus.Starting);
+                    var stoppingIdx = Array.IndexOf(observed, CollectorStatus.Stopping);
+
+                    if (startingIdx >= 0 && stoppingIdx >= 0)
+                    {
+                        Assert.True(stoppingIdx > startingIdx,
+                            $"Iteration {iteration}: Stopping fired before Starting. Events: [{string.Join(", ", observed)}]");
+                    }
+                }
+            }
+        }
+
         [SuiteSoakFact]
         public async Task Adversarial_suite_repeated_for_duration_stays_green()
         {

--- a/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
@@ -966,6 +966,30 @@ namespace HSMDataCollector.Tests
         }
 
         [Fact]
+        public async Task ToStarting_handler_dispose_does_not_start_queues_after_dispose()
+        {
+            var sender = new ProbeDataSender();
+            var collector = CreateCollector(sender);
+            var neverComplete = new TaskCompletionSource<bool>();
+
+            collector.ToStarting += collector.Dispose;
+
+            try
+            {
+                var startTask = collector.Start(neverComplete.Task);
+                var completed = await Task.WhenAny(startTask, Task.Delay(TimeSpan.FromSeconds(1))).ConfigureAwait(false);
+
+                Assert.Same(startTask, completed);
+                Assert.Equal(CollectorStatus.Disposed, collector.Status);
+            }
+            finally
+            {
+                neverComplete.TrySetResult(true);
+                collector.Dispose();
+            }
+        }
+
+        [Fact]
         public async Task Dispose_concurrent_with_stop_fires_ToStopped_exactly_once()
         {
             for (var iteration = 0; iteration < 25; iteration++)
@@ -994,6 +1018,34 @@ namespace HSMDataCollector.Tests
                 Assert.Equal(CollectorStatus.Disposed, collector.Status);
                 Assert.Equal(1, stoppingCount);
                 Assert.Equal(1, stoppedCount);
+            }
+        }
+
+        [Fact]
+        public async Task Dispose_concurrent_with_stop_custom_task_does_not_wait_for_custom_task()
+        {
+            var sender = new ProbeDataSender();
+            var collector = CreateCollector(sender);
+            var neverComplete = new TaskCompletionSource<bool>();
+
+            try
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var stopTask = collector.Stop(neverComplete.Task);
+                var disposeTask = Task.Run(() => collector.Dispose());
+                var completed = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromSeconds(1))).ConfigureAwait(false);
+
+                Assert.Same(disposeTask, completed);
+                Assert.Equal(CollectorStatus.Disposed, collector.Status);
+
+                neverComplete.SetResult(true);
+                await stopTask.ConfigureAwait(false);
+            }
+            finally
+            {
+                neverComplete.TrySetResult(true);
+                collector.Dispose();
             }
         }
 

--- a/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
@@ -999,6 +999,57 @@ namespace HSMDataCollector.Tests
 
 
         [Fact]
+        public async Task Concurrent_start_and_stop_does_not_leave_queues_running_after_status_stopped()
+        {
+            // Regression test for the start/stop ordering bug: if Stop runs StopAsync against queues
+            // that haven't been spawned yet (because Start released _opLock between TryStart and
+            // _dataProcessor.Start()), and Start then spawned them anyway and bailed without rollback,
+            // background queue processors would stay alive while public Status reads Stopped.
+            //
+            // To make the leak observable, after the race we actively try to push data: create a
+            // sensor and call AddValue. If the data queue is still alive despite Status == Stopped,
+            // SendDataAsync will eventually be invoked on the sender and DataPackages will tick.
+            for (var iteration = 0; iteration < 50; iteration++)
+            {
+                var sender = new ProbeDataSender();
+                var collector = CreateCollector(sender);
+
+                var startTask = Task.Run(() => collector.Start());
+                var stopTask = Task.Run(() => collector.Stop());
+
+                await Task.WhenAll(startTask, stopTask).ConfigureAwait(false);
+
+                var status = collector.Status;
+                Assert.True(
+                    status == CollectorStatus.Stopped ||
+                    status == CollectorStatus.Running ||
+                    status == CollectorStatus.Starting,
+                    $"Iteration {iteration}: unexpected status {status}");
+
+                if (status == CollectorStatus.Stopped)
+                {
+                    var sendsBefore = sender.DataPackages;
+
+                    // Provoke any zombie queue: a live queue will accept and forward this value.
+                    // A properly stopped queue will reject (or drop) it.
+                    var probe = collector.CreateIntSensor("adversarial/start-stop-race/probe");
+                    for (var i = 0; i < 5; i++)
+                        probe.AddValue(i);
+
+                    // Wait at least one PackageCollectPeriod so a live worker would flush.
+                    await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+
+                    var sendsAfter = sender.DataPackages;
+
+                    Assert.True(sendsAfter == sendsBefore,
+                        $"Iteration {iteration}: queue processors continued sending after Status == Stopped (before={sendsBefore}, after={sendsAfter}).");
+                }
+
+                collector.Dispose();
+            }
+        }
+
+        [Fact]
         public async Task Concurrent_start_and_stop_keeps_event_order_consistent_with_status()
         {
             // Regression test for the event-ordering race: when Start and Stop race, subscribers

--- a/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorAdversarialTests.cs
@@ -984,6 +984,11 @@ namespace HSMDataCollector.Tests
                 var stopTask = collector.Stop();
                 collector.Dispose();
 
+                // ToStopped must have been raised before Dispose() returned — Dispose either drove
+                // CompleteStop itself or waited for Stop's continuation to do it. Either way, no event
+                // may fire on a half-disposed collector.
+                Assert.Equal(1, stoppedCount);
+
                 await stopTask.ConfigureAwait(false);
 
                 Assert.Equal(CollectorStatus.Disposed, collector.Status);
@@ -991,6 +996,7 @@ namespace HSMDataCollector.Tests
                 Assert.Equal(1, stoppedCount);
             }
         }
+
 
         [Fact]
         public async Task Concurrent_start_and_stop_keeps_event_order_consistent_with_status()

--- a/src/collector/HSMDataCollector.Tests/CollectorLifecycleTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorLifecycleTests.cs
@@ -1,0 +1,350 @@
+using HSMDataCollector.Core;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMDataCollector.Tests
+{
+    public sealed class CollectorLifecycleTests
+    {
+        [Fact]
+        public void Initial_status_is_stopped()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+            Assert.False(lifecycle.CanAcceptData);
+            Assert.False(lifecycle.CanStartNewSensors);
+        }
+
+        [Fact]
+        public void TryStart_from_stopped_succeeds()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.True(lifecycle.TryStart());
+            Assert.Equal(CollectorStatus.Starting, lifecycle.Status);
+            Assert.True(lifecycle.CanAcceptData);
+            Assert.True(lifecycle.CanStartNewSensors);
+        }
+
+        [Fact]
+        public void TryStart_from_starting_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+
+            Assert.False(lifecycle.TryStart());
+            Assert.Equal(CollectorStatus.Starting, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryStart_from_running_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+
+            Assert.False(lifecycle.TryStart());
+            Assert.Equal(CollectorStatus.Running, lifecycle.Status);
+        }
+
+        [Fact]
+        public void CompleteStart_from_starting_succeeds()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+
+            Assert.True(lifecycle.CompleteStart());
+            Assert.Equal(CollectorStatus.Running, lifecycle.Status);
+            Assert.True(lifecycle.CanAcceptData);
+            Assert.True(lifecycle.CanStartNewSensors);
+        }
+
+        [Fact]
+        public void CompleteStart_from_stopped_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.False(lifecycle.CompleteStart());
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+        }
+
+        [Fact]
+        public void AbortStart_from_starting_returns_to_stopped()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+
+            Assert.True(lifecycle.AbortStart());
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+            Assert.False(lifecycle.CanAcceptData);
+        }
+
+        [Fact]
+        public void AbortStart_from_running_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+
+            Assert.False(lifecycle.AbortStart());
+            Assert.Equal(CollectorStatus.Running, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryStop_from_running_succeeds()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+
+            Assert.True(lifecycle.TryStop());
+            Assert.Equal(CollectorStatus.Stopping, lifecycle.Status);
+            Assert.True(lifecycle.CanAcceptData);
+            Assert.False(lifecycle.CanStartNewSensors);
+        }
+
+        [Fact]
+        public void TryStop_from_starting_succeeds()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+
+            Assert.True(lifecycle.TryStop());
+            Assert.Equal(CollectorStatus.Stopping, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryStop_from_stopped_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.False(lifecycle.TryStop());
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryStop_from_stopping_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryStop();
+
+            Assert.False(lifecycle.TryStop());
+            Assert.Equal(CollectorStatus.Stopping, lifecycle.Status);
+        }
+
+        [Fact]
+        public void CompleteStop_from_stopping_returns_to_stopped()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryStop();
+
+            Assert.True(lifecycle.CompleteStop());
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+            Assert.False(lifecycle.CanAcceptData);
+        }
+
+        [Fact]
+        public void CompleteStop_from_stopped_is_noop()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.False(lifecycle.CompleteStop());
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+        }
+
+        [Fact]
+        public void Full_lifecycle_stopped_to_running_to_stopped()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.True(lifecycle.TryStart());
+            Assert.True(lifecycle.CompleteStart());
+            Assert.True(lifecycle.TryStop());
+            Assert.True(lifecycle.CompleteStop());
+
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.Status);
+        }
+
+        [Fact]
+        public void Restart_after_stop_succeeds()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryStop();
+            lifecycle.CompleteStop();
+
+            Assert.True(lifecycle.TryStart());
+            Assert.Equal(CollectorStatus.Starting, lifecycle.Status);
+        }
+
+        // --- Dispose transitions ---
+
+        [Fact]
+        public void TryDispose_from_stopped_returns_stopped()
+        {
+            var lifecycle = new CollectorLifecycle();
+
+            Assert.Equal(CollectorStatus.Stopped, lifecycle.TryDispose());
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryDispose_from_running_returns_running()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+
+            Assert.Equal(CollectorStatus.Running, lifecycle.TryDispose());
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryDispose_from_starting_returns_starting()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+
+            Assert.Equal(CollectorStatus.Starting, lifecycle.TryDispose());
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.Status);
+        }
+
+        [Fact]
+        public void TryDispose_from_stopping_returns_stopping()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryStop();
+
+            Assert.Equal(CollectorStatus.Stopping, lifecycle.TryDispose());
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.Status);
+        }
+
+        [Fact]
+        public void Double_dispose_returns_disposed()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryDispose();
+
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.TryDispose());
+        }
+
+        [Fact]
+        public void TryStart_after_dispose_fails()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryDispose();
+
+            Assert.False(lifecycle.TryStart());
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.Status);
+        }
+
+        [Fact]
+        public void CanStartNewSensors_false_after_dispose()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryDispose();
+
+            Assert.False(lifecycle.CanStartNewSensors);
+        }
+
+        [Fact]
+        public void CanAcceptData_true_during_stopping_after_dispose()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryDispose();
+            lifecycle.TryStop();
+
+            Assert.True(lifecycle.CanAcceptData);
+        }
+
+        [Fact]
+        public void CanAcceptData_false_after_complete_stop_following_dispose()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+            lifecycle.TryDispose();
+            lifecycle.TryStop();
+            lifecycle.CompleteStop();
+
+            Assert.False(lifecycle.CanAcceptData);
+        }
+
+        // --- Concurrency ---
+
+        [Fact]
+        public void Concurrent_TryStart_only_one_wins()
+        {
+            var lifecycle = new CollectorLifecycle();
+            var wins = 0;
+
+            Parallel.For(0, 100, _ =>
+            {
+                if (lifecycle.TryStart())
+                    Interlocked.Increment(ref wins);
+            });
+
+            Assert.Equal(1, wins);
+            Assert.Equal(CollectorStatus.Starting, lifecycle.Status);
+        }
+
+        [Fact]
+        public void Concurrent_TryDispose_only_one_returns_non_disposed()
+        {
+            var lifecycle = new CollectorLifecycle();
+            lifecycle.TryStart();
+            lifecycle.CompleteStart();
+
+            var disposedCount = 0;
+
+            Parallel.For(0, 100, _ =>
+            {
+                if (lifecycle.TryDispose() != CollectorStatus.Disposed)
+                    Interlocked.Increment(ref disposedCount);
+            });
+
+            Assert.Equal(1, disposedCount);
+            Assert.Equal(CollectorStatus.Disposed, lifecycle.Status);
+        }
+
+        [Fact]
+        public void Concurrent_TryStart_and_TryStop_reach_valid_state()
+        {
+            for (var iteration = 0; iteration < 100; iteration++)
+            {
+                var lifecycle = new CollectorLifecycle();
+
+                var started = false;
+                var stopped = false;
+
+                var startTask = Task.Run(() => { started = lifecycle.TryStart(); });
+                var stopTask = Task.Run(() => { stopped = lifecycle.TryStop(); });
+
+                Task.WaitAll(startTask, stopTask);
+
+                var status = lifecycle.Status;
+
+                Assert.True(
+                    status == CollectorStatus.Stopped ||
+                    status == CollectorStatus.Starting ||
+                    status == CollectorStatus.Stopping,
+                    $"Status should be Stopped, Starting, or Stopping but was {status}");
+            }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector/Core/CollectorLifecycle.cs
+++ b/src/collector/HSMDataCollector/Core/CollectorLifecycle.cs
@@ -1,0 +1,114 @@
+namespace HSMDataCollector.Core
+{
+    internal sealed class CollectorLifecycle
+    {
+        private readonly object _lock = new object();
+        private CollectorStatus _status = CollectorStatus.Stopped;
+        private bool _disposed;
+
+
+        internal CollectorStatus Status
+        {
+            get
+            {
+                lock (_lock)
+                    return _disposed ? CollectorStatus.Disposed : _status;
+            }
+        }
+
+        internal bool CanAcceptData
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    var s = _status;
+                    return s == CollectorStatus.Starting || s == CollectorStatus.Running || s == CollectorStatus.Stopping;
+                }
+            }
+        }
+
+        internal bool CanStartNewSensors
+        {
+            get
+            {
+                lock (_lock)
+                    return !_disposed && (_status == CollectorStatus.Starting || _status == CollectorStatus.Running);
+            }
+        }
+
+
+        internal bool TryStart()
+        {
+            lock (_lock)
+            {
+                if (_disposed || _status != CollectorStatus.Stopped)
+                    return false;
+
+                _status = CollectorStatus.Starting;
+                return true;
+            }
+        }
+
+        internal bool CompleteStart()
+        {
+            lock (_lock)
+            {
+                if (_status != CollectorStatus.Starting)
+                    return false;
+
+                _status = CollectorStatus.Running;
+                return true;
+            }
+        }
+
+        internal bool AbortStart()
+        {
+            lock (_lock)
+            {
+                if (_status != CollectorStatus.Starting)
+                    return false;
+
+                _status = CollectorStatus.Stopped;
+                return true;
+            }
+        }
+
+        internal bool TryStop()
+        {
+            lock (_lock)
+            {
+                if (_status != CollectorStatus.Starting && _status != CollectorStatus.Running)
+                    return false;
+
+                _status = CollectorStatus.Stopping;
+                return true;
+            }
+        }
+
+        internal bool CompleteStop()
+        {
+            lock (_lock)
+            {
+                if (_status != CollectorStatus.Stopping)
+                    return false;
+
+                _status = CollectorStatus.Stopped;
+                return true;
+            }
+        }
+
+        /// <returns>The lifecycle status before disposal, or Disposed if already disposed.</returns>
+        internal CollectorStatus TryDispose()
+        {
+            lock (_lock)
+            {
+                if (_disposed)
+                    return CollectorStatus.Disposed;
+
+                _disposed = true;
+                return _status;
+            }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -35,6 +35,16 @@ namespace HSMDataCollector.Core
         private readonly DataProcessor _dataProcessor;
         private readonly CollectorLifecycle _lifecycle = new CollectorLifecycle();
 
+        // Serializes lifecycle state transitions with their lifecycle event raise so that
+        // concurrent Start/Stop/Dispose cannot reorder events (e.g. ToStopping before ToStarting).
+        // Always acquired before any _lifecycle method that mutates state.
+        private readonly object _opLock = new object();
+
+        // Tracks the in-flight Stop() task so that a racing Dispose() can wait for it
+        // instead of issuing a duplicate StopAsync (which would no-op against queues already in Stopping
+        // and then fire ToStopped while the original Stop is still draining).
+        private Task _currentStopTask;
+
         internal static bool IsWindowsOS { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         public IWindowsCollection Windows => _sensorsStorage.Windows;
@@ -135,37 +145,51 @@ namespace HSMDataCollector.Core
 
         public async Task Start(Task customStartingTask)
         {
-            if (!_lifecycle.TryStart())
-                return;
+            lock (_opLock)
+            {
+                if (!_lifecycle.TryStart())
+                    return;
 
-            LogAndRaise(CollectorStatus.Starting);
+                LogAndRaise(CollectorStatus.Starting);
+            }
 
             try
             {
-                if (!_dataProcessor.Start())
+                if (_dataProcessor.Start())
                 {
-                    if (_lifecycle.AbortStart())
-                        LogAndRaise(CollectorStatus.Stopped);
+                    await customStartingTask.ConfigureAwait(false);
+
+                    if (!Status.IsStartingOrRunning())
+                        return;
+
+                    await _dataProcessor.InitAsync().ConfigureAwait(false);
+
+                    lock (_opLock)
+                    {
+                        if (_lifecycle.CompleteStart())
+                            LogAndRaise(CollectorStatus.Running);
+                    }
 
                     return;
                 }
-
-                await customStartingTask.ConfigureAwait(false);
-
-                if (!Status.IsStartingOrRunning())
-                    return;
-
-                await _dataProcessor.InitAsync().ConfigureAwait(false);
-
-                if (_lifecycle.CompleteStart())
-                    LogAndRaise(CollectorStatus.Running);
             }
             catch (Exception ex)
             {
                 _logger.Error($"DataCollector starting error: {ex}");
 
-                await _dataProcessor.StopAsync();
+                try
+                {
+                    await _dataProcessor.StopAsync().ConfigureAwait(false);
+                }
+                catch (Exception stopEx)
+                {
+                    _logger.Error($"DataCollector start-rollback stop error: {stopEx}");
+                }
+            }
 
+            // Abort path: reached when _dataProcessor.Start() returned false or an exception was caught.
+            lock (_opLock)
+            {
                 if (_lifecycle.AbortStart())
                     LogAndRaise(CollectorStatus.Stopped);
             }
@@ -176,30 +200,47 @@ namespace HSMDataCollector.Core
 
         public async Task Stop(Task customStartingTask)
         {
-            if (!_lifecycle.TryStop())
-                return;
+            Task stopTask;
+            lock (_opLock)
+            {
+                if (!_lifecycle.TryStop())
+                    return;
 
-            LogAndRaise(CollectorStatus.Stopping);
+                LogAndRaise(CollectorStatus.Stopping);
+
+                stopTask = Task.WhenAll(_dataProcessor.StopAsync(), customStartingTask);
+                _currentStopTask = stopTask;
+            }
 
             try
             {
-                await Task.WhenAll(_dataProcessor.StopAsync(), customStartingTask).ConfigureAwait(false);
+                await stopTask.ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.Error(ex);
             }
 
-            if (_lifecycle.CompleteStop())
-                LogAndRaise(CollectorStatus.Stopped);
+            lock (_opLock)
+            {
+                // Clear only if still pointing to our task — Dispose may have overwritten with its own.
+                if (ReferenceEquals(_currentStopTask, stopTask))
+                    _currentStopTask = null;
+
+                if (_lifecycle.CompleteStop())
+                    LogAndRaise(CollectorStatus.Stopped);
+            }
         }
 
         private void InitializeProcessor()
         {
-            if (!_lifecycle.TryStart())
-                return;
+            lock (_opLock)
+            {
+                if (!_lifecycle.TryStart())
+                    return;
 
-            LogAndRaise(CollectorStatus.Starting);
+                LogAndRaise(CollectorStatus.Starting);
+            }
 
             try
             {
@@ -207,47 +248,93 @@ namespace HSMDataCollector.Core
 
                 if (!_dataProcessor.Start())
                 {
-                    if (_lifecycle.AbortStart())
-                        LogAndRaise(CollectorStatus.Stopped);
+                    lock (_opLock)
+                    {
+                        if (_lifecycle.AbortStart())
+                            LogAndRaise(CollectorStatus.Stopped);
+                    }
 
                     return;
                 }
 
                 _dataProcessor.InitAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-                if (_lifecycle.CompleteStart())
-                    LogAndRaise(CollectorStatus.Running);
+                lock (_opLock)
+                {
+                    if (_lifecycle.CompleteStart())
+                        LogAndRaise(CollectorStatus.Running);
+                }
             }
             catch (Exception ex)
             {
                 _logger.Error($"DataCollector initialization error: {ex}");
 
-                _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                try
+                {
+                    _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                }
+                catch (Exception stopEx)
+                {
+                    _logger.Error($"DataCollector init-rollback stop error: {stopEx}");
+                }
 
-                if (_lifecycle.AbortStart())
-                    LogAndRaise(CollectorStatus.Stopped);
+                lock (_opLock)
+                {
+                    if (_lifecycle.AbortStart())
+                        LogAndRaise(CollectorStatus.Stopped);
+                }
             }
         }
 
 
         public void Dispose()
         {
-            var previousStatus = _lifecycle.TryDispose();
+            CollectorStatus previousStatus;
+            Task inFlightStop;
+            bool ownsStop;
 
-            if (previousStatus == CollectorStatus.Disposed)
-                return;
+            lock (_opLock)
+            {
+                previousStatus = _lifecycle.TryDispose();
+
+                if (previousStatus == CollectorStatus.Disposed)
+                    return;
+
+                // If another thread is already stopping, do not issue a duplicate StopAsync —
+                // wait for its task. Otherwise take the Starting/Running -> Stopping transition ourselves.
+                inFlightStop = _currentStopTask;
+                ownsStop = inFlightStop == null
+                    && previousStatus.IsStartingOrRunning()
+                    && _lifecycle.TryStop();
+
+                if (ownsStop)
+                    LogAndRaise(CollectorStatus.Stopping);
+            }
 
             try
             {
-                if (previousStatus.IsStartingOrRunning() && _lifecycle.TryStop())
-                    RaiseLifecycleEvent(ToStopping, nameof(ToStopping));
-
-                if (previousStatus != CollectorStatus.Stopped)
+                if (inFlightStop != null)
+                {
+                    // Concurrent Stop() is responsible for firing ToStopped and CompleteStop;
+                    // we just wait so we do not tear down the sender while queues still drain.
+                    try
+                    {
+                        inFlightStop.ConfigureAwait(false).GetAwaiter().GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.Error($"DataCollector waiting for in-flight stop failed: {ex}");
+                    }
+                }
+                else if (ownsStop)
                 {
                     DisposeComponent(() => _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult(), nameof(_dataProcessor));
 
-                    if (_lifecycle.CompleteStop())
-                        RaiseLifecycleEvent(ToStopped, nameof(ToStopped));
+                    lock (_opLock)
+                    {
+                        if (_lifecycle.CompleteStop())
+                            LogAndRaise(CollectorStatus.Stopped);
+                    }
                 }
 
                 DisposeComponent(_dataProcessor.Dispose, nameof(_dataProcessor));

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -218,7 +218,7 @@ namespace HSMDataCollector.Core
             }
             catch (Exception ex)
             {
-                _logger.Error(ex);
+                _logger.Error($"DataCollector Stop error: {ex}");
             }
 
             lock (_opLock)
@@ -315,8 +315,10 @@ namespace HSMDataCollector.Core
             {
                 if (inFlightStop != null)
                 {
-                    // Concurrent Stop() is responsible for firing ToStopped and CompleteStop;
-                    // we just wait so we do not tear down the sender while queues still drain.
+                    // Concurrent Stop() is responsible for firing ToStopped — but its continuation runs on
+                    // the threadpool after the inner stop task completes, with no ordering guarantee relative
+                    // to GetAwaiter().GetResult() returning here. Without coordination, Stop's continuation
+                    // could fire ToStopped after Dispose has already torn down components.
                     try
                     {
                         inFlightStop.ConfigureAwait(false).GetAwaiter().GetResult();
@@ -324,6 +326,15 @@ namespace HSMDataCollector.Core
                     catch (Exception ex)
                     {
                         _logger.Error($"DataCollector waiting for in-flight stop failed: {ex}");
+                    }
+
+                    // Race the continuation: whichever path acquires _opLock first calls CompleteStop;
+                    // the other finds the transition already done and no-ops. Either way ToStopped fires
+                    // exactly once, and always before component disposal below.
+                    lock (_opLock)
+                    {
+                        if (_lifecycle.CompleteStop())
+                            LogAndRaise(CollectorStatus.Stopped);
                     }
                 }
                 else if (ownsStop)

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -21,6 +21,7 @@ namespace HSMDataCollector.Core
         Running,
         Stopping,
         Stopped,
+        Disposed,
     }
 
 
@@ -32,9 +33,7 @@ namespace HSMDataCollector.Core
         private readonly CollectorOptions _options;
         private readonly IDataSender _dataSender;
         private readonly DataProcessor _dataProcessor;
-        private readonly object _lifecycleLock = new object();
-
-        private bool _disposed;
+        private readonly CollectorLifecycle _lifecycle = new CollectorLifecycle();
 
         internal static bool IsWindowsOS { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -43,7 +42,7 @@ namespace HSMDataCollector.Core
         public IUnixCollection Unix => _sensorsStorage.Unix;
 
 
-        public CollectorStatus Status { get; private set; } = CollectorStatus.Stopped;
+        public CollectorStatus Status => _lifecycle.Status;
 
         public string ComputerName => _options?.ComputerName;
 
@@ -76,7 +75,7 @@ namespace HSMDataCollector.Core
 
             _dataSender = options.DataSender;
 
-            _dataProcessor = new DataProcessor(options, _logger);
+            _dataProcessor = new DataProcessor(options, _lifecycle, _logger);
 
             _sensorsStorage = _dataProcessor.SensorStorage;
 
@@ -136,20 +135,18 @@ namespace HSMDataCollector.Core
 
         public async Task Start(Task customStartingTask)
         {
+            if (!_lifecycle.TryStart())
+                return;
+
+            LogAndRaise(CollectorStatus.Starting);
+
             try
             {
-                lock (_lifecycleLock)
+                if (!_dataProcessor.Start())
                 {
-                    if (_disposed)
-                        return;
-
-                    if (!Status.IsStopped())
-                        return;
-
-                    if (!_dataProcessor.Start())
-                        return;
-
-                    ChangeStatus(CollectorStatus.Starting);
+                    _lifecycle.AbortStart();
+                    LogAndRaise(CollectorStatus.Stopped);
+                    return;
                 }
 
                 await customStartingTask.ConfigureAwait(false);
@@ -159,21 +156,17 @@ namespace HSMDataCollector.Core
 
                 await _dataProcessor.InitAsync().ConfigureAwait(false);
 
-                lock (_lifecycleLock)
-                {
-                    if (Status == CollectorStatus.Starting)
-                        ChangeStatus(CollectorStatus.Running);
-                }
-
+                if (_lifecycle.CompleteStart())
+                    LogAndRaise(CollectorStatus.Running);
             }
             catch (Exception ex)
             {
-                _logger.Error($"DataCollector starting error: {ex}" );
+                _logger.Error($"DataCollector starting error: {ex}");
 
                 await _dataProcessor.StopAsync();
 
-                lock (_lifecycleLock)
-                    ChangeStatus(CollectorStatus.Stopped);
+                _lifecycle.AbortStart();
+                LogAndRaise(CollectorStatus.Stopped);
             }
         }
 
@@ -182,55 +175,46 @@ namespace HSMDataCollector.Core
 
         public async Task Stop(Task customStartingTask)
         {
+            if (!_lifecycle.TryStop())
+                return;
+
+            LogAndRaise(CollectorStatus.Stopping);
+
             try
             {
-                lock (_lifecycleLock)
-                {
-                    if (!Status.IsStartingOrRunning())
-                        return;
-
-                    ChangeStatus(CollectorStatus.Stopping);
-                }
-
                 await Task.WhenAll(_dataProcessor.StopAsync(), customStartingTask).ConfigureAwait(false);
-
-                lock (_lifecycleLock)
-                    ChangeStatus(CollectorStatus.Stopped);
             }
             catch (Exception ex)
             {
                 _logger.Error(ex);
-
-                lock (_lifecycleLock)
-                    ChangeStatus(CollectorStatus.Stopped);
             }
 
+            if (_lifecycle.CompleteStop())
+                LogAndRaise(CollectorStatus.Stopped);
         }
 
         private void InitializeProcessor()
         {
+            if (!_lifecycle.TryStart())
+                return;
+
+            LogAndRaise(CollectorStatus.Starting);
+
             try
             {
-                lock (_lifecycleLock)
+                _logger.Info("Initialize timer...");
+
+                if (!_dataProcessor.Start())
                 {
-                    if (_disposed)
-                        return;
-
-                    if (!Status.IsStopped())
-                        return;
-
-                    _logger.Info("Initialize timer...");
-
-                    if (!_dataProcessor.Start())
-                        return;
-
-                    ChangeStatus(CollectorStatus.Starting);
+                    _lifecycle.AbortStart();
+                    LogAndRaise(CollectorStatus.Stopped);
+                    return;
                 }
 
                 _dataProcessor.InitAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-                lock (_lifecycleLock)
-                    ChangeStatus(CollectorStatus.Running);
+                if (_lifecycle.CompleteStart())
+                    LogAndRaise(CollectorStatus.Running);
             }
             catch (Exception ex)
             {
@@ -238,34 +222,34 @@ namespace HSMDataCollector.Core
 
                 _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-                lock (_lifecycleLock)
-                    ChangeStatus(CollectorStatus.Stopped);
+                _lifecycle.AbortStart();
+                LogAndRaise(CollectorStatus.Stopped);
             }
         }
 
 
         public void Dispose()
         {
-            var shouldStopProcessor = false;
+            var previousStatus = _lifecycle.TryDispose();
+
+            if (previousStatus == CollectorStatus.Disposed)
+                return;
 
             try
             {
-                lock (_lifecycleLock)
+                if (previousStatus.IsStartingOrRunning())
                 {
-                    if (_disposed)
-                        return;
-
-                    _disposed = true;
-
-                    if (!Status.IsStopped())
-                    {
-                        shouldStopProcessor = true;
-                        ChangeStatus(CollectorStatus.Stopping);
-                    }
+                    _lifecycle.TryStop();
+                    RaiseLifecycleEvent(ToStopping, nameof(ToStopping));
                 }
 
-                if (shouldStopProcessor)
+                if (previousStatus != CollectorStatus.Stopped)
+                {
                     DisposeComponent(() => _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult(), nameof(_dataProcessor));
+
+                    _lifecycle.CompleteStop();
+                    RaiseLifecycleEvent(ToStopped, nameof(ToStopped));
+                }
 
                 DisposeComponent(_dataProcessor.Dispose, nameof(_dataProcessor));
 
@@ -274,23 +258,15 @@ namespace HSMDataCollector.Core
             finally
             {
                 AppDomain.CurrentDomain.UnhandledException -= UnhandledExceptionHandler;
-
-                lock (_lifecycleLock)
-                {
-                    if (!Status.IsStopped())
-                        ChangeStatus(CollectorStatus.Stopped);
-                }
             }
         }
 
 
-        private void ChangeStatus(CollectorStatus newStatus)
+        private void LogAndRaise(CollectorStatus status)
         {
-            Status = newStatus;
+            _logger.Info($"DataCollector (v. {DataCollectorExtensions.Version}) -> {status}");
 
-            _logger.Info($"DataCollector (v. {DataCollectorExtensions.Version}) -> {newStatus}");
-
-            switch (newStatus)
+            switch (status)
             {
                 case CollectorStatus.Starting:
                     RaiseLifecycleEvent(ToStarting, nameof(ToStarting));

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -145,53 +145,84 @@ namespace HSMDataCollector.Core
 
         public async Task Start(Task customStartingTask)
         {
+            bool processorStarted;
+
+            // Take _opLock through the physical processor start. Otherwise a concurrent Stop could
+            // run StopAsync against queues that have not been started yet, then this method would
+            // bring them up afterwards — leaving live background tasks while public Status == Stopped.
             lock (_opLock)
             {
                 if (!_lifecycle.TryStart())
                     return;
 
                 LogAndRaise(CollectorStatus.Starting);
-            }
 
-            try
-            {
-                if (_dataProcessor.Start())
+                try
                 {
-                    await customStartingTask.ConfigureAwait(false);
+                    processorStarted = _dataProcessor.Start();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"DataCollector starting error during processor start: {ex}");
+                    processorStarted = false;
+                }
 
-                    if (!Status.IsStartingOrRunning())
-                        return;
-
-                    await _dataProcessor.InitAsync().ConfigureAwait(false);
-
-                    lock (_opLock)
-                    {
-                        if (_lifecycle.CompleteStart())
-                            LogAndRaise(CollectorStatus.Running);
-                    }
-
+                if (!processorStarted)
+                {
+                    if (_lifecycle.AbortStart())
+                        LogAndRaise(CollectorStatus.Stopped);
                     return;
                 }
+            }
+
+            // Queues are now running. Any exit path from here must roll them back if the lifecycle
+            // was cancelled by a concurrent Stop/Dispose, or background processors will outlive Status.
+            try
+            {
+                await customStartingTask.ConfigureAwait(false);
+
+                if (!Status.IsStartingOrRunning())
+                {
+                    await SafeStopProcessor().ConfigureAwait(false);
+                    return;
+                }
+
+                await _dataProcessor.InitAsync().ConfigureAwait(false);
+
+                bool completed;
+                lock (_opLock)
+                {
+                    completed = _lifecycle.CompleteStart();
+                    if (completed)
+                        LogAndRaise(CollectorStatus.Running);
+                }
+
+                if (!completed)
+                    await SafeStopProcessor().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.Error($"DataCollector starting error: {ex}");
 
-                try
+                await SafeStopProcessor().ConfigureAwait(false);
+
+                lock (_opLock)
                 {
-                    await _dataProcessor.StopAsync().ConfigureAwait(false);
-                }
-                catch (Exception stopEx)
-                {
-                    _logger.Error($"DataCollector start-rollback stop error: {stopEx}");
+                    if (_lifecycle.AbortStart())
+                        LogAndRaise(CollectorStatus.Stopped);
                 }
             }
+        }
 
-            // Abort path: reached when _dataProcessor.Start() returned false or an exception was caught.
-            lock (_opLock)
+        private async Task SafeStopProcessor()
+        {
+            try
             {
-                if (_lifecycle.AbortStart())
-                    LogAndRaise(CollectorStatus.Stopped);
+                await _dataProcessor.StopAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"DataCollector start-rollback stop error: {ex}");
             }
         }
 
@@ -234,49 +265,55 @@ namespace HSMDataCollector.Core
 
         private void InitializeProcessor()
         {
+            bool processorStarted;
+
             lock (_opLock)
             {
                 if (!_lifecycle.TryStart())
                     return;
 
                 LogAndRaise(CollectorStatus.Starting);
+
+                _logger.Info("Initialize timer...");
+
+                try
+                {
+                    processorStarted = _dataProcessor.Start();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"DataCollector initialization error during processor start: {ex}");
+                    processorStarted = false;
+                }
+
+                if (!processorStarted)
+                {
+                    if (_lifecycle.AbortStart())
+                        LogAndRaise(CollectorStatus.Stopped);
+                    return;
+                }
             }
 
             try
             {
-                _logger.Info("Initialize timer...");
-
-                if (!_dataProcessor.Start())
-                {
-                    lock (_opLock)
-                    {
-                        if (_lifecycle.AbortStart())
-                            LogAndRaise(CollectorStatus.Stopped);
-                    }
-
-                    return;
-                }
-
                 _dataProcessor.InitAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
+                bool completed;
                 lock (_opLock)
                 {
-                    if (_lifecycle.CompleteStart())
+                    completed = _lifecycle.CompleteStart();
+                    if (completed)
                         LogAndRaise(CollectorStatus.Running);
                 }
+
+                if (!completed)
+                    SafeStopProcessor().ConfigureAwait(false).GetAwaiter().GetResult();
             }
             catch (Exception ex)
             {
                 _logger.Error($"DataCollector initialization error: {ex}");
 
-                try
-                {
-                    _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-                }
-                catch (Exception stopEx)
-                {
-                    _logger.Error($"DataCollector init-rollback stop error: {stopEx}");
-                }
+                SafeStopProcessor().ConfigureAwait(false).GetAwaiter().GetResult();
 
                 lock (_opLock)
                 {

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -40,10 +40,10 @@ namespace HSMDataCollector.Core
         // Always acquired before any _lifecycle method that mutates state.
         private readonly object _opLock = new object();
 
-        // Tracks the in-flight Stop() task so that a racing Dispose() can wait for it
+        // Tracks the in-flight processor StopAsync task so that a racing Dispose() can wait for it
         // instead of issuing a duplicate StopAsync (which would no-op against queues already in Stopping
         // and then fire ToStopped while the original Stop is still draining).
-        private Task _currentStopTask;
+        private Task _currentProcessorStopTask;
 
         internal static bool IsWindowsOS { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
@@ -157,6 +157,9 @@ namespace HSMDataCollector.Core
 
                 LogAndRaise(CollectorStatus.Starting);
 
+                if (!Status.IsStartingOrRunning())
+                    return;
+
                 try
                 {
                     processorStarted = _dataProcessor.Start();
@@ -231,7 +234,9 @@ namespace HSMDataCollector.Core
 
         public async Task Stop(Task customStartingTask)
         {
+            Task processorStopTask;
             Task stopTask;
+
             lock (_opLock)
             {
                 if (!_lifecycle.TryStop())
@@ -239,8 +244,9 @@ namespace HSMDataCollector.Core
 
                 LogAndRaise(CollectorStatus.Stopping);
 
-                stopTask = Task.WhenAll(_dataProcessor.StopAsync(), customStartingTask);
-                _currentStopTask = stopTask;
+                processorStopTask = _dataProcessor.StopAsync();
+                stopTask = Task.WhenAll(processorStopTask, customStartingTask);
+                _currentProcessorStopTask = processorStopTask;
             }
 
             try
@@ -255,8 +261,8 @@ namespace HSMDataCollector.Core
             lock (_opLock)
             {
                 // Clear only if still pointing to our task — Dispose may have overwritten with its own.
-                if (ReferenceEquals(_currentStopTask, stopTask))
-                    _currentStopTask = null;
+                if (ReferenceEquals(_currentProcessorStopTask, processorStopTask))
+                    _currentProcessorStopTask = null;
 
                 if (_lifecycle.CompleteStop())
                     LogAndRaise(CollectorStatus.Stopped);
@@ -339,7 +345,7 @@ namespace HSMDataCollector.Core
 
                 // If another thread is already stopping, do not issue a duplicate StopAsync —
                 // wait for its task. Otherwise take the Starting/Running -> Stopping transition ourselves.
-                inFlightStop = _currentStopTask;
+                inFlightStop = _currentProcessorStopTask;
                 ownsStop = inFlightStop == null
                     && previousStatus.IsStartingOrRunning()
                     && _lifecycle.TryStop();

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -144,8 +144,9 @@ namespace HSMDataCollector.Core
             {
                 if (!_dataProcessor.Start())
                 {
-                    _lifecycle.AbortStart();
-                    LogAndRaise(CollectorStatus.Stopped);
+                    if (_lifecycle.AbortStart())
+                        LogAndRaise(CollectorStatus.Stopped);
+
                     return;
                 }
 
@@ -165,8 +166,8 @@ namespace HSMDataCollector.Core
 
                 await _dataProcessor.StopAsync();
 
-                _lifecycle.AbortStart();
-                LogAndRaise(CollectorStatus.Stopped);
+                if (_lifecycle.AbortStart())
+                    LogAndRaise(CollectorStatus.Stopped);
             }
         }
 
@@ -206,8 +207,9 @@ namespace HSMDataCollector.Core
 
                 if (!_dataProcessor.Start())
                 {
-                    _lifecycle.AbortStart();
-                    LogAndRaise(CollectorStatus.Stopped);
+                    if (_lifecycle.AbortStart())
+                        LogAndRaise(CollectorStatus.Stopped);
+
                     return;
                 }
 
@@ -222,8 +224,8 @@ namespace HSMDataCollector.Core
 
                 _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult();
 
-                _lifecycle.AbortStart();
-                LogAndRaise(CollectorStatus.Stopped);
+                if (_lifecycle.AbortStart())
+                    LogAndRaise(CollectorStatus.Stopped);
             }
         }
 
@@ -237,18 +239,15 @@ namespace HSMDataCollector.Core
 
             try
             {
-                if (previousStatus.IsStartingOrRunning())
-                {
-                    _lifecycle.TryStop();
+                if (previousStatus.IsStartingOrRunning() && _lifecycle.TryStop())
                     RaiseLifecycleEvent(ToStopping, nameof(ToStopping));
-                }
 
                 if (previousStatus != CollectorStatus.Stopped)
                 {
                     DisposeComponent(() => _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult(), nameof(_dataProcessor));
 
-                    _lifecycle.CompleteStop();
-                    RaiseLifecycleEvent(ToStopped, nameof(ToStopped));
+                    if (_lifecycle.CompleteStop())
+                        RaiseLifecycleEvent(ToStopped, nameof(ToStopped));
                 }
 
                 DisposeComponent(_dataProcessor.Dispose, nameof(_dataProcessor));

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -40,6 +40,10 @@ namespace HSMDataCollector.Core
         // Always acquired before any _lifecycle method that mutates state.
         private readonly object _opLock = new object();
 
+        // Tracks the in-flight SensorStorage init/start phase so Stop/Dispose do not dispose
+        // queues or sensors while Start() is still touching them.
+        private Task _currentStartInitTask;
+
         // Tracks the in-flight processor StopAsync task so that a racing Dispose() can wait for it
         // instead of issuing a duplicate StopAsync (which would no-op against queues already in Stopping
         // and then fire ToStopped while the original Stop is still draining).
@@ -184,24 +188,35 @@ namespace HSMDataCollector.Core
             {
                 await customStartingTask.ConfigureAwait(false);
 
-                if (!Status.IsStartingOrRunning())
-                {
-                    await SafeStopProcessor().ConfigureAwait(false);
-                    return;
-                }
-
-                await _dataProcessor.InitAsync().ConfigureAwait(false);
-
-                bool completed;
+                Task initTask;
                 lock (_opLock)
                 {
-                    completed = _lifecycle.CompleteStart();
-                    if (completed)
-                        LogAndRaise(CollectorStatus.Running);
+                    if (!Status.IsStartingOrRunning())
+                        return;
+
+                    initTask = _dataProcessor.InitAsync();
+                    _currentStartInitTask = initTask;
                 }
 
-                if (!completed)
-                    await SafeStopProcessor().ConfigureAwait(false);
+                try
+                {
+                    await initTask.ConfigureAwait(false);
+                }
+                finally
+                {
+                    lock (_opLock)
+                    {
+                        if (ReferenceEquals(_currentStartInitTask, initTask))
+                            _currentStartInitTask = null;
+                    }
+                }
+
+                lock (_opLock)
+                {
+                    if (_lifecycle.CompleteStart())
+                        LogAndRaise(CollectorStatus.Running);
+                    return;
+                }
             }
             catch (Exception ex)
             {
@@ -215,6 +230,23 @@ namespace HSMDataCollector.Core
                         LogAndRaise(CollectorStatus.Stopped);
                 }
             }
+        }
+
+        private async Task WaitForStartInitThenStopProcessor(Task startInitTask)
+        {
+            if (startInitTask != null)
+            {
+                try
+                {
+                    await startInitTask.ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"DataCollector waiting for in-flight start initialization failed: {ex}");
+                }
+            }
+
+            await _dataProcessor.StopAsync().ConfigureAwait(false);
         }
 
         private async Task SafeStopProcessor()
@@ -232,8 +264,9 @@ namespace HSMDataCollector.Core
 
         public Task Stop() => Stop(Task.CompletedTask);
 
-        public async Task Stop(Task customStartingTask)
+        public async Task Stop(Task customStoppingTask)
         {
+            Task startInitTask;
             Task processorStopTask;
             Task stopTask;
 
@@ -244,8 +277,9 @@ namespace HSMDataCollector.Core
 
                 LogAndRaise(CollectorStatus.Stopping);
 
-                processorStopTask = _dataProcessor.StopAsync();
-                stopTask = Task.WhenAll(processorStopTask, customStartingTask);
+                startInitTask = _currentStartInitTask;
+                processorStopTask = WaitForStartInitThenStopProcessor(startInitTask);
+                stopTask = Task.WhenAll(processorStopTask, customStoppingTask);
                 _currentProcessorStopTask = processorStopTask;
             }
 
@@ -334,6 +368,7 @@ namespace HSMDataCollector.Core
         {
             CollectorStatus previousStatus;
             Task inFlightStop;
+            Task inFlightStartInit;
             bool ownsStop;
 
             lock (_opLock)
@@ -346,6 +381,7 @@ namespace HSMDataCollector.Core
                 // If another thread is already stopping, do not issue a duplicate StopAsync —
                 // wait for its task. Otherwise take the Starting/Running -> Stopping transition ourselves.
                 inFlightStop = _currentProcessorStopTask;
+                inFlightStartInit = _currentStartInitTask;
                 ownsStop = inFlightStop == null
                     && previousStatus.IsStartingOrRunning()
                     && _lifecycle.TryStop();
@@ -382,7 +418,7 @@ namespace HSMDataCollector.Core
                 }
                 else if (ownsStop)
                 {
-                    DisposeComponent(() => _dataProcessor.StopAsync().ConfigureAwait(false).GetAwaiter().GetResult(), nameof(_dataProcessor));
+                    DisposeComponent(() => WaitForStartInitThenStopProcessor(inFlightStartInit).ConfigureAwait(false).GetAwaiter().GetResult(), nameof(_dataProcessor));
 
                     lock (_opLock)
                     {

--- a/src/collector/HSMDataCollector/Core/DataProcessor.cs
+++ b/src/collector/HSMDataCollector/Core/DataProcessor.cs
@@ -24,22 +24,19 @@ namespace HSMDataCollector.Core
         private readonly CommandQueueProcessor _commandQueue;
         private readonly LoggerManager _logger;
         private readonly MessageDeduplicator _messageDeduplicator;
+        private readonly CollectorLifecycle _lifecycle;
         private readonly TimeSpan _stopFlushTimeout;
 
         private DefaultSensorsCollection DefaultSensors => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? (DefaultSensorsCollection)SensorStorage.Windows : (DefaultSensorsCollection)SensorStorage.Unix;
 
         internal SensorsStorage SensorStorage { get; }
 
-        private int _isStarted;
-        private int _isStopping;
+        internal bool CanStartNewSensors => _lifecycle.CanStartNewSensors;
 
-        public bool IsStarted => Volatile.Read(ref _isStarted) == 1;
-
-        internal bool CanStartNewSensors => IsStarted && Volatile.Read(ref _isStopping) == 0;
-
-        public DataProcessor(CollectorOptions options, LoggerManager logger)
+        public DataProcessor(CollectorOptions options, CollectorLifecycle lifecycle, LoggerManager logger)
         {
             _logger = logger;
+            _lifecycle = lifecycle;
             _stopFlushTimeout = TimeSpan.FromTicks(Math.Min(Math.Max(options.RequestTimeout.Ticks, TimeSpan.FromSeconds(1).Ticks),
                                                             TimeSpan.FromSeconds(5).Ticks));
 
@@ -57,11 +54,6 @@ namespace HSMDataCollector.Core
 
         public bool Start()
         {
-            if (IsStarted)
-                return true;
-
-            Volatile.Write(ref _isStopping, 0);
-
             var dataStarted = _dataQueue.Start();
             var priorityStarted = dataStarted && _priorityQueue.Start();
             var fileStarted = priorityStarted && _fileQueue.Start();
@@ -73,7 +65,6 @@ namespace HSMDataCollector.Core
                 return false;
             }
 
-            Volatile.Write(ref _isStarted, 1);
             return true;
         }
 
@@ -85,39 +76,29 @@ namespace HSMDataCollector.Core
 
         public async Task StopAsync()
         {
-            Volatile.Write(ref _isStopping, 1);
-            try
+            await SensorStorage.StopAsync().ConfigureAwait(false);
+
+            var dataQueueStopped = await _dataQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
+            var priorityQueueStopped = await _priorityQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
+
+            if (priorityQueueStopped)
             {
-                await SensorStorage.StopAsync().ConfigureAwait(false);
-                Volatile.Write(ref _isStarted, 0);
+                using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
+                    await _priorityQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
 
-                var dataQueueStopped = await _dataQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
-                var priorityQueueStopped = await _priorityQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
-
-                if (priorityQueueStopped)
-                {
-                    using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
-                        await _priorityQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
-
-                    LogDiscardedItems(_priorityQueue.ClearQueue(), _priorityQueue.QueueName);
-                }
-
-                if (dataQueueStopped)
-                {
-                    using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
-                        await _dataQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
-
-                    LogDiscardedItems(_dataQueue.ClearQueue(), _dataQueue.QueueName);
-                }
-
-                await _fileQueue.StopAsync().ConfigureAwait(false);
-                await _commandQueue.StopAsync().ConfigureAwait(false);
+                LogDiscardedItems(_priorityQueue.ClearQueue(), _priorityQueue.QueueName);
             }
-            finally
+
+            if (dataQueueStopped)
             {
-                Volatile.Write(ref _isStarted, 0);
-                Volatile.Write(ref _isStopping, 0);
+                using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
+                    await _dataQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
+
+                LogDiscardedItems(_dataQueue.ClearQueue(), _dataQueue.QueueName);
             }
+
+            await _fileQueue.StopAsync().ConfigureAwait(false);
+            await _commandQueue.StopAsync().ConfigureAwait(false);
         }
 
         public void Dispose()
@@ -132,7 +113,7 @@ namespace HSMDataCollector.Core
 
         public void AddData(ISensor sender, SensorValueBase data)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _dataQueue.Enqeue(data), _dataQueue.QueueName);
@@ -140,7 +121,7 @@ namespace HSMDataCollector.Core
 
         public void AddData(ISensor sender, IEnumerable<SensorValueBase> items)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _dataQueue.Enqeue(items), _dataQueue.QueueName);
@@ -148,7 +129,7 @@ namespace HSMDataCollector.Core
 
         public void AddPriorityData(ISensor sender, SensorValueBase data)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _priorityQueue.Enqeue(data), _priorityQueue.QueueName);
@@ -156,7 +137,7 @@ namespace HSMDataCollector.Core
 
         public void AddPriorityData(ISensor sender, IEnumerable<SensorValueBase> items)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _priorityQueue.Enqeue(items), _priorityQueue.QueueName);
@@ -164,7 +145,7 @@ namespace HSMDataCollector.Core
 
         public void AddCommand(ISensor sender, CommandRequestBase command)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _commandQueue.Enqeue(command), _commandQueue.QueueName);
@@ -172,7 +153,7 @@ namespace HSMDataCollector.Core
 
         public void AddCommand(ISensor sender, IEnumerable<CommandRequestBase> commands)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _commandQueue.Enqeue(commands), _commandQueue.QueueName);
@@ -180,7 +161,7 @@ namespace HSMDataCollector.Core
 
         public void AddFile(ISensor sender, FileSensorValue file)
         {
-            if (!IsStarted)
+            if (!_lifecycle.CanAcceptData)
                 return;
 
             SendQueueOverflow(sender, _fileQueue.Enqeue(file), _fileQueue.QueueName);

--- a/src/collector/HSMDataCollector/Core/DataProcessor.cs
+++ b/src/collector/HSMDataCollector/Core/DataProcessor.cs
@@ -76,29 +76,65 @@ namespace HSMDataCollector.Core
 
         public async Task StopAsync()
         {
-            await SensorStorage.StopAsync().ConfigureAwait(false);
+            // Collect failures across phases so a single phase exception does not leave background queues running.
+            // After all phases attempt to stop, rethrow as AggregateException so the caller knows the stop was degraded.
+            var failures = new List<Exception>();
 
-            var dataQueueStopped = await _dataQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
-            var priorityQueueStopped = await _priorityQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
+            await TryStopPhase(() => SensorStorage.StopAsync(), failures).ConfigureAwait(false);
+
+            var dataQueueStopped = false;
+            var priorityQueueStopped = false;
+
+            await TryStopPhase(async () =>
+            {
+                dataQueueStopped = await _dataQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
+            }, failures).ConfigureAwait(false);
+
+            await TryStopPhase(async () =>
+            {
+                priorityQueueStopped = await _priorityQueue.StopAsync(clearQueue: false).ConfigureAwait(false);
+            }, failures).ConfigureAwait(false);
 
             if (priorityQueueStopped)
             {
-                using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
-                    await _priorityQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
+                await TryStopPhase(async () =>
+                {
+                    using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
+                        await _priorityQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
 
-                LogDiscardedItems(_priorityQueue.ClearQueue(), _priorityQueue.QueueName);
+                    LogDiscardedItems(_priorityQueue.ClearQueue(), _priorityQueue.QueueName);
+                }, failures).ConfigureAwait(false);
             }
 
             if (dataQueueStopped)
             {
-                using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
-                    await _dataQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
+                await TryStopPhase(async () =>
+                {
+                    using (var flushCancellation = new CancellationTokenSource(_stopFlushTimeout))
+                        await _dataQueue.FlushAsync(flushCancellation.Token).ConfigureAwait(false);
 
-                LogDiscardedItems(_dataQueue.ClearQueue(), _dataQueue.QueueName);
+                    LogDiscardedItems(_dataQueue.ClearQueue(), _dataQueue.QueueName);
+                }, failures).ConfigureAwait(false);
             }
 
-            await _fileQueue.StopAsync().ConfigureAwait(false);
-            await _commandQueue.StopAsync().ConfigureAwait(false);
+            await TryStopPhase(() => _fileQueue.StopAsync().AsTask(), failures).ConfigureAwait(false);
+            await TryStopPhase(() => _commandQueue.StopAsync().AsTask(), failures).ConfigureAwait(false);
+
+            if (failures.Count > 0)
+                throw new AggregateException("One or more phases of DataProcessor.StopAsync failed; remaining phases completed.", failures);
+        }
+
+        private async Task TryStopPhase(Func<Task> phase, List<Exception> failures)
+        {
+            try
+            {
+                await phase().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error($"DataProcessor stop phase failed: {ex}");
+                failures.Add(ex);
+            }
         }
 
         public void Dispose()

--- a/src/collector/HSMDataCollector/Extensions/DataCollectorExtensions.cs
+++ b/src/collector/HSMDataCollector/Extensions/DataCollectorExtensions.cs
@@ -31,15 +31,5 @@ namespace HSMDataCollector.Extensions
         {
             return status == CollectorStatus.Running;
         }
-
-        public static bool IsDisposed(this CollectorStatus status)
-        {
-            return status == CollectorStatus.Disposed;
-        }
-
-        public static bool IsStoppedOrDisposed(this CollectorStatus status)
-        {
-            return status == CollectorStatus.Stopped || status == CollectorStatus.Disposed;
-        }
     }
 }

--- a/src/collector/HSMDataCollector/Extensions/DataCollectorExtensions.cs
+++ b/src/collector/HSMDataCollector/Extensions/DataCollectorExtensions.cs
@@ -31,5 +31,15 @@ namespace HSMDataCollector.Extensions
         {
             return status == CollectorStatus.Running;
         }
+
+        public static bool IsDisposed(this CollectorStatus status)
+        {
+            return status == CollectorStatus.Disposed;
+        }
+
+        public static bool IsStoppedOrDisposed(this CollectorStatus status)
+        {
+            return status == CollectorStatus.Stopped || status == CollectorStatus.Disposed;
+        }
     }
 }

--- a/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
+++ b/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
@@ -66,7 +66,24 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
                 }
 
                 if (_state == QueueState.Running)
-                    return true;
+                {
+                    // Defensive: ProcessingLoop should never exit on its own (it loops until cancellation),
+                    // but if a subclass override breaks that contract, recover by treating the queue as stopped.
+                    if (_task == null || _task.IsCompleted)
+                    {
+                        _logger.Error($"{QueueName} queue processor task exited unexpectedly; restarting.");
+                        _task?.Dispose();
+                        _task = null;
+                        _cancellationTokenSource?.Dispose();
+                        _cancellationTokenSource = null;
+                        _state = QueueState.Stopped;
+                        Interlocked.Exchange(ref _cleanupContinuationRegistered, 0);
+                    }
+                    else
+                    {
+                        return true;
+                    }
+                }
 
                 _cancellationTokenSource = new CancellationTokenSource();
                 _task = Task.Run(() => ProcessingLoop(_cancellationTokenSource.Token), _cancellationTokenSource.Token);

--- a/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
+++ b/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
@@ -59,6 +59,12 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
         {
             lock (_lifecycleLock)
             {
+                if (_disposed)
+                {
+                    _logger.Error($"{QueueName} queue processor is disposed and cannot be started.");
+                    return false;
+                }
+
                 if (_state == QueueState.Stopping)
                 {
                     _logger.Error($"{QueueName} queue processor is still stopping and cannot be started again yet.");

--- a/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
+++ b/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
@@ -69,10 +69,11 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
                 {
                     // Defensive: ProcessingLoop should never exit on its own (it loops until cancellation),
                     // but if a subclass override breaks that contract, recover by treating the queue as stopped.
+                    // We do NOT call Task.Dispose on a possibly-faulted task — let the GC handle it to avoid
+                    // surfacing unobserved exceptions on the finalizer thread.
                     if (_task == null || _task.IsCompleted)
                     {
                         _logger.Error($"{QueueName} queue processor task exited unexpectedly; restarting.");
-                        _task?.Dispose();
                         _task = null;
                         _cancellationTokenSource?.Dispose();
                         _cancellationTokenSource = null;

--- a/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
+++ b/src/collector/HSMDataCollector/SyncQueue/SpecificQueue/QueueProcessorBase.cs
@@ -1,4 +1,4 @@
-﻿using HSMDataCollector.Core;
+using HSMDataCollector.Core;
 using HSMDataCollector.Logging;
 using HSMDataCollector.SyncQueue.Data;
 using HSMSensorDataObjects.SensorValueRequests;
@@ -11,10 +11,19 @@ using System.Threading.Tasks;
 
 namespace HSMDataCollector.SyncQueue.SpecificQueue
 {
+    internal enum QueueState : byte
+    {
+        Stopped,
+        Running,
+        Stopping,
+    }
+
+
     internal abstract class QueueProcessorBase<T> : IDisposable
     {
         private Task _task;
         private bool _disposed;
+        private QueueState _state;
         private readonly Channel<QueueItem<T>> _channel;
 
         protected ChannelReader<QueueItem<T>> Reader => _channel.Reader;
@@ -27,7 +36,6 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
 
         private readonly object _lifecycleLock = new object();
         protected int _queueCount;
-        private int _stopTimedOut;
         private int _cleanupContinuationRegistered;
 
         public abstract string QueueName { get; }
@@ -51,19 +59,18 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
         {
             lock (_lifecycleLock)
             {
-                if (_task != null)
+                if (_state == QueueState.Stopping)
                 {
-                    if (_task.IsCompleted)
-                        CompleteStoppedTask(_task, _cancellationTokenSource, clearQueue: false);
-                    else
-                    {
-                        _logger.Error($"{QueueName} queue processor is still stopping and cannot be started again yet.");
-                        return false;
-                    }
+                    _logger.Error($"{QueueName} queue processor is still stopping and cannot be started again yet.");
+                    return false;
                 }
+
+                if (_state == QueueState.Running)
+                    return true;
 
                 _cancellationTokenSource = new CancellationTokenSource();
                 _task = Task.Run(() => ProcessingLoop(_cancellationTokenSource.Token), _cancellationTokenSource.Token);
+                _state = QueueState.Running;
                 Interlocked.Exchange(ref _cleanupContinuationRegistered, 0);
             }
 
@@ -79,7 +86,7 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
 
                 lock (_lifecycleLock)
                 {
-                    if (_task is null)
+                    if (_state == QueueState.Stopped)
                     {
                         if (clearQueue)
                             ClearQueue();
@@ -87,6 +94,15 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
                         return true;
                     }
 
+                    if (_state == QueueState.Stopping)
+                    {
+                        if (clearQueue)
+                            ClearQueue();
+
+                        return false;
+                    }
+
+                    _state = QueueState.Stopping;
                     taskToWait = _task;
                     tokenSourceToDispose = _cancellationTokenSource;
                 }
@@ -106,8 +122,7 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
                             {
                                 RegisterCompletionCleanup(taskToWait, tokenSourceToDispose);
 
-                                if (Interlocked.Exchange(ref _stopTimedOut, 1) == 0)
-                                    _logger.Error($"{QueueName} queue processor did not stop within {_options.RequestTimeout}. IDataSender may ignore cancellation.");
+                                _logger.Error($"{QueueName} queue processor did not stop within {_options.RequestTimeout}. IDataSender may ignore cancellation.");
 
                                 if (clearQueue)
                                     ClearQueue();
@@ -262,7 +277,7 @@ namespace HSMDataCollector.SyncQueue.SpecificQueue
                 if (clearQueue)
                     ClearQueue();
 
-                Interlocked.Exchange(ref _stopTimedOut, 0);
+                _state = QueueState.Stopped;
                 Interlocked.Exchange(ref _cleanupContinuationRegistered, 0);
             }
         }

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.31</Version>
+    <Version>3.40.32</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
## Summary

Refactor DataCollector lifecycle management to formalize the state machine as a single source of truth. This is the foundation for porting the library to other languages (Rust, Go, Python) — a clear state machine ports 1:1, whereas scattered flags do not.

Implements items 1-3 from the refactoring plan: state machine enum, lifecycle gate, actor-like queues.

## Changes

### New
- `CollectorLifecycle.cs` — atomic state machine with `Status`, `CanAcceptData`, `CanStartNewSensors` and explicit transitions (`TryStart`, `CompleteStart`, `AbortStart`, `TryStop`, `CompleteStop`, `TryDispose`)
- `QueueState` enum (Stopped / Running / Stopping) in `QueueProcessorBase`
- `CollectorLifecycleTests.cs` — 28 unit tests covering all transitions, dispose paths, and concurrent operations
- `IsDisposed()` / `IsStoppedOrDisposed()` extension methods
- `Disposed` added to `CollectorStatus` enum

### Removed
- `DataCollector._lifecycleLock`, `_disposed`, `Status` setter, `ChangeStatus()`
- `DataProcessor._isStarted` (int), `_isStopping` (int), `IsStarted` property, `Volatile.Read/Write` for those flags
- `QueueProcessorBase._stopTimedOut` flag (replaced by `_state == Stopping`)

### Modified
- `DataCollector.Start/Stop/Dispose` delegate to `_lifecycle` for state transitions
- `DataProcessor.AddData/AddPriorityData/AddCommand/AddFile` check `_lifecycle.CanAcceptData`
- `DataProcessor.CanStartNewSensors` delegates to `_lifecycle.CanStartNewSensors`
- `QueueProcessorBase.Start/StopAsync/CompleteStoppedTask` use `_state` transitions
- Server version bumped 3.40.31 → 3.40.32

## Review findings (and fixes applied)

During self-review I found and fixed two correctness issues before opening this PR:

1. **`CanAcceptData` was too restrictive.** Initial implementation gated data on `Starting | Running` only, but the old code allowed enqueueing during `Stopping` (the `_isStarted` flag stayed 1 until `StopAsync` completed). This broke 7 tests where sensors flush their last values during stop. **Fix:** `CanAcceptData` now includes `Stopping`. To support this without breaking the \"no new starts after dispose\" guarantee, `_disposed` is a separate flag from `_status` — `Status` returns `Disposed` when disposed, but data gating still consults `_status` so flush-during-stop works.

2. **Double event firing in Dispose + Stop race.** `Dispose()` raised `ToStopping`/`ToStopped` unconditionally, and the `Start()` error path raised `ToStopped` regardless of whether `AbortStart()` succeeded. Both produced duplicate events if a concurrent `Stop()` had already fired them. **Fix:** all lifecycle event raises are now guarded on the return value of the transition method that logically owns them — `if (_lifecycle.TryStop()) RaiseLifecycleEvent(ToStopping, …)`. Added regression tests covering Stop+Dispose race and ensuring exactly-once event delivery.

## Verification

- `dotnet build` of full solution — no warnings introduced
- All 67 existing collector tests pass
- 28 new `CollectorLifecycleTests` pass
- 3 new adversarial tests pass:
  - `Dispose_from_running_fires_stopping_and_stopped_events` (backward compatibility)
  - `Double_dispose_does_not_throw`
  - `Stop_after_dispose_is_noop`
- Behavior is backward compatible: existing consumers of `Status` and lifecycle events see no change

## Known acceptable deltas vs. old behavior

- `Status` returns `Disposed` (new terminal state) instead of `Stopped` after `Dispose()`. Tests asserting `Stopped` after `Dispose()` were updated.
- `CanAcceptData` during `Stopping` is now consulted through the lifecycle rather than `_isStarted`. Net behavior matches old code (sensors can flush during stop, drops happen after `Stopped`).

## Follow-up (separate epics, tracked in issues)

- #1055 Scheduler refactoring — instance-based, interface, unify with PeriodicTask
- #1056 Sensor architecture — composition over inheritance
- #1057 Public API simplification — builder pattern, ILifecycleListener
- #1058 Separate registration from start
- #1059 Adversarial test matrix + platform isolation + conformance suite

## Test plan

- [x] `dotnet build` succeeds with no new warnings
- [x] `dotnet test` collector tests — all green (67/67)
- [x] New `CollectorLifecycleTests` — all green (28/28)
- [x] New adversarial tests for Dispose semantics — all green
- [ ] Smoke test against running HSMServer (reviewer to confirm)