### PR TITLE
Refactor: DataCollector portability batch (#1055–#1059)

### DIFF
--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -82,9 +82,9 @@ Sensor registration is gated by `CollectorLifecycle.CanRegisterSensors` and foll
 | Shutdown | Stopping | false | **Rejected** — logged, disposed, not added. |
 | Terminal | Disposed | false | **Rejected** — logged, disposed, not added. |
 
-`CanRegisterSensors` = `!disposed && status != Stopping` (i.e. the union of configuration and operational phases). `CanStartNewSensors` = `!disposed && (Starting || Running)` — the narrower gate that decides immediate start vs. deferred queueing.
+`CanRegisterSensors` = `!disposed && status != Stopping` (i.e. the union of configuration and operational phases). `CanStartNewSensors` = `!disposed && (Starting || Running)` — the narrower gate that decides immediate start vs. deferred queueing. The registration decision is serialized with collector stop/dispose transitions, and dynamically started sensors are tracked so shutdown waits for their init/start path before stopping sensor storage.
 
-Rejection is non-throwing: the rejected sensor is disposed and returned inert, so late `collector.CreateXxxSensor(...)` / `collector.Windows.AddXxx(...)` calls during shutdown do not crash the host. Consumers can pre-check `IDataCollector.IsAcceptingRegistrations` (which mirrors `CanRegisterSensors`).
+Rejection is non-throwing: the rejected sensor is disposed and returned inert, so late `collector.CreateXxxSensor(...)` / `collector.Windows.AddXxx(...)` calls during shutdown do not crash the host. Consumers can pre-check `DataCollector.IsAcceptingRegistrations` (or the optional `ICollectorRegistrationState` capability), which mirrors `CanRegisterSensors`.
 
 Registration is idempotent on path: registering a path that already exists returns the existing sensor without starting a duplicate.
 
@@ -92,7 +92,7 @@ Registration is idempotent on path: registering a path that already exists retur
 
 Two additive, portable-friendly APIs sit alongside the legacy surface (nothing removed):
 
-- **`ILifecycleListener`** — observer interface (`OnStarting`/`OnRunning`/`OnStopping`/`OnStopped`) registered via `IDataCollector.AddLifecycleListener(...)`. This is the portable equivalent of the `ToStarting`/`ToRunning`/`ToStopping`/`ToStopped` C# events (which still fire). Listeners are invoked from `LogAndRaise` under `_opLock` with per-listener exception isolation; only transitions after registration are delivered (no replay).
+- **`ILifecycleListener`** — observer interface (`OnStarting`/`OnRunning`/`OnStopping`/`OnStopped`) registered via `DataCollector.AddLifecycleListener(...)`, the `IDataCollector` extension method, or the optional `ILifecycleObservableCollector` capability. The extension delegates only when the collector exposes that optional capability; custom `IDataCollector` implementations without it are left unchanged. This is the portable equivalent of the `ToStarting`/`ToRunning`/`ToStopping`/`ToStopped` C# events (which still fire). Listeners are invoked from `LogAndRaise` under `_opLock` with per-listener exception isolation; only transitions after registration are delivered (no replay).
 - **Fluent sensor builders** — `collector.InstantSensor<T>(path)`, `BarSensor<T>(path)`, `RateSensor(path)` extension methods returning fluent builders whose `Build()` dispatches to the existing options-based `CreateXxx(path, options)` factory methods. Implemented as extension methods, so the `IDataCollector` interface is unchanged; the legacy per-type overloads remain. The builders give ports a single `path → type → kind → options → Build` mental model instead of 100+ overloads.
 
 ### Data gating

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -131,6 +131,12 @@ Sensors do not own scheduling boilerplate inline. The "schedule one periodic act
 
 `ScheduledTaskHandle.Start` and `StopAsync` are idempotent and thread-safe. `WindowsServiceStatusSensor` deliberately keeps a raw `ScheduledTask` because it needs `ScheduledTask.CurrentRun`/`IsRunning` to defer `ServiceController` disposal until the in-flight run completes — a specialization the simple handle intentionally does not expose.
 
+### Platform metric sources
+
+The Windows-only `System.Diagnostics.PerformanceCounter` API is isolated behind `IPerformanceCounterFactory` / `IPerformanceCounter`. `WindowsSensorBase` (CPU/RAM/disk bars) and `BaseSocketsSensor` (TCP connection counts) depend on the factory via an `internal virtual PerformanceCounterFactory` seam that defaults to `WindowsPerformanceCounterFactory` (the only place real `PerformanceCounter`/`PerformanceCounterCategory` calls live). Tests substitute a fake factory, so these sensors are now unit-testable on any OS.
+
+Linux default sensors still read metrics by shelling out to `top`/`free` via `BashCommandExtension.BashExecute()`; migrating them to direct `/proc` reads behind the same kind of seam is tracked separately (issue #1065).
+
 ## Features
 
 | Feature | Folder | Description |

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -28,7 +28,7 @@ DataCollector (public API)
     |       +-- CommandQueueProcessor (server commands)
     |       +-- MessageDeduplicator (error deduplication)
     |
-    +-- CollectorScheduler (static timer wheel)
+    +-- ICollectorScheduler (per-collector instance, bucketed timer wheel)
     |       |
     |       +-- ScheduledTask (per-sensor periodic action)
     |
@@ -94,6 +94,10 @@ If `Stop()` or `Dispose()` races with `Start()` while sensor initialization is a
 
 Each `QueueProcessorBase` maintains its own `QueueState` (Stopped/Running/Stopping). If `StopAsync` times out (IDataSender ignores cancellation), the queue stays in `Stopping` and blocks subsequent `Start()` until the background task completes. As a defensive measure, `Start()` will reset and restart a queue whose `_task` exited unexpectedly while `_state` is still `Running` — this only fires if a subclass overrides `ProcessingLoop` and breaks the "loop until cancellation" contract.
 
+### Scheduler ownership
+
+Each `DataCollector` owns its own `CollectorScheduler` instance (implementing `ICollectorScheduler`). The scheduler is constructed in `DataCollector`'s constructor, threaded through `DataProcessor.Scheduler`, and disposed at the end of `Dispose()` after `_dataProcessor` and `_dataSender`. Sensors and `MessageDeduplicator` schedule periodic work through this injected instance — there is no process-global scheduler. Two collectors in the same process have independent timer wheels and worker tasks.
+
 ## Features
 
 | Feature | Folder | Description |
@@ -108,7 +112,7 @@ Each `QueueProcessorBase` maintains its own `QueueState` (Stopped/Running/Stoppi
 ## Thread Safety Model
 
 - All public sensor methods (`AddValue`, `SendValue`) can be called from any thread
-- `CollectorScheduler` fires callbacks on ThreadPool threads
+- `CollectorScheduler` (per-collector instance) fires callbacks on ThreadPool threads
 - `CollectorLifecycle` uses a single `lock` for atomic state transitions (shared by DataCollector and DataProcessor)
 - `QueueProcessorBase` uses its own `lock` for queue lifecycle (Start/Stop) + `Interlocked` for queue count
 - Shared mutable state uses: `Interlocked` (counters, flags), `Volatile` (reads/writes), `lock` (complex operations)

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -88,6 +88,13 @@ Rejection is non-throwing: the rejected sensor is disposed and returned inert, s
 
 Registration is idempotent on path: registering a path that already exists returns the existing sensor without starting a duplicate.
 
+### Public API surface (portability-oriented)
+
+Two additive, portable-friendly APIs sit alongside the legacy surface (nothing removed):
+
+- **`ILifecycleListener`** — observer interface (`OnStarting`/`OnRunning`/`OnStopping`/`OnStopped`) registered via `IDataCollector.AddLifecycleListener(...)`. This is the portable equivalent of the `ToStarting`/`ToRunning`/`ToStopping`/`ToStopped` C# events (which still fire). Listeners are invoked from `LogAndRaise` under `_opLock` with per-listener exception isolation; only transitions after registration are delivered (no replay).
+- **Fluent sensor builders** — `collector.InstantSensor<T>(path)`, `BarSensor<T>(path)`, `RateSensor(path)` extension methods returning fluent builders whose `Build()` dispatches to the existing options-based `CreateXxx(path, options)` factory methods. Implemented as extension methods, so the `IDataCollector` interface is unchanged; the legacy per-type overloads remain. The builders give ports a single `path → type → kind → options → Build` mental model instead of 100+ overloads.
+
 ### Data gating
 
 `CanAcceptData` returns true during `Starting`, `Running`, and `Stopping` states. This allows sensors to flush pending values during stop. `CanStartNewSensors` returns true only during `Starting` and `Running` (and not when disposed).

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -122,6 +122,15 @@ Each `QueueProcessorBase` maintains its own `QueueState` (Stopped/Running/Stoppi
 
 Each `DataCollector` owns its own `CollectorScheduler` instance (implementing `ICollectorScheduler`). The scheduler is constructed in `DataCollector`'s constructor, threaded through `DataProcessor.Scheduler`, and disposed at the end of `Dispose()` after `_dataProcessor` and `_dataSender`. Sensors and `MessageDeduplicator` schedule periodic work through this injected instance — there is no process-global scheduler. Two collectors in the same process have independent timer wheels and worker tasks.
 
+### Sensor scheduling via composition
+
+Sensors do not own scheduling boilerplate inline. The "schedule one periodic action; start/stop/restart it once" lifecycle is extracted into `ScheduledTaskHandle` (a composable wrapper over a single `ScheduledTask`). Sensors *compose* one handle per periodic action rather than inheriting the timer plumbing:
+- `MonitoringSensorBase` composes a send-loop handle (the periodic `SendValueAction`).
+- `BarMonitoringSensorBase` composes a second handle for the bar-collect loop, on top of the inherited send handle.
+- `FreeDiskSpacePredictionBase` composes a handle for its disk-speed sampling loop.
+
+`ScheduledTaskHandle.Start` and `StopAsync` are idempotent and thread-safe. `WindowsServiceStatusSensor` deliberately keeps a raw `ScheduledTask` because it needs `ScheduledTask.CurrentRun`/`IsRunning` to defer `ServiceController` disposal until the in-flight run completes — a specialization the simple handle intentionally does not expose.
+
 ## Features
 
 | Feature | Folder | Description |

--- a/aicontext/features/collector/overview.md
+++ b/aicontext/features/collector/overview.md
@@ -71,6 +71,23 @@ Key rules:
 - Lifecycle events (`ToStarting`, `ToRunning`, etc.) isolate subscriber exceptions
 - `Dispose()` from active states fires `ToStopping`/`ToStopped` for backward compatibility
 
+### Sensor registration (two-phase contract)
+
+Sensor registration is gated by `CollectorLifecycle.CanRegisterSensors` and follows two phases:
+
+| Phase | Status | `CanRegisterSensors` | Behavior of `Register` |
+|---|---|---|---|
+| Configuration | Stopped | true | Sensor is **queued**. It is initialized and started by `SensorsStorage.InitAsync`/`StartAsync` on the next `Start()`. |
+| Operational | Starting / Running | true | Sensor is added and **started immediately** (fire-and-forget `InitAndStart`). |
+| Shutdown | Stopping | false | **Rejected** — logged, disposed, not added. |
+| Terminal | Disposed | false | **Rejected** — logged, disposed, not added. |
+
+`CanRegisterSensors` = `!disposed && status != Stopping` (i.e. the union of configuration and operational phases). `CanStartNewSensors` = `!disposed && (Starting || Running)` — the narrower gate that decides immediate start vs. deferred queueing.
+
+Rejection is non-throwing: the rejected sensor is disposed and returned inert, so late `collector.CreateXxxSensor(...)` / `collector.Windows.AddXxx(...)` calls during shutdown do not crash the host. Consumers can pre-check `IDataCollector.IsAcceptingRegistrations` (which mirrors `CanRegisterSensors`).
+
+Registration is idempotent on path: registering a path that already exists returns the existing sensor without starting a duplicate.
+
 ### Data gating
 
 `CanAcceptData` returns true during `Starting`, `Running`, and `Stopping` states. This allows sensors to flush pending values during stop. `CanStartNewSensors` returns true only during `Starting` and `Running` (and not when disposed).

--- a/src/collector/HSMDataCollector.Tests/CollectorBuilderAndListenerTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorBuilderAndListenerTests.cs
@@ -1,0 +1,311 @@
+using HSMDataCollector.Core;
+using HSMDataCollector.Options;
+using HSMDataCollector.PublicInterface;
+using HSMDataCollector.SyncQueue.Data;
+using HSMSensorDataObjects;
+using HSMSensorDataObjects.SensorValueRequests;
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMDataCollector.Tests
+{
+    public sealed class CollectorBuilderAndListenerTests
+    {
+        private static DataCollector CreateCollector(IDataSender sender)
+        {
+            return new DataCollector(new CollectorOptions
+            {
+                AccessKey = "builder-listener-key",
+                ClientName = "builder-listener-client",
+                ComputerName = "builder-listener-host",
+                Module = "builder-listener-module",
+                DataSender = sender,
+                MaxQueueSize = 1000,
+                MaxValuesInPackage = 50,
+                PackageCollectPeriod = TimeSpan.FromMilliseconds(50),
+                RequestTimeout = TimeSpan.FromSeconds(1),
+                ExceptionDeduplicatorWindow = TimeSpan.FromMilliseconds(100),
+                MaxDeduplicatedMessages = 100,
+            });
+        }
+
+        // --- ILifecycleListener ---
+
+        [Fact]
+        public async Task Listener_receives_transitions_in_order()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                var listener = new RecordingListener();
+                collector.AddLifecycleListener(listener);
+
+                await collector.Start().ConfigureAwait(false);
+                await collector.Stop().ConfigureAwait(false);
+
+                Assert.Equal(
+                    new[] { "Starting", "Running", "Stopping", "Stopped" },
+                    listener.Calls.ToArray());
+            }
+        }
+
+        [Fact]
+        public async Task Events_still_fire_alongside_listeners()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                var eventCalls = new List<string>();
+                collector.ToStarting += () => eventCalls.Add("Starting");
+                collector.ToRunning += () => eventCalls.Add("Running");
+
+                var listener = new RecordingListener();
+                collector.AddLifecycleListener(listener);
+
+                await collector.Start().ConfigureAwait(false);
+
+                Assert.Contains("Starting", eventCalls);
+                Assert.Contains("Running", eventCalls);
+                Assert.Contains("Starting", listener.Calls);
+                Assert.Contains("Running", listener.Calls);
+            }
+        }
+
+        [Fact]
+        public async Task Multiple_listeners_all_notified()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                var a = new RecordingListener();
+                var b = new RecordingListener();
+                collector.AddLifecycleListener(a).AddLifecycleListener(b);
+
+                await collector.Start().ConfigureAwait(false);
+
+                Assert.Contains("Running", a.Calls);
+                Assert.Contains("Running", b.Calls);
+            }
+        }
+
+        [Fact]
+        public async Task Listener_exception_is_isolated()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                var healthy = new RecordingListener();
+                collector.AddLifecycleListener(new ThrowingListener());
+                collector.AddLifecycleListener(healthy);
+
+                var ex = await Record.ExceptionAsync(() => collector.Start()).ConfigureAwait(false);
+
+                Assert.Null(ex); // a throwing listener must not break Start
+                Assert.Contains("Running", healthy.Calls); // nor the next listener
+            }
+        }
+
+        [Fact]
+        public void Null_listener_is_ignored()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                var ex = Record.Exception(() => collector.AddLifecycleListener(null));
+                Assert.Null(ex);
+            }
+        }
+
+        [Fact]
+        public async Task Listener_can_register_another_listener_reentrantly_without_deadlock()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                var added = new RecordingListener();
+                // A listener that, on the first callback, registers another listener. This re-enters
+                // AddLifecycleListener (which takes _listenersLock) while the snapshot is being iterated —
+                // must not deadlock because notification iterates a released snapshot.
+                collector.AddLifecycleListener(new ReentrantAddListener(collector, added));
+
+                var startTask = collector.Start();
+                var completed = await Task.WhenAny(startTask, Task.Delay(TimeSpan.FromSeconds(5))).ConfigureAwait(false);
+
+                Assert.Same(startTask, completed); // no deadlock
+                await startTask.ConfigureAwait(false);
+            }
+        }
+
+        private sealed class ReentrantAddListener : ILifecycleListener
+        {
+            private readonly IDataCollector _collector;
+            private readonly ILifecycleListener _toAdd;
+            private int _added;
+
+            public ReentrantAddListener(IDataCollector collector, ILifecycleListener toAdd)
+            {
+                _collector = collector;
+                _toAdd = toAdd;
+            }
+
+            private void AddOnce()
+            {
+                if (Interlocked.Exchange(ref _added, 1) == 0)
+                    _collector.AddLifecycleListener(_toAdd);
+            }
+
+            public void OnStarting() => AddOnce();
+            public void OnRunning() => AddOnce();
+            public void OnStopping() => AddOnce();
+            public void OnStopped() => AddOnce();
+        }
+
+        // --- Sensor builder facade ---
+
+        [Fact]
+        public async Task InstantSensor_builder_creates_working_sensor()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var sensor = collector.InstantSensor<int>("builder/instant/int")
+                    .Description("built via builder")
+                    .Build();
+
+                Assert.NotNull(sensor);
+                Assert.IsAssignableFrom<IInstantValueSensor<int>>(sensor);
+
+                sensor.AddValue(123);
+                Assert.True(await sender.WaitForDataAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false));
+            }
+        }
+
+        [Fact]
+        public async Task BarSensor_builder_creates_working_sensor()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var sensor = collector.BarSensor<double>("builder/bar/double")
+                    .BarPeriod(TimeSpan.FromMilliseconds(200))
+                    .TickPeriod(TimeSpan.FromMilliseconds(50))
+                    .PostPeriod(TimeSpan.FromMilliseconds(100))
+                    .Precision(3)
+                    .Build();
+
+                Assert.NotNull(sensor);
+                Assert.IsAssignableFrom<IBarSensor<double>>(sensor);
+
+                sensor.AddValue(1.5);
+                Assert.True(await sender.WaitForDataAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false));
+            }
+        }
+
+        [Fact]
+        public async Task RateSensor_builder_creates_working_sensor()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var sensor = collector.RateSensor("builder/rate")
+                    .PostPeriod(TimeSpan.FromMilliseconds(150))
+                    .Description("rate via builder")
+                    .Build();
+
+                Assert.NotNull(sensor);
+                sensor.AddValue(10);
+                Assert.True(await sender.WaitForDataAsync(TimeSpan.FromSeconds(3)).ConfigureAwait(false));
+            }
+        }
+
+        [Fact]
+        public void InstantSensor_builder_rejects_unsupported_type()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                Assert.Throws<NotSupportedException>(() =>
+                    collector.InstantSensor<DateTime>("builder/instant/unsupported").Build());
+            }
+        }
+
+        [Fact]
+        public async Task Builder_registered_before_start_queues_then_sends()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                // Build while stopped — configuration phase, should queue.
+                var sensor = collector.InstantSensor<int>("builder/before-start").Build();
+                Assert.Contains(collector.DefaultSensors, s => s.SensorPath.Contains("before-start"));
+
+                await collector.Start().ConfigureAwait(false);
+
+                sensor.AddValue(5);
+                Assert.True(await sender.WaitForDataAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false));
+            }
+        }
+
+        private sealed class RecordingListener : ILifecycleListener
+        {
+            private readonly object _lock = new object();
+            private readonly List<string> _calls = new List<string>();
+
+            public List<string> Calls
+            {
+                get { lock (_lock) return new List<string>(_calls); }
+            }
+
+            private void Record(string name) { lock (_lock) _calls.Add(name); }
+
+            public void OnStarting() => Record("Starting");
+            public void OnRunning() => Record("Running");
+            public void OnStopping() => Record("Stopping");
+            public void OnStopped() => Record("Stopped");
+        }
+
+        private sealed class ThrowingListener : ILifecycleListener
+        {
+            public void OnStarting() => throw new InvalidOperationException("boom-starting");
+            public void OnRunning() => throw new InvalidOperationException("boom-running");
+            public void OnStopping() => throw new InvalidOperationException("boom-stopping");
+            public void OnStopped() => throw new InvalidOperationException("boom-stopped");
+        }
+
+        private sealed class CountingSender : IDataSender
+        {
+            private int _dataPackages;
+            private readonly TaskCompletionSource<bool> _dataReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public int DataPackages => Volatile.Read(ref _dataPackages);
+
+            public Task<bool> WaitForDataAsync(TimeSpan timeout) => WaitAsync(_dataReceived.Task, timeout);
+
+            public void Dispose() { }
+
+            public ValueTask<ConnectionResult> TestConnectionAsync() => new ValueTask<ConnectionResult>(ConnectionResult.Ok);
+
+            public ValueTask<PackageSendingInfo> SendDataAsync(IEnumerable<SensorValueBase> items, CancellationToken token)
+            {
+                Interlocked.Increment(ref _dataPackages);
+                _dataReceived.TrySetResult(true);
+                return default;
+            }
+
+            public ValueTask<PackageSendingInfo> SendPriorityDataAsync(IEnumerable<SensorValueBase> items, CancellationToken token)
+                => SendDataAsync(items, token);
+
+            public ValueTask<PackageSendingInfo> SendCommandAsync(IEnumerable<CommandRequestBase> commands, CancellationToken token) => default;
+
+            public ValueTask<PackageSendingInfo> SendFileAsync(FileSensorValue file, CancellationToken token) => default;
+
+            private static async Task<bool> WaitAsync(Task signal, TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(signal, Task.Delay(timeout)).ConfigureAwait(false);
+                return ReferenceEquals(completed, signal);
+            }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector.Tests/CollectorRegistrationContractTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorRegistrationContractTests.cs
@@ -1,0 +1,253 @@
+using HSMDataCollector.Core;
+using HSMDataCollector.Options;
+using HSMDataCollector.SyncQueue.Data;
+using HSMSensorDataObjects;
+using HSMSensorDataObjects.SensorValueRequests;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMDataCollector.Tests
+{
+    /// <summary>
+    /// Verifies the two-phase sensor registration contract (#1058):
+    ///   - Configuration phase (Stopped): registration is allowed; sensors are queued and started
+    ///     by the next Start().
+    ///   - Operational phase (Starting/Running): registration is allowed; sensors start immediately.
+    ///   - Shutdown (Stopping) and terminal (Disposed): registration is rejected — the sensor is not
+    ///     added to storage.
+    /// </summary>
+    public sealed class CollectorRegistrationContractTests
+    {
+        private static DataCollector CreateCollector(IDataSender sender)
+        {
+            return new DataCollector(new CollectorOptions
+            {
+                AccessKey = "register-contract-key",
+                ClientName = "register-contract-client",
+                ComputerName = "register-contract-host",
+                Module = "register-contract-module",
+                DataSender = sender,
+                MaxQueueSize = 1000,
+                MaxValuesInPackage = 50,
+                PackageCollectPeriod = TimeSpan.FromMilliseconds(50),
+                RequestTimeout = TimeSpan.FromSeconds(1),
+                ExceptionDeduplicatorWindow = TimeSpan.FromMilliseconds(100),
+                MaxDeduplicatedMessages = 100,
+            });
+        }
+
+        // --- IsAcceptingRegistrations reflects the phase ---
+
+        [Fact]
+        public void IsAcceptingRegistrations_true_when_stopped()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                Assert.Equal(CollectorStatus.Stopped, collector.Status);
+                Assert.True(collector.IsAcceptingRegistrations);
+            }
+        }
+
+        [Fact]
+        public async Task IsAcceptingRegistrations_true_when_running()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                Assert.Equal(CollectorStatus.Running, collector.Status);
+                Assert.True(collector.IsAcceptingRegistrations);
+            }
+        }
+
+        [Fact]
+        public async Task IsAcceptingRegistrations_false_when_stopping()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var stopTask = collector.Stop(release.Task);
+
+                Assert.Equal(CollectorStatus.Stopping, collector.Status);
+                Assert.False(collector.IsAcceptingRegistrations);
+
+                release.SetResult(true);
+                await stopTask.ConfigureAwait(false);
+            }
+        }
+
+        [Fact]
+        public async Task IsAcceptingRegistrations_false_after_dispose()
+        {
+            var collector = CreateCollector(new CountingSender());
+            await collector.Start().ConfigureAwait(false);
+
+            collector.Dispose();
+
+            Assert.Equal(CollectorStatus.Disposed, collector.Status);
+            Assert.False(collector.IsAcceptingRegistrations);
+        }
+
+        // --- Configuration phase: register before Start ---
+
+        [Fact]
+        public async Task Sensors_registered_before_start_all_send_after_start()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                var sensors = Enumerable.Range(0, 5)
+                    .Select(i => collector.CreateIntSensor($"contract/before-start/{i}"))
+                    .ToList();
+
+                // All five must be registered (queued) while stopped.
+                Assert.Equal(5, collector.DefaultSensors.Count(s => s.SensorPath.Contains("before-start")));
+
+                // Nothing is sent before Start — the collector drops values while stopped.
+                foreach (var s in sensors)
+                    s.AddValue(1);
+                await Task.Delay(150).ConfigureAwait(false);
+                Assert.Equal(0, sender.DataPackages);
+
+                await collector.Start().ConfigureAwait(false);
+
+                // After Start, every queued sensor is operational and its values reach the sender.
+                foreach (var s in sensors)
+                    s.AddValue(2);
+
+                var received = await sender.WaitForDataAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                Assert.True(received, "Values from sensors registered before Start should be sent after Start.");
+            }
+        }
+
+        // --- Operational phase: register during Running ---
+
+        [Fact]
+        public async Task Sensor_registered_during_running_sends_immediately()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var sensor = collector.CreateIntSensor("contract/during-running/0");
+                Assert.Contains(collector.DefaultSensors, s => s.SensorPath.Contains("during-running"));
+
+                sensor.AddValue(42);
+
+                var received = await sender.WaitForDataAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                Assert.True(received, "A sensor registered while Running should send values immediately.");
+            }
+        }
+
+        // --- Shutdown phase: register during Stopping is rejected ---
+
+        [Fact]
+        public async Task Register_during_stopping_is_rejected()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var release = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var stopTask = collector.Stop(release.Task);
+
+                Assert.Equal(CollectorStatus.Stopping, collector.Status);
+
+                var sensor = collector.CreateIntSensor("contract/during-stopping/0");
+
+                // The sensor must NOT be added to storage while stopping.
+                Assert.DoesNotContain(collector.DefaultSensors, s => s.SensorPath.Contains("during-stopping"));
+
+                // Using the rejected sensor must not throw.
+                var ex = Record.Exception(() => sensor.AddValue(1));
+                Assert.Null(ex);
+
+                release.SetResult(true);
+                await stopTask.ConfigureAwait(false);
+            }
+        }
+
+        // --- Terminal: register after Dispose is rejected ---
+
+        [Fact]
+        public async Task Register_after_dispose_is_rejected_and_does_not_throw()
+        {
+            var collector = CreateCollector(new CountingSender());
+            await collector.Start().ConfigureAwait(false);
+            collector.Dispose();
+
+            var sensor = collector.CreateIntSensor("contract/after-dispose/0");
+
+            Assert.DoesNotContain(collector.DefaultSensors, s => s.SensorPath.Contains("after-dispose"));
+
+            var ex = Record.Exception(() => sensor.AddValue(1));
+            Assert.Null(ex);
+        }
+
+        // --- Restart: register after Stop queues for the next Start ---
+
+        [Fact]
+        public async Task Register_after_stop_queues_for_next_start()
+        {
+            var sender = new CountingSender();
+            using (var collector = CreateCollector(sender))
+            {
+                await collector.Start().ConfigureAwait(false);
+                await collector.Stop().ConfigureAwait(false);
+
+                Assert.Equal(CollectorStatus.Stopped, collector.Status);
+                Assert.True(collector.IsAcceptingRegistrations);
+
+                var sensor = collector.CreateIntSensor("contract/after-stop/0");
+                Assert.Contains(collector.DefaultSensors, s => s.SensorPath.Contains("after-stop"));
+
+                await collector.Start().ConfigureAwait(false);
+
+                sensor.AddValue(7);
+                var received = await sender.WaitForDataAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+                Assert.True(received, "A sensor registered after Stop should send after the next Start.");
+            }
+        }
+
+        private sealed class CountingSender : IDataSender
+        {
+            private int _dataPackages;
+            private readonly TaskCompletionSource<bool> _dataReceived = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            public int DataPackages => Volatile.Read(ref _dataPackages);
+
+            public Task<bool> WaitForDataAsync(TimeSpan timeout) => WaitAsync(_dataReceived.Task, timeout);
+
+            public void Dispose() { }
+
+            public ValueTask<ConnectionResult> TestConnectionAsync() => new ValueTask<ConnectionResult>(ConnectionResult.Ok);
+
+            public ValueTask<PackageSendingInfo> SendDataAsync(IEnumerable<SensorValueBase> items, CancellationToken token)
+            {
+                Interlocked.Increment(ref _dataPackages);
+                _dataReceived.TrySetResult(true);
+                return default;
+            }
+
+            public ValueTask<PackageSendingInfo> SendPriorityDataAsync(IEnumerable<SensorValueBase> items, CancellationToken token)
+                => SendDataAsync(items, token);
+
+            public ValueTask<PackageSendingInfo> SendCommandAsync(IEnumerable<CommandRequestBase> commands, CancellationToken token) => default;
+
+            public ValueTask<PackageSendingInfo> SendFileAsync(FileSensorValue file, CancellationToken token) => default;
+
+            private static async Task<bool> WaitAsync(Task signal, TimeSpan timeout)
+            {
+                var completed = await Task.WhenAny(signal, Task.Delay(timeout)).ConfigureAwait(false);
+                return ReferenceEquals(completed, signal);
+            }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector.Tests/CollectorRegistrationContractTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorRegistrationContractTests.cs
@@ -1,11 +1,14 @@
 using HSMDataCollector.Core;
+using HSMDataCollector.DefaultSensors;
 using HSMDataCollector.Options;
 using HSMDataCollector.SyncQueue.Data;
 using HSMSensorDataObjects;
+using HSMSensorDataObjects.SensorRequests;
 using HSMSensorDataObjects.SensorValueRequests;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -49,7 +52,17 @@ namespace HSMDataCollector.Tests
             {
                 Assert.Equal(CollectorStatus.Stopped, collector.Status);
                 Assert.True(collector.IsAcceptingRegistrations);
+                Assert.True(((ICollectorRegistrationState)collector).IsAcceptingRegistrations);
             }
+        }
+
+        [Fact]
+        public void Registration_state_and_lifecycle_listener_do_not_extend_IDataCollector_contract()
+        {
+            Assert.Empty(typeof(IDataCollector).GetMember(nameof(DataCollector.IsAcceptingRegistrations)));
+            Assert.Empty(typeof(IDataCollector).GetMethods().Where(m => m.Name == nameof(DataCollector.AddLifecycleListener)));
+            Assert.True(typeof(ICollectorRegistrationState).IsAssignableFrom(typeof(DataCollector)));
+            Assert.True(typeof(ILifecycleObservableCollector).IsAssignableFrom(typeof(DataCollector)));
         }
 
         [Fact]
@@ -216,6 +229,66 @@ namespace HSMDataCollector.Tests
             }
         }
 
+        [Fact]
+        public async Task Stop_waits_for_dynamic_sensor_init_before_stopping_storage()
+        {
+            using (var collector = CreateCollector(new CountingSender()))
+            {
+                await collector.Start().ConfigureAwait(false);
+
+                var initEntered = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var releaseInit = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+                var sensor = RegisterBlockingInitSensor(collector, "contract/dynamic-stop-race/0", initEntered, releaseInit);
+
+                Assert.True(await WaitForTaskAsync(initEntered.Task, TimeSpan.FromSeconds(2)).ConfigureAwait(false),
+                    "The dynamically registered sensor should enter InitAsync.");
+
+                var stopTask = collector.Stop();
+
+                Assert.False(await WaitForTaskAsync(stopTask, TimeSpan.FromMilliseconds(150)).ConfigureAwait(false),
+                    "Stop must wait for the in-flight dynamic InitAsync before stopping storage.");
+                Assert.Equal(0, sensor.StopCalls);
+
+                releaseInit.SetResult(true);
+                await stopTask.ConfigureAwait(false);
+
+                Assert.Equal(CollectorStatus.Stopped, collector.Status);
+                Assert.Equal(0, sensor.StartCalls);
+                Assert.Equal(1, sensor.StopCalls);
+            }
+        }
+
+        private static BlockingInitSensor RegisterBlockingInitSensor(
+            DataCollector collector,
+            string path,
+            TaskCompletionSource<bool> initEntered,
+            TaskCompletionSource<bool> releaseInit)
+        {
+            var dataProcessor = (DataProcessor)typeof(DataCollector)
+                .GetField("_dataProcessor", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(collector);
+            var sensorsStorage = (SensorsStorage)typeof(DataCollector)
+                .GetField("_sensorsStorage", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(collector);
+
+            var sensor = new BlockingInitSensor(new InstantSensorOptions
+            {
+                ComputerName = collector.ComputerName,
+                Module = collector.Module,
+                Path = path,
+                DataProcessor = dataProcessor,
+            }, initEntered, releaseInit);
+
+            sensorsStorage.Register(sensor);
+            return sensor;
+        }
+
+        private static async Task<bool> WaitForTaskAsync(Task task, TimeSpan timeout)
+        {
+            var completed = await Task.WhenAny(task, Task.Delay(timeout)).ConfigureAwait(false);
+            return ReferenceEquals(completed, task);
+        }
+
         private sealed class CountingSender : IDataSender
         {
             private int _dataPackages;
@@ -247,6 +320,46 @@ namespace HSMDataCollector.Tests
             {
                 var completed = await Task.WhenAny(signal, Task.Delay(timeout)).ConfigureAwait(false);
                 return ReferenceEquals(completed, signal);
+            }
+        }
+
+        private sealed class BlockingInitSensor : SensorBase<NoDisplayUnit>
+        {
+            private readonly TaskCompletionSource<bool> _initEntered;
+            private readonly TaskCompletionSource<bool> _releaseInit;
+            private int _startCalls;
+            private int _stopCalls;
+
+            internal BlockingInitSensor(
+                InstantSensorOptions options,
+                TaskCompletionSource<bool> initEntered,
+                TaskCompletionSource<bool> releaseInit) : base(options)
+            {
+                _initEntered = initEntered;
+                _releaseInit = releaseInit;
+            }
+
+            internal int StartCalls => Volatile.Read(ref _startCalls);
+
+            internal int StopCalls => Volatile.Read(ref _stopCalls);
+
+            public override async ValueTask<bool> InitAsync()
+            {
+                _initEntered.TrySetResult(true);
+                await _releaseInit.Task.ConfigureAwait(false);
+                return true;
+            }
+
+            public override ValueTask<bool> StartAsync()
+            {
+                Interlocked.Increment(ref _startCalls);
+                return new ValueTask<bool>(true);
+            }
+
+            public override ValueTask StopAsync()
+            {
+                Interlocked.Increment(ref _stopCalls);
+                return default;
             }
         }
     }

--- a/src/collector/HSMDataCollector.Tests/CollectorSchedulerTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorSchedulerTests.cs
@@ -1,0 +1,217 @@
+using HSMDataCollector.Threading;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMDataCollector.Tests
+{
+    public sealed class CollectorSchedulerTests
+    {
+        [Fact]
+        public async Task Schedule_invokes_action_after_delay()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var signal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                scheduler.Schedule(() => signal.TrySetResult(true), TimeSpan.FromMilliseconds(50), Timeout.InfiniteTimeSpan);
+
+                var completed = await Task.WhenAny(signal.Task, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+                Assert.Same(signal.Task, completed);
+            }
+        }
+
+        [Fact]
+        public async Task Schedule_periodic_invokes_action_repeatedly()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var count = 0;
+                var period = TimeSpan.FromMilliseconds(50);
+
+                var task = scheduler.Schedule(() => Interlocked.Increment(ref count), TimeSpan.Zero, period);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(300)).ConfigureAwait(false);
+
+                task.Dispose();
+                var observed = Volatile.Read(ref count);
+
+                // With 50ms period over 300ms we expect ~5-6 invocations; assert at least 3 to allow scheduler jitter.
+                Assert.True(observed >= 3, $"Expected at least 3 invocations, got {observed}.");
+            }
+        }
+
+        [Fact]
+        public async Task Schedule_async_action_awaits_completion_before_next_invocation()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var inFlight = 0;
+                var maxConcurrent = 0;
+                var period = TimeSpan.FromMilliseconds(20);
+
+                var task = scheduler.Schedule(async () =>
+                {
+                    var current = Interlocked.Increment(ref inFlight);
+                    var oldMax = Volatile.Read(ref maxConcurrent);
+                    while (current > oldMax && Interlocked.CompareExchange(ref maxConcurrent, current, oldMax) != oldMax)
+                        oldMax = Volatile.Read(ref maxConcurrent);
+
+                    await Task.Delay(100).ConfigureAwait(false);
+
+                    Interlocked.Decrement(ref inFlight);
+                }, TimeSpan.Zero, period);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
+                task.Dispose();
+
+                // A ScheduledTask must not start a new run while its previous run is still in flight.
+                Assert.Equal(1, Volatile.Read(ref maxConcurrent));
+            }
+        }
+
+        [Fact]
+        public async Task Remove_stops_scheduled_action()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var count = 0;
+                var task = scheduler.Schedule(() => Interlocked.Increment(ref count), TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+
+                await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+                scheduler.Remove(task);
+
+                // Allow any in-flight invocation that the worker already dispatched to finish before snapshotting.
+                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+                var afterRemoveCount = Volatile.Read(ref count);
+                await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+
+                Assert.Equal(afterRemoveCount, Volatile.Read(ref count));
+            }
+        }
+
+        [Fact]
+        public async Task Dispose_stops_worker_and_blocks_new_schedules()
+        {
+            var scheduler = new CollectorScheduler();
+            var fired = 0;
+            scheduler.Schedule(() => Interlocked.Increment(ref fired), TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50));
+            await Task.Delay(TimeSpan.FromMilliseconds(150)).ConfigureAwait(false);
+
+            scheduler.Dispose();
+
+            // Drain any in-flight invocation already dispatched to the threadpool before snapshotting.
+            await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+            var afterDisposeCount = Volatile.Read(ref fired);
+            await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+
+            Assert.Equal(afterDisposeCount, Volatile.Read(ref fired));
+            Assert.Throws<ObjectDisposedException>(() => scheduler.Schedule(() => { }, TimeSpan.Zero, TimeSpan.FromSeconds(1)));
+        }
+
+        [Fact]
+        public void Schedule_with_negative_delay_throws()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => scheduler.Schedule(() => { }, TimeSpan.FromSeconds(-1), TimeSpan.FromSeconds(1)));
+            }
+        }
+
+        [Fact]
+        public void Schedule_with_zero_period_throws()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                Assert.Throws<ArgumentOutOfRangeException>(
+                    () => scheduler.Schedule(() => { }, TimeSpan.Zero, TimeSpan.Zero));
+            }
+        }
+
+        [Fact]
+        public void Schedule_with_null_action_throws()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                Assert.Throws<ArgumentNullException>(
+                    () => scheduler.Schedule((Action)null, TimeSpan.Zero, TimeSpan.FromSeconds(1)));
+                Assert.Throws<ArgumentNullException>(
+                    () => scheduler.Schedule((Func<Task>)null, TimeSpan.Zero, TimeSpan.FromSeconds(1)));
+            }
+        }
+
+        [Fact]
+        public async Task Multiple_schedulers_are_independent()
+        {
+            // Per-collector schedulers should not share state — confirms removal of static global state.
+            using (var schedulerA = new CollectorScheduler())
+            using (var schedulerB = new CollectorScheduler())
+            {
+                var countA = 0;
+                var countB = 0;
+
+                var taskA = schedulerA.Schedule(() => Interlocked.Increment(ref countA), TimeSpan.Zero, TimeSpan.FromMilliseconds(50));
+                var taskB = schedulerB.Schedule(() => Interlocked.Increment(ref countB), TimeSpan.Zero, TimeSpan.FromMilliseconds(50));
+
+                await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+
+                schedulerA.Remove(taskA);
+
+                // Drain any in-flight invocation already dispatched to the threadpool before snapshotting.
+                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+                var snapshotA = Volatile.Read(ref countA);
+                await Task.Delay(TimeSpan.FromMilliseconds(200)).ConfigureAwait(false);
+
+                // schedulerB must keep firing after schedulerA's task was removed.
+                Assert.True(Volatile.Read(ref countB) > snapshotA / 2,
+                    $"schedulerB should keep firing independently. countA(after-remove)={snapshotA}, countB={Volatile.Read(ref countB)}");
+                Assert.Equal(snapshotA, Volatile.Read(ref countA));
+
+                taskB.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task Onerror_callback_receives_exception_from_action()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                Exception caught = null;
+                var signal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                scheduler.Schedule(
+                    () => throw new InvalidOperationException("boom"),
+                    TimeSpan.FromMilliseconds(20),
+                    Timeout.InfiniteTimeSpan,
+                    ex => { caught = ex; signal.TrySetResult(true); });
+
+                var completed = await Task.WhenAny(signal.Task, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+
+                Assert.Same(signal.Task, completed);
+                Assert.IsType<InvalidOperationException>(caught);
+            }
+        }
+
+        [Fact]
+        public async Task ScheduledTask_dispose_removes_from_owning_scheduler()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var count = 0;
+                var task = scheduler.Schedule(() => Interlocked.Increment(ref count), TimeSpan.Zero, TimeSpan.FromMilliseconds(40));
+
+                await Task.Delay(TimeSpan.FromMilliseconds(150)).ConfigureAwait(false);
+                task.Dispose();
+
+                // Drain any in-flight invocation already dispatched to the threadpool before snapshotting.
+                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+                var snapshot = Volatile.Read(ref count);
+                await Task.Delay(TimeSpan.FromMilliseconds(150)).ConfigureAwait(false);
+
+                Assert.Equal(snapshot, Volatile.Read(ref count));
+            }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector.Tests/PerformanceCounterIsolationTests.cs
+++ b/src/collector/HSMDataCollector.Tests/PerformanceCounterIsolationTests.cs
@@ -1,0 +1,185 @@
+using HSMDataCollector.Core;
+using HSMDataCollector.DefaultSensors;
+using HSMDataCollector.DefaultSensors.Windows;
+using HSMDataCollector.Options;
+using HSMSensorDataObjects;
+using HSMSensorDataObjects.SensorValueRequests;
+using HSMDataCollector.SyncQueue.Data;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMDataCollector.Tests
+{
+    /// <summary>
+    /// Verifies that the Windows performance-counter sensors are decoupled from the real
+    /// System.Diagnostics.PerformanceCounter via IPerformanceCounterFactory, so they can be exercised
+    /// on any OS by substituting a fake factory. Before the isolation these classes could not be
+    /// unit-tested off Windows at all.
+    /// </summary>
+    public sealed class PerformanceCounterIsolationTests
+    {
+        [Fact]
+        public async Task WindowsSensor_reads_value_through_injected_factory()
+        {
+            using (var collector = CreateCollector())
+            {
+                var dataProcessor = GetDataProcessor(collector);
+                var factory = new FakeFactory(sampleValue: 42.0);
+                var options = BarOptions(dataProcessor, "perf/iso/windows");
+
+                var sensor = new TestWindowsSensor(options, factory);
+
+                Assert.True(await sensor.CallInitAsync().ConfigureAwait(false));
+
+                // The factory was consulted with the sensor's category/counter/instance.
+                Assert.Equal("TestCategory", factory.LastCategory);
+                Assert.Equal("TestCounter", factory.LastCounter);
+
+                // Bar data comes from the fake counter, not a real OS counter.
+                Assert.Equal(42.0, sensor.CallGetBarData());
+
+                await sensor.CallStopAsync().ConfigureAwait(false);
+                Assert.True(factory.CreatedCounter.Disposed, "Counter should be disposed on stop.");
+            }
+        }
+
+        [Fact]
+        public async Task WindowsSensor_init_fails_when_factory_returns_null_instance()
+        {
+            using (var collector = CreateCollector())
+            {
+                var dataProcessor = GetDataProcessor(collector);
+                var factory = new FakeFactory(sampleValue: 1.0) { ReturnNull = true };
+                var options = BarOptions(dataProcessor, "perf/iso/missing-instance");
+
+                var sensor = new TestWindowsSensor(options, factory) { Instance = "no-such-instance" };
+
+                // Factory returns null for a missing instance → InitAsync must fail gracefully (no throw).
+                Assert.False(await sensor.CallInitAsync().ConfigureAwait(false));
+            }
+        }
+
+        [Fact]
+        public void Production_factory_default_is_the_windows_factory()
+        {
+            using (var collector = CreateCollector())
+            {
+                var dataProcessor = GetDataProcessor(collector);
+                var options = BarOptions(dataProcessor, "perf/iso/default-factory");
+
+                // A sensor that does not override the seam uses the real Windows factory by default.
+                var sensor = new DefaultFactoryWindowsSensor(options);
+
+                Assert.IsType<WindowsPerformanceCounterFactory>(sensor.ExposedFactory);
+            }
+        }
+
+        // --- helpers ---
+
+        private static DataCollector CreateCollector()
+        {
+            return new DataCollector(new CollectorOptions
+            {
+                AccessKey = "perf-iso-key",
+                ClientName = "perf-iso-client",
+                ComputerName = "perf-iso-host",
+                Module = "perf-iso-module",
+                DataSender = new NoopSender(),
+                MaxQueueSize = 1000,
+                MaxValuesInPackage = 50,
+                PackageCollectPeriod = TimeSpan.FromMilliseconds(50),
+                RequestTimeout = TimeSpan.FromSeconds(1),
+                ExceptionDeduplicatorWindow = TimeSpan.FromMilliseconds(100),
+                MaxDeduplicatedMessages = 100,
+            });
+        }
+
+        private static DataProcessor GetDataProcessor(DataCollector collector) =>
+            (DataProcessor)typeof(DataCollector)
+                .GetField("_dataProcessor", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(collector);
+
+        private static BarSensorOptions BarOptions(DataProcessor dataProcessor, string path) =>
+            new BarSensorOptions
+            {
+                Path = path,
+                DataProcessor = dataProcessor,
+                PostDataPeriod = TimeSpan.FromMilliseconds(100),
+                BarTickPeriod = TimeSpan.FromMilliseconds(50),
+                BarPeriod = TimeSpan.FromMilliseconds(200),
+            };
+
+        private sealed class FakeFactory : IPerformanceCounterFactory
+        {
+            public FakeFactory(double sampleValue) => CreatedCounter = new FakeCounter(sampleValue);
+
+            public FakeCounter CreatedCounter { get; }
+            public bool ReturnNull { get; set; }
+            public string LastCategory { get; private set; }
+            public string LastCounter { get; private set; }
+            public string LastInstance { get; private set; }
+
+            public IPerformanceCounter Create(string category, string counter, string instanceFilter = null)
+            {
+                LastCategory = category;
+                LastCounter = counter;
+                LastInstance = instanceFilter;
+                return ReturnNull ? null : CreatedCounter;
+            }
+        }
+
+        private sealed class FakeCounter : IPerformanceCounter
+        {
+            private readonly double _value;
+            public FakeCounter(double value) => _value = value;
+            public bool Disposed { get; private set; }
+            public double NextValue() => _value;
+            public void Dispose() => Disposed = true;
+        }
+
+        private sealed class TestWindowsSensor : WindowsSensorBase
+        {
+            private readonly IPerformanceCounterFactory _factory;
+
+            public TestWindowsSensor(BarSensorOptions options, IPerformanceCounterFactory factory) : base(options)
+            {
+                _factory = factory;
+            }
+
+            public string Instance { get; set; }
+
+            internal override IPerformanceCounterFactory PerformanceCounterFactory => _factory;
+            protected override string CategoryName => "TestCategory";
+            protected override string CounterName => "TestCounter";
+            protected override string InstanceName => Instance;
+
+            public ValueTask<bool> CallInitAsync() => InitAsync();
+            public ValueTask CallStopAsync() => StopAsync();
+            public double? CallGetBarData() => GetBarData();
+        }
+
+        private sealed class DefaultFactoryWindowsSensor : WindowsSensorBase
+        {
+            public DefaultFactoryWindowsSensor(BarSensorOptions options) : base(options) { }
+
+            protected override string CategoryName => "X";
+            protected override string CounterName => "Y";
+
+            public IPerformanceCounterFactory ExposedFactory => PerformanceCounterFactory;
+        }
+
+        private sealed class NoopSender : IDataSender
+        {
+            public void Dispose() { }
+            public ValueTask<ConnectionResult> TestConnectionAsync() => new ValueTask<ConnectionResult>(ConnectionResult.Ok);
+            public ValueTask<PackageSendingInfo> SendDataAsync(IEnumerable<SensorValueBase> items, CancellationToken token) => default;
+            public ValueTask<PackageSendingInfo> SendPriorityDataAsync(IEnumerable<SensorValueBase> items, CancellationToken token) => default;
+            public ValueTask<PackageSendingInfo> SendCommandAsync(IEnumerable<CommandRequestBase> commands, CancellationToken token) => default;
+            public ValueTask<PackageSendingInfo> SendFileAsync(FileSensorValue file, CancellationToken token) => default;
+        }
+    }
+}

--- a/src/collector/HSMDataCollector.Tests/PerformanceCounterIsolationTests.cs
+++ b/src/collector/HSMDataCollector.Tests/PerformanceCounterIsolationTests.cs
@@ -1,6 +1,7 @@
 using HSMDataCollector.Core;
 using HSMDataCollector.DefaultSensors;
 using HSMDataCollector.DefaultSensors.Windows;
+using HSMDataCollector.DefaultSensors.Windows.Network;
 using HSMDataCollector.Options;
 using HSMSensorDataObjects;
 using HSMSensorDataObjects.SensorValueRequests;
@@ -78,6 +79,44 @@ namespace HSMDataCollector.Tests
             }
         }
 
+        [Fact]
+        public async Task BaseSocketsSensor_reads_tcp4_and_tcp6_through_injected_factory()
+        {
+            using (var collector = CreateCollector())
+            {
+                var dataProcessor = GetDataProcessor(collector);
+                var factory = new SocketFakeFactory(("TCPv4", 2), ("TCPv6", 3));
+                var options = InstantOptions(dataProcessor, "perf/iso/sockets");
+
+                var sensor = new TestSocketsSensor(options, factory);
+
+                Assert.True(await sensor.CallInitAsync().ConfigureAwait(false));
+
+                Assert.Equal(new[] { "TCPv4:TestSocketCounter", "TCPv6:TestSocketCounter" }, factory.Requests);
+                Assert.Equal(5, sensor.CallGetValue());
+
+                await sensor.CallStopAsync().ConfigureAwait(false);
+                Assert.All(factory.CreatedCounters, c => Assert.True(c.Disposed, "Socket counters should be disposed on stop."));
+            }
+        }
+
+        [Fact]
+        public async Task BaseSocketsSensor_disposes_first_counter_when_second_counter_init_fails()
+        {
+            using (var collector = CreateCollector())
+            {
+                var dataProcessor = GetDataProcessor(collector);
+                var factory = new SocketFakeFactory(("TCPv4", 2)) { ThrowOnCategory = "TCPv6" };
+                var options = InstantOptions(dataProcessor, "perf/iso/sockets-failure");
+
+                var sensor = new TestSocketsSensor(options, factory);
+
+                Assert.False(await sensor.CallInitAsync().ConfigureAwait(false));
+                Assert.Single(factory.CreatedCounters);
+                Assert.True(factory.CreatedCounters[0].Disposed, "The first counter should be disposed when socket initialization fails part-way.");
+            }
+        }
+
         // --- helpers ---
 
         private static DataCollector CreateCollector()
@@ -113,6 +152,14 @@ namespace HSMDataCollector.Tests
                 BarPeriod = TimeSpan.FromMilliseconds(200),
             };
 
+        private static MonitoringInstantSensorOptions InstantOptions(DataProcessor dataProcessor, string path) =>
+            new MonitoringInstantSensorOptions
+            {
+                Path = path,
+                DataProcessor = dataProcessor,
+                PostDataPeriod = TimeSpan.FromMilliseconds(100),
+            };
+
         private sealed class FakeFactory : IPerformanceCounterFactory
         {
             public FakeFactory(double sampleValue) => CreatedCounter = new FakeCounter(sampleValue);
@@ -139,6 +186,35 @@ namespace HSMDataCollector.Tests
             public bool Disposed { get; private set; }
             public double NextValue() => _value;
             public void Dispose() => Disposed = true;
+        }
+
+        private sealed class SocketFakeFactory : IPerformanceCounterFactory
+        {
+            private readonly Dictionary<string, double> _values = new Dictionary<string, double>();
+
+            public SocketFakeFactory(params (string Category, double Value)[] values)
+            {
+                foreach (var value in values)
+                    _values[value.Category] = value.Value;
+            }
+
+            public string ThrowOnCategory { get; set; }
+
+            public List<string> Requests { get; } = new List<string>();
+
+            public List<FakeCounter> CreatedCounters { get; } = new List<FakeCounter>();
+
+            public IPerformanceCounter Create(string category, string counter, string instanceFilter = null)
+            {
+                Requests.Add($"{category}:{counter}");
+
+                if (string.Equals(category, ThrowOnCategory, StringComparison.Ordinal))
+                    throw new InvalidOperationException($"Cannot create {category}");
+
+                var created = new FakeCounter(_values[category]);
+                CreatedCounters.Add(created);
+                return created;
+            }
         }
 
         private sealed class TestWindowsSensor : WindowsSensorBase
@@ -170,6 +246,23 @@ namespace HSMDataCollector.Tests
             protected override string CounterName => "Y";
 
             public IPerformanceCounterFactory ExposedFactory => PerformanceCounterFactory;
+        }
+
+        private sealed class TestSocketsSensor : BaseSocketsSensor
+        {
+            private readonly IPerformanceCounterFactory _factory;
+
+            public TestSocketsSensor(MonitoringInstantSensorOptions options, IPerformanceCounterFactory factory) : base(options)
+            {
+                _factory = factory;
+            }
+
+            internal override IPerformanceCounterFactory PerformanceCounterFactory => _factory;
+            protected override string CounterName => "TestSocketCounter";
+
+            public ValueTask<bool> CallInitAsync() => InitAsync();
+            public ValueTask CallStopAsync() => StopAsync();
+            public int? CallGetValue() => GetValue();
         }
 
         private sealed class NoopSender : IDataSender

--- a/src/collector/HSMDataCollector.Tests/ScheduledTaskHandleTests.cs
+++ b/src/collector/HSMDataCollector.Tests/ScheduledTaskHandleTests.cs
@@ -1,0 +1,143 @@
+using HSMDataCollector.Threading;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMDataCollector.Tests
+{
+    public sealed class ScheduledTaskHandleTests
+    {
+        [Fact]
+        public void Null_scheduler_throws()
+        {
+            Assert.Throws<ArgumentNullException>(() => new ScheduledTaskHandle(null));
+        }
+
+        [Fact]
+        public void Not_scheduled_initially()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+                Assert.False(handle.IsScheduled);
+            }
+        }
+
+        [Fact]
+        public async Task Start_schedules_and_action_runs()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+                var signal = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+                handle.Start(() => signal.TrySetResult(true), TimeSpan.FromMilliseconds(20), Timeout.InfiniteTimeSpan, null);
+
+                Assert.True(handle.IsScheduled);
+
+                var completed = await Task.WhenAny(signal.Task, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+                Assert.Same(signal.Task, completed);
+            }
+        }
+
+        [Fact]
+        public void Start_is_idempotent_keeps_first_schedule()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+                var first = 0;
+                var second = 0;
+
+                handle.Start(() => Interlocked.Increment(ref first), TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50), null);
+                // Second Start while already scheduled must be a no-op — the second action never runs.
+                handle.Start(() => Interlocked.Increment(ref second), TimeSpan.FromMilliseconds(50), TimeSpan.FromMilliseconds(50), null);
+
+                Assert.True(handle.IsScheduled);
+                Assert.Equal(0, Volatile.Read(ref second));
+            }
+        }
+
+        [Fact]
+        public async Task StopAsync_stops_the_action()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+                var count = 0;
+
+                handle.Start(() => Interlocked.Increment(ref count), TimeSpan.FromMilliseconds(40), TimeSpan.FromMilliseconds(40), null);
+                await Task.Delay(TimeSpan.FromMilliseconds(150)).ConfigureAwait(false);
+
+                await handle.StopAsync().ConfigureAwait(false);
+                Assert.False(handle.IsScheduled);
+
+                // Allow any in-flight dispatch to drain, then confirm no further runs.
+                await Task.Delay(TimeSpan.FromMilliseconds(80)).ConfigureAwait(false);
+                var snapshot = Volatile.Read(ref count);
+                await Task.Delay(TimeSpan.FromMilliseconds(150)).ConfigureAwait(false);
+
+                Assert.Equal(snapshot, Volatile.Read(ref count));
+            }
+        }
+
+        [Fact]
+        public async Task StopAsync_is_idempotent_and_safe_when_not_started()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+
+                var ex = await Record.ExceptionAsync(async () =>
+                {
+                    await handle.StopAsync().ConfigureAwait(false);
+                    await handle.StopAsync().ConfigureAwait(false);
+                }).ConfigureAwait(false);
+
+                Assert.Null(ex);
+            }
+        }
+
+        [Fact]
+        public async Task StopAsync_without_waiting_for_current_run_completes_promptly()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+                handle.Start(() => { }, TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30), null);
+                await Task.Delay(TimeSpan.FromMilliseconds(80)).ConfigureAwait(false);
+
+                var stopTask = handle.StopAsync(waitForCurrentRun: false).AsTask();
+                var completed = await Task.WhenAny(stopTask, Task.Delay(TimeSpan.FromSeconds(2))).ConfigureAwait(false);
+
+                Assert.Same(stopTask, completed);
+                Assert.False(handle.IsScheduled);
+            }
+        }
+
+        [Fact]
+        public async Task Restart_after_stop_schedules_again()
+        {
+            using (var scheduler = new CollectorScheduler())
+            {
+                var handle = new ScheduledTaskHandle(scheduler);
+                var runs = 0;
+
+                handle.Start(() => Interlocked.Increment(ref runs), TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30), null);
+                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+                await handle.StopAsync().ConfigureAwait(false);
+
+                var afterStop = Volatile.Read(ref runs);
+
+                handle.Start(() => Interlocked.Increment(ref runs), TimeSpan.FromMilliseconds(30), TimeSpan.FromMilliseconds(30), null);
+                Assert.True(handle.IsScheduled);
+
+                await Task.Delay(TimeSpan.FromMilliseconds(150)).ConfigureAwait(false);
+                await handle.StopAsync().ConfigureAwait(false);
+
+                Assert.True(Volatile.Read(ref runs) > afterStop, "Handle should schedule again after a stop.");
+            }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector/Core/Builders/SensorBuilders.cs
+++ b/src/collector/HSMDataCollector/Core/Builders/SensorBuilders.cs
@@ -1,0 +1,219 @@
+using System;
+using HSMDataCollector.Options;
+using HSMDataCollector.PublicInterface;
+
+
+namespace HSMDataCollector.Core
+{
+    /// <summary>
+    /// Fluent entry points for creating sensors. These are a thin, portable facade over the existing
+    /// options-based <c>IDataCollector.CreateXxx(path, options)</c> methods — the verbose per-type
+    /// overloads remain available and unchanged. The builder collects an options object and dispatches
+    /// to the correct factory method at <c>Build()</c>, so the same mental model
+    /// (path → value type → kind → options) maps 1:1 onto a non-.NET port.
+    ///
+    /// <code>
+    /// var cpu  = collector.InstantSensor&lt;double&gt;("cpu").Description("CPU %").Build();
+    /// var rps  = collector.RateSensor("requests").PostPeriod(TimeSpan.FromMinutes(1)).Build();
+    /// var lat  = collector.BarSensor&lt;double&gt;("latency").BarPeriod(TimeSpan.FromMinutes(5)).Precision(3).Build();
+    /// </code>
+    /// </summary>
+    public static class SensorBuilderExtensions
+    {
+        /// <summary>Begins building an instant value sensor of type <typeparamref name="T"/>.</summary>
+        public static InstantSensorBuilder<T> InstantSensor<T>(this IDataCollector collector, string path)
+            => new InstantSensorBuilder<T>(collector, path);
+
+        /// <summary>Begins building a bar (aggregated) sensor of type <typeparamref name="T"/> (int or double).</summary>
+        public static BarSensorBuilder<T> BarSensor<T>(this IDataCollector collector, string path)
+            where T : struct
+            => new BarSensorBuilder<T>(collector, path);
+
+        /// <summary>Begins building a rate sensor (values-per-second over a window).</summary>
+        public static RateSensorBuilder RateSensor(this IDataCollector collector, string path)
+            => new RateSensorBuilder(collector, path);
+    }
+
+
+    /// <summary>
+    /// Fluent builder for an instant value sensor. Supported <typeparamref name="T"/>: bool, int, double,
+    /// string, <see cref="Version"/>, <see cref="TimeSpan"/>.
+    /// </summary>
+    public sealed class InstantSensorBuilder<T>
+    {
+        private readonly IDataCollector _collector;
+        private readonly string _path;
+        private readonly InstantSensorOptions _options = new InstantSensorOptions();
+
+        internal InstantSensorBuilder(IDataCollector collector, string path)
+        {
+            _collector = collector ?? throw new ArgumentNullException(nameof(collector));
+            _path = path;
+        }
+
+        public InstantSensorBuilder<T> Description(string description)
+        {
+            _options.Description = description;
+            return this;
+        }
+
+        public InstantSensorBuilder<T> Ttl(TimeSpan ttl)
+        {
+            _options.TTL = ttl;
+            return this;
+        }
+
+        public InstantSensorBuilder<T> KeepHistory(TimeSpan keepHistory)
+        {
+            _options.KeepHistory = keepHistory;
+            return this;
+        }
+
+        public InstantSensorBuilder<T> Priority(bool isPriority = true)
+        {
+            _options.IsPrioritySensor = isPriority;
+            return this;
+        }
+
+        /// <summary>Escape hatch for any option not exposed as a fluent setter.</summary>
+        public InstantSensorBuilder<T> Configure(Action<InstantSensorOptions> configure)
+        {
+            configure?.Invoke(_options);
+            return this;
+        }
+
+        public IInstantValueSensor<T> Build()
+        {
+            var type = typeof(T);
+
+            if (type == typeof(bool))
+                return Cast(_collector.CreateBoolSensor(_path, _options));
+            if (type == typeof(int))
+                return Cast(_collector.CreateIntSensor(_path, _options));
+            if (type == typeof(double))
+                return Cast(_collector.CreateDoubleSensor(_path, _options));
+            if (type == typeof(string))
+                return Cast(_collector.CreateStringSensor(_path, _options));
+            if (type == typeof(Version))
+                return Cast(_collector.CreateVersionSensor(_path, _options));
+            if (type == typeof(TimeSpan))
+                return Cast(_collector.CreateTimeSensor(_path, _options));
+
+            throw new NotSupportedException(
+                $"Instant sensor of type '{type.Name}' is not supported. Supported types: bool, int, double, string, Version, TimeSpan.");
+        }
+
+        // T is verified to match the created sensor's type before this is called, so the object bridge is safe.
+        private static IInstantValueSensor<T> Cast(object sensor) => (IInstantValueSensor<T>)sensor;
+    }
+
+
+    /// <summary>
+    /// Fluent builder for a bar (aggregated) sensor. Supported <typeparamref name="T"/>: int, double.
+    /// </summary>
+    public sealed class BarSensorBuilder<T> where T : struct
+    {
+        private readonly IDataCollector _collector;
+        private readonly string _path;
+        private readonly BarSensorOptions _options = new BarSensorOptions();
+
+        internal BarSensorBuilder(IDataCollector collector, string path)
+        {
+            _collector = collector ?? throw new ArgumentNullException(nameof(collector));
+            _path = path;
+        }
+
+        /// <summary>The time span one bar aggregates (default 5 minutes).</summary>
+        public BarSensorBuilder<T> BarPeriod(TimeSpan barPeriod)
+        {
+            _options.BarPeriod = barPeriod;
+            return this;
+        }
+
+        /// <summary>How often partial bar updates are sent to the server (default 15 seconds).</summary>
+        public BarSensorBuilder<T> PostPeriod(TimeSpan postPeriod)
+        {
+            _options.PostDataPeriod = postPeriod;
+            return this;
+        }
+
+        /// <summary>How often a value is sampled into the current bar (default 5 seconds).</summary>
+        public BarSensorBuilder<T> TickPeriod(TimeSpan tickPeriod)
+        {
+            _options.BarTickPeriod = tickPeriod;
+            return this;
+        }
+
+        /// <summary>Rounding precision for computed bar characteristics (default 2).</summary>
+        public BarSensorBuilder<T> Precision(int precision)
+        {
+            _options.Precision = precision;
+            return this;
+        }
+
+        public BarSensorBuilder<T> Description(string description)
+        {
+            _options.Description = description;
+            return this;
+        }
+
+        /// <summary>Escape hatch for any option not exposed as a fluent setter.</summary>
+        public BarSensorBuilder<T> Configure(Action<BarSensorOptions> configure)
+        {
+            configure?.Invoke(_options);
+            return this;
+        }
+
+        public IBarSensor<T> Build()
+        {
+            var type = typeof(T);
+
+            if (type == typeof(int))
+                return (IBarSensor<T>)_collector.CreateIntBarSensor(_path, _options);
+            if (type == typeof(double))
+                return (IBarSensor<T>)_collector.CreateDoubleBarSensor(_path, _options);
+
+            throw new NotSupportedException(
+                $"Bar sensor of type '{type.Name}' is not supported. Supported types: int, double.");
+        }
+    }
+
+
+    /// <summary>
+    /// Fluent builder for a rate sensor (reports the rate of supplied values per second over a window).
+    /// </summary>
+    public sealed class RateSensorBuilder
+    {
+        private readonly IDataCollector _collector;
+        private readonly string _path;
+        private readonly RateSensorOptions _options = new RateSensorOptions();
+
+        internal RateSensorBuilder(IDataCollector collector, string path)
+        {
+            _collector = collector ?? throw new ArgumentNullException(nameof(collector));
+            _path = path;
+        }
+
+        /// <summary>The window over which the rate is computed and sent (default 1 minute).</summary>
+        public RateSensorBuilder PostPeriod(TimeSpan postPeriod)
+        {
+            _options.PostDataPeriod = postPeriod;
+            return this;
+        }
+
+        public RateSensorBuilder Description(string description)
+        {
+            _options.Description = description;
+            return this;
+        }
+
+        /// <summary>Escape hatch for any option not exposed as a fluent setter.</summary>
+        public RateSensorBuilder Configure(Action<RateSensorOptions> configure)
+        {
+            configure?.Invoke(_options);
+            return this;
+        }
+
+        public IMonitoringRateSensor Build() => _collector.CreateRateSensor(_path, _options);
+    }
+}

--- a/src/collector/HSMDataCollector/Core/CollectorLifecycle.cs
+++ b/src/collector/HSMDataCollector/Core/CollectorLifecycle.cs
@@ -28,6 +28,26 @@ namespace HSMDataCollector.Core
             }
         }
 
+        /// <summary>
+        /// True while new sensors may be *registered*. This is the union of the configuration phase
+        /// (Stopped — sensors are queued and started on the next Start) and the operational phase
+        /// (Starting/Running — sensors are started immediately). Registration is rejected during
+        /// Stopping (the collector is shutting down) and after Dispose (terminal).
+        /// </summary>
+        internal bool CanRegisterSensors
+        {
+            get
+            {
+                lock (_lock)
+                    return !_disposed && _status != CollectorStatus.Stopping;
+            }
+        }
+
+        /// <summary>
+        /// True while a newly-registered sensor should be started immediately (operational phase).
+        /// In the configuration phase (Stopped) registration is allowed but the sensor is only
+        /// queued — <see cref="CanRegisterSensors"/> is true but this is false.
+        /// </summary>
         internal bool CanStartNewSensors
         {
             get

--- a/src/collector/HSMDataCollector/Core/CollectorLifecycleExtensions.cs
+++ b/src/collector/HSMDataCollector/Core/CollectorLifecycleExtensions.cs
@@ -1,0 +1,23 @@
+using System;
+
+
+namespace HSMDataCollector.Core
+{
+    public static class CollectorLifecycleExtensions
+    {
+        /// <summary>
+        /// Registers a lifecycle listener when the collector exposes the optional observer
+        /// capability, without adding a required member to <see cref="IDataCollector"/>.
+        /// </summary>
+        public static IDataCollector AddLifecycleListener(this IDataCollector collector, ILifecycleListener listener)
+        {
+            if (collector == null)
+                throw new ArgumentNullException(nameof(collector));
+
+            if (collector is ILifecycleObservableCollector observable)
+                return observable.AddLifecycleListener(listener);
+
+            return collector;
+        }
+    }
+}

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -10,6 +10,7 @@ using HSMDataCollector.Logging;
 using HSMDataCollector.Options;
 using HSMDataCollector.Prototypes;
 using HSMDataCollector.PublicInterface;
+using HSMDataCollector.Threading;
 using HSMSensorDataObjects;
 
 
@@ -34,6 +35,7 @@ namespace HSMDataCollector.Core
         private readonly IDataSender _dataSender;
         private readonly DataProcessor _dataProcessor;
         private readonly CollectorLifecycle _lifecycle = new CollectorLifecycle();
+        private readonly ICollectorScheduler _scheduler;
 
         // Serializes lifecycle state transitions with their lifecycle event raise so that
         // concurrent Start/Stop/Dispose cannot reorder events (e.g. ToStopping before ToStarting).
@@ -89,7 +91,9 @@ namespace HSMDataCollector.Core
 
             _dataSender = options.DataSender;
 
-            _dataProcessor = new DataProcessor(options, _lifecycle, _logger);
+            _scheduler = new CollectorScheduler();
+
+            _dataProcessor = new DataProcessor(options, _lifecycle, _scheduler, _logger);
 
             _sensorsStorage = _dataProcessor.SensorStorage;
 
@@ -430,6 +434,8 @@ namespace HSMDataCollector.Core
                 DisposeComponent(_dataProcessor.Dispose, nameof(_dataProcessor));
 
                 DisposeComponent(_dataSender.Dispose, nameof(_dataSender));
+
+                DisposeComponent(_scheduler.Dispose, nameof(_scheduler));
             }
             finally
             {

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -51,6 +51,11 @@ namespace HSMDataCollector.Core
         // and then fire ToStopped while the original Stop is still draining).
         private Task _currentProcessorStopTask;
 
+        // Observer-pattern lifecycle listeners (portable alternative to the C# events). Guarded by
+        // its own lock; notified from LogAndRaise alongside the events.
+        private readonly object _listenersLock = new object();
+        private readonly List<ILifecycleListener> _lifecycleListeners = new List<ILifecycleListener>();
+
         internal static bool IsWindowsOS { get; } = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
 
         public IWindowsCollection Windows => _sensorsStorage.Windows;
@@ -131,6 +136,17 @@ namespace HSMDataCollector.Core
         public IDataCollector AddCustomLogger(ICollectorLogger logger)
         {
             _logger.AddLogger(logger);
+
+            return this;
+        }
+
+        public IDataCollector AddLifecycleListener(ILifecycleListener listener)
+        {
+            if (listener == null)
+                return this;
+
+            lock (_listenersLock)
+                _lifecycleListeners.Add(listener);
 
             return this;
         }
@@ -464,6 +480,46 @@ namespace HSMDataCollector.Core
                 case CollectorStatus.Stopped:
                     RaiseLifecycleEvent(ToStopped, nameof(ToStopped));
                     break;
+            }
+
+            NotifyLifecycleListeners(status);
+        }
+
+        private void NotifyLifecycleListeners(CollectorStatus status)
+        {
+            ILifecycleListener[] snapshot;
+            lock (_listenersLock)
+            {
+                if (_lifecycleListeners.Count == 0)
+                    return;
+
+                snapshot = _lifecycleListeners.ToArray();
+            }
+
+            foreach (var listener in snapshot)
+            {
+                try
+                {
+                    switch (status)
+                    {
+                        case CollectorStatus.Starting:
+                            listener.OnStarting();
+                            break;
+                        case CollectorStatus.Running:
+                            listener.OnRunning();
+                            break;
+                        case CollectorStatus.Stopping:
+                            listener.OnStopping();
+                            break;
+                        case CollectorStatus.Stopped:
+                            listener.OnStopped();
+                            break;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error($"DataCollector lifecycle listener error on {status}: {ex}");
+                }
             }
         }
 

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -60,6 +60,8 @@ namespace HSMDataCollector.Core
 
         public CollectorStatus Status => _lifecycle.Status;
 
+        public bool IsAcceptingRegistrations => _lifecycle.CanRegisterSensors;
+
         public string ComputerName => _options?.ComputerName;
 
         public string Module => _options?.Module;

--- a/src/collector/HSMDataCollector/Core/DataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/DataCollector.cs
@@ -26,7 +26,7 @@ namespace HSMDataCollector.Core
     }
 
 
-    public sealed class DataCollector : IDataCollector
+    public sealed class DataCollector : IDataCollector, ICollectorRegistrationState, ILifecycleObservableCollector
     {
         private readonly LoggerManager _logger = new LoggerManager();
 
@@ -100,7 +100,7 @@ namespace HSMDataCollector.Core
 
             _scheduler = new CollectorScheduler();
 
-            _dataProcessor = new DataProcessor(options, _lifecycle, _scheduler, _logger);
+            _dataProcessor = new DataProcessor(options, _lifecycle, _opLock, _scheduler, _logger);
 
             _sensorsStorage = _dataProcessor.SensorStorage;
 

--- a/src/collector/HSMDataCollector/Core/DataProcessor.cs
+++ b/src/collector/HSMDataCollector/Core/DataProcessor.cs
@@ -40,6 +40,8 @@ namespace HSMDataCollector.Core
 
         internal bool CanStartNewSensors => _lifecycle.CanStartNewSensors;
 
+        internal bool CanRegisterSensors => _lifecycle.CanRegisterSensors;
+
         public DataProcessor(CollectorOptions options, CollectorLifecycle lifecycle, ICollectorScheduler scheduler, LoggerManager logger)
         {
             _logger = logger;

--- a/src/collector/HSMDataCollector/Core/DataProcessor.cs
+++ b/src/collector/HSMDataCollector/Core/DataProcessor.cs
@@ -10,6 +10,7 @@ using HSMDataCollector.Exceptions;
 using HSMDataCollector.Logging;
 using HSMDataCollector.SyncQueue.Data;
 using HSMDataCollector.SyncQueue.SpecificQueue;
+using HSMDataCollector.Threading;
 using HSMSensorDataObjects;
 using HSMSensorDataObjects.SensorValueRequests;
 
@@ -31,12 +32,19 @@ namespace HSMDataCollector.Core
 
         internal SensorsStorage SensorStorage { get; }
 
+        /// <summary>
+        /// Per-collector scheduler used by sensors and the message deduplicator. Owned by the
+        /// outer <see cref="DataCollector"/>; disposed there.
+        /// </summary>
+        internal ICollectorScheduler Scheduler { get; }
+
         internal bool CanStartNewSensors => _lifecycle.CanStartNewSensors;
 
-        public DataProcessor(CollectorOptions options, CollectorLifecycle lifecycle, LoggerManager logger)
+        public DataProcessor(CollectorOptions options, CollectorLifecycle lifecycle, ICollectorScheduler scheduler, LoggerManager logger)
         {
             _logger = logger;
             _lifecycle = lifecycle;
+            Scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
             _stopFlushTimeout = TimeSpan.FromTicks(Math.Min(Math.Max(options.RequestTimeout.Ticks, TimeSpan.FromSeconds(1).Ticks),
                                                             TimeSpan.FromSeconds(5).Ticks));
 
@@ -46,7 +54,8 @@ namespace HSMDataCollector.Core
             _priorityQueue = new PriorityDataQueueProcessor(options, this, logger);
             _fileQueue     = new FileQueueProcessor(options, this, logger);
             _commandQueue  = new CommandQueueProcessor(options, this, logger);
-            _messageDeduplicator = new MessageDeduplicator((msg) => { _logger.Error(msg);
+            _messageDeduplicator = new MessageDeduplicator(scheduler,
+                                                           (msg) => { _logger.Error(msg);
                                                                       DefaultSensors?.CollectorErrors?.SendCollectorError(msg);
                                                                     }, options.ExceptionDeduplicatorWindow, options.MaxDeduplicatedMessages);
         }

--- a/src/collector/HSMDataCollector/Core/DataProcessor.cs
+++ b/src/collector/HSMDataCollector/Core/DataProcessor.cs
@@ -26,6 +26,7 @@ namespace HSMDataCollector.Core
         private readonly LoggerManager _logger;
         private readonly MessageDeduplicator _messageDeduplicator;
         private readonly CollectorLifecycle _lifecycle;
+        private readonly object _lifecycleGate;
         private readonly TimeSpan _stopFlushTimeout;
 
         private DefaultSensorsCollection DefaultSensors => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? (DefaultSensorsCollection)SensorStorage.Windows : (DefaultSensorsCollection)SensorStorage.Unix;
@@ -42,10 +43,13 @@ namespace HSMDataCollector.Core
 
         internal bool CanRegisterSensors => _lifecycle.CanRegisterSensors;
 
-        public DataProcessor(CollectorOptions options, CollectorLifecycle lifecycle, ICollectorScheduler scheduler, LoggerManager logger)
+        internal object LifecycleGate => _lifecycleGate;
+
+        public DataProcessor(CollectorOptions options, CollectorLifecycle lifecycle, object lifecycleGate, ICollectorScheduler scheduler, LoggerManager logger)
         {
             _logger = logger;
             _lifecycle = lifecycle;
+            _lifecycleGate = lifecycleGate ?? throw new ArgumentNullException(nameof(lifecycleGate));
             Scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
             _stopFlushTimeout = TimeSpan.FromTicks(Math.Min(Math.Max(options.RequestTimeout.Ticks, TimeSpan.FromSeconds(1).Ticks),
                                                             TimeSpan.FromSeconds(5).Ticks));
@@ -91,6 +95,7 @@ namespace HSMDataCollector.Core
             // After all phases attempt to stop, rethrow as AggregateException so the caller knows the stop was degraded.
             var failures = new List<Exception>();
 
+            await TryStopPhase(() => SensorStorage.WaitForDynamicStartTasksAsync(), failures).ConfigureAwait(false);
             await TryStopPhase(() => SensorStorage.StopAsync(), failures).ConfigureAwait(false);
 
             var dataQueueStopped = false;

--- a/src/collector/HSMDataCollector/Core/ICollectorRegistrationState.cs
+++ b/src/collector/HSMDataCollector/Core/ICollectorRegistrationState.cs
@@ -1,0 +1,17 @@
+namespace HSMDataCollector.Core
+{
+    /// <summary>
+    /// Optional collector capability for callers that need to know whether new sensors may be
+    /// registered without extending the compatibility-sensitive <see cref="IDataCollector"/>.
+    /// </summary>
+    public interface ICollectorRegistrationState
+    {
+        /// <summary>
+        /// True while new sensors may be registered: during the configuration phase (collector
+        /// Stopped, sensors are queued and started on the next <see cref="IDataCollector.Start()"/>)
+        /// and the operational phase (Starting/Running, sensors start immediately). False while the
+        /// collector is Stopping or after it has been disposed.
+        /// </summary>
+        bool IsAcceptingRegistrations { get; }
+    }
+}

--- a/src/collector/HSMDataCollector/Core/IDataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/IDataCollector.cs
@@ -19,6 +19,15 @@ namespace HSMDataCollector.Core
 
         CollectorStatus Status { get; }
 
+        /// <summary>
+        /// True while new sensors may be registered: during the configuration phase (collector
+        /// Stopped — sensors are queued and started on the next <see cref="Start()"/>) and the
+        /// operational phase (Starting/Running — sensors start immediately). False while the
+        /// collector is Stopping or after it has been disposed; registration attempts in those
+        /// states are rejected (logged, the sensor is not added).
+        /// </summary>
+        bool IsAcceptingRegistrations { get; }
+
         string ComputerName { get; }
 
         string Module { get; }

--- a/src/collector/HSMDataCollector/Core/IDataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/IDataCollector.cs
@@ -38,6 +38,15 @@ namespace HSMDataCollector.Core
         event Action ToStopping;
         event Action ToStopped;
 
+        /// <summary>
+        /// Registers an observer notified on each lifecycle transition. This is the portable
+        /// equivalent of the ToStarting/ToRunning/ToStopping/ToStopped events — prefer it for new
+        /// code. The listener is invoked under the same lock as the events; handlers must not block.
+        /// Only transitions occurring after registration are delivered (the current state is not
+        /// replayed). Returns this collector for chaining. A null listener is ignored.
+        /// </summary>
+        IDataCollector AddLifecycleListener(ILifecycleListener listener);
+
         IEnumerable<ISensor> DefaultSensors { get; }
 
         /// <summary>

--- a/src/collector/HSMDataCollector/Core/IDataCollector.cs
+++ b/src/collector/HSMDataCollector/Core/IDataCollector.cs
@@ -19,15 +19,6 @@ namespace HSMDataCollector.Core
 
         CollectorStatus Status { get; }
 
-        /// <summary>
-        /// True while new sensors may be registered: during the configuration phase (collector
-        /// Stopped — sensors are queued and started on the next <see cref="Start()"/>) and the
-        /// operational phase (Starting/Running — sensors start immediately). False while the
-        /// collector is Stopping or after it has been disposed; registration attempts in those
-        /// states are rejected (logged, the sensor is not added).
-        /// </summary>
-        bool IsAcceptingRegistrations { get; }
-
         string ComputerName { get; }
 
         string Module { get; }
@@ -37,15 +28,6 @@ namespace HSMDataCollector.Core
         event Action ToRunning;
         event Action ToStopping;
         event Action ToStopped;
-
-        /// <summary>
-        /// Registers an observer notified on each lifecycle transition. This is the portable
-        /// equivalent of the ToStarting/ToRunning/ToStopping/ToStopped events — prefer it for new
-        /// code. The listener is invoked under the same lock as the events; handlers must not block.
-        /// Only transitions occurring after registration are delivered (the current state is not
-        /// replayed). Returns this collector for chaining. A null listener is ignored.
-        /// </summary>
-        IDataCollector AddLifecycleListener(ILifecycleListener listener);
 
         IEnumerable<ISensor> DefaultSensors { get; }
 

--- a/src/collector/HSMDataCollector/Core/ILifecycleListener.cs
+++ b/src/collector/HSMDataCollector/Core/ILifecycleListener.cs
@@ -1,0 +1,25 @@
+namespace HSMDataCollector.Core
+{
+    /// <summary>
+    /// Observer notified on each <see cref="DataCollector"/> lifecycle transition. This is the
+    /// portable equivalent of the <c>ToStarting</c>/<c>ToRunning</c>/<c>ToStopping</c>/<c>ToStopped</c>
+    /// events — prefer it for new code and for non-.NET ports, where C# events have no direct analog.
+    ///
+    /// Implementations are invoked under the collector's internal lifecycle lock (the same place the
+    /// events fire), so handlers must not block or call back into Start/Stop/Dispose. Exceptions thrown
+    /// by a handler are caught and logged; they do not affect other listeners or the transition itself.
+    ///
+    /// Only transitions that occur after the listener is registered are delivered — the current state
+    /// is not replayed on registration.
+    /// </summary>
+    public interface ILifecycleListener
+    {
+        void OnStarting();
+
+        void OnRunning();
+
+        void OnStopping();
+
+        void OnStopped();
+    }
+}

--- a/src/collector/HSMDataCollector/Core/ILifecycleObservableCollector.cs
+++ b/src/collector/HSMDataCollector/Core/ILifecycleObservableCollector.cs
@@ -1,0 +1,18 @@
+namespace HSMDataCollector.Core
+{
+    /// <summary>
+    /// Optional collector capability for portable lifecycle observers. Kept separate from
+    /// <see cref="IDataCollector"/> so external implementations of the legacy interface remain
+    /// source-compatible.
+    /// </summary>
+    public interface ILifecycleObservableCollector
+    {
+        /// <summary>
+        /// Registers an observer notified on each lifecycle transition. This is the portable
+        /// equivalent of the ToStarting/ToRunning/ToStopping/ToStopped events. Only transitions
+        /// occurring after registration are delivered (the current state is not replayed).
+        /// Returns this collector for chaining. A null listener is ignored.
+        /// </summary>
+        IDataCollector AddLifecycleListener(ILifecycleListener listener);
+    }
+}

--- a/src/collector/HSMDataCollector/Core/SensorsStorage.cs
+++ b/src/collector/HSMDataCollector/Core/SensorsStorage.cs
@@ -172,14 +172,32 @@ namespace HSMDataCollector.Core
             if (_sensors.TryGetValue(path, out var oldSensor))
                 return oldSensor;
 
+            // Shutdown phase (Stopping) or terminal (Disposed): reject. Adding here would either
+            // leak the sensor into storage that is being torn down, or register a sensor that can
+            // never be started. Dispose the rejected sensor so it does not leak, and return it
+            // inert rather than throwing (keeps the public AddXxx API non-throwing for late calls).
+            if (!_dataProcessor.CanRegisterSensors)
+            {
+                Logger.Error($"Cannot register sensor '{path}' — collector is stopping or disposed. The sensor was not added.");
+                sensor.Dispose();
+                return sensor;
+            }
+
+            // Operational phase (Starting/Running): add and start immediately.
             if (_dataProcessor.CanStartNewSensors)
             {
                 var addedSensor = AddSensor(sensor);
-                _ = InitAndStart(addedSensor);
+
+                // If the sensor was deduplicated against an existing one, don't start the duplicate.
+                if (ReferenceEquals(addedSensor, sensor))
+                    _ = InitAndStart(addedSensor);
+
                 return addedSensor;
             }
-            else
-                return AddSensor(sensor);
+
+            // Configuration phase (Stopped): queue the sensor; it will be initialized and started
+            // by SensorsStorage.InitAsync/StartAsync when the collector next starts.
+            return AddSensor(sensor);
         }
 
 

--- a/src/collector/HSMDataCollector/Core/SensorsStorage.cs
+++ b/src/collector/HSMDataCollector/Core/SensorsStorage.cs
@@ -31,6 +31,8 @@ namespace HSMDataCollector.Core
         private readonly DataProcessor _dataProcessor;
 
         private readonly PrototypesCollection _prototypes;
+        private readonly object _dynamicStartTasksLock = new object();
+        private readonly List<Task> _dynamicStartTasks = new List<Task>();
         private int _sensorCount;
 
         public IWindowsCollection Windows { get; }
@@ -80,6 +82,16 @@ namespace HSMDataCollector.Core
         internal Task StartAsync() => Task.WhenAll(_sensors.Values.Select(async s => await s.StartAsync().ConfigureAwait(false)));
 
         internal Task StopAsync() => Task.WhenAll(_sensors.Values.Select(async s => await s.StopAsync().ConfigureAwait(false)));
+
+        internal Task WaitForDynamicStartTasksAsync()
+        {
+            Task[] tasks;
+
+            lock (_dynamicStartTasksLock)
+                tasks = _dynamicStartTasks.ToArray();
+
+            return tasks.Length == 0 ? Task.CompletedTask : Task.WhenAll(tasks);
+        }
 
         public bool TryRemove(string key, out ISensor value)
         {
@@ -172,32 +184,37 @@ namespace HSMDataCollector.Core
             if (_sensors.TryGetValue(path, out var oldSensor))
                 return oldSensor;
 
-            // Shutdown phase (Stopping) or terminal (Disposed): reject. Adding here would either
-            // leak the sensor into storage that is being torn down, or register a sensor that can
-            // never be started. Dispose the rejected sensor so it does not leak, and return it
-            // inert rather than throwing (keeps the public AddXxx API non-throwing for late calls).
-            if (!_dataProcessor.CanRegisterSensors)
+            lock (_dataProcessor.LifecycleGate)
             {
-                Logger.Error($"Cannot register sensor '{path}' — collector is stopping or disposed. The sensor was not added.");
-                sensor.Dispose();
-                return sensor;
+                // Shutdown phase (Stopping) or terminal (Disposed): reject. Adding here would either
+                // leak the sensor into storage that is being torn down, or register a sensor that can
+                // never be started. Dispose the rejected sensor so it does not leak, and return it
+                // inert rather than throwing (keeps the public AddXxx API non-throwing for late calls).
+                if (!_dataProcessor.CanRegisterSensors)
+                {
+                    Logger.Error($"Cannot register sensor '{path}' - collector is stopping or disposed. The sensor was not added.");
+                    sensor.Dispose();
+                    return sensor;
+                }
+
+                // Operational phase (Starting/Running): add and start immediately. The lifecycle
+                // gate serializes this decision with Stop/Dispose, and StopAsync waits for tracked
+                // dynamic starts before stopping sensors.
+                if (_dataProcessor.CanStartNewSensors)
+                {
+                    var addedSensor = AddSensor(sensor);
+
+                    // If the sensor was deduplicated against an existing one, don't start the duplicate.
+                    if (ReferenceEquals(addedSensor, sensor))
+                        TrackDynamicStart(InitAndStart(addedSensor));
+
+                    return addedSensor;
+                }
+
+                // Configuration phase (Stopped): queue the sensor; it will be initialized and started
+                // by SensorsStorage.InitAsync/StartAsync when the collector next starts.
+                return AddSensor(sensor);
             }
-
-            // Operational phase (Starting/Running): add and start immediately.
-            if (_dataProcessor.CanStartNewSensors)
-            {
-                var addedSensor = AddSensor(sensor);
-
-                // If the sensor was deduplicated against an existing one, don't start the duplicate.
-                if (ReferenceEquals(addedSensor, sensor))
-                    _ = InitAndStart(addedSensor);
-
-                return addedSensor;
-            }
-
-            // Configuration phase (Stopped): queue the sensor; it will be initialized and started
-            // by SensorsStorage.InitAsync/StartAsync when the collector next starts.
-            return AddSensor(sensor);
         }
 
 
@@ -205,10 +222,25 @@ namespace HSMDataCollector.Core
         {
             if (!await sensor.InitAsync().ConfigureAwait(false))
                 Logger.Error($"Failed to init {sensor.SensorPath}");
-            else if (!await sensor.StartAsync().ConfigureAwait(false))
+            else if (_dataProcessor.CanStartNewSensors && !await sensor.StartAsync().ConfigureAwait(false))
                 Logger.Error($"Failed to start {sensor.SensorPath}");
 
             return sensor;
+        }
+
+        private void TrackDynamicStart(Task task)
+        {
+            lock (_dynamicStartTasksLock)
+                _dynamicStartTasks.Add(task);
+
+            task.ContinueWith(t =>
+            {
+                if (t.IsFaulted)
+                    Logger.Error($"Dynamic sensor start failed: {t.Exception}");
+
+                lock (_dynamicStartTasksLock)
+                    _dynamicStartTasks.Remove(t);
+            }, TaskScheduler.Default);
         }
 
         private ISensor AddSensor(ISensor sensor)

--- a/src/collector/HSMDataCollector/Core/SensorsStorage.cs
+++ b/src/collector/HSMDataCollector/Core/SensorsStorage.cs
@@ -16,8 +16,16 @@ using System.Threading;
 
 namespace HSMDataCollector.Core
 {
-    internal sealed class SensorsStorage : ConcurrentDictionary<string, ISensor>, IDisposable
+    /// <summary>
+    /// Owns the set of registered sensors and orchestrates their lifecycle. Uses a private
+    /// <see cref="ConcurrentDictionary{TKey, TValue}"/> for storage rather than inheriting from it,
+    /// so the public surface is limited to the operations the collector actually needs.
+    /// Sensor identity is the (full) sensor path.
+    /// </summary>
+    internal sealed class SensorsStorage : IDisposable
     {
+        private readonly ConcurrentDictionary<string, ISensor> _sensors = new ConcurrentDictionary<string, ISensor>();
+
         private readonly CollectorOptions _options;
 
         private readonly DataProcessor _dataProcessor;
@@ -30,6 +38,20 @@ namespace HSMDataCollector.Core
         public IUnixCollection Unix { get; }
 
         internal ICollectorLogger Logger { get; }
+
+        /// <summary>
+        /// Snapshot of currently-registered sensors. Safe to enumerate during concurrent
+        /// register/unregister; the underlying dictionary is concurrent.
+        /// </summary>
+        public IEnumerable<ISensor> Values => _sensors.Values;
+
+        /// <summary>
+        /// Approximate number of currently-registered sensors. Tracked via <see cref="Interlocked"/>
+        /// for O(1) reads. Exposed for diagnostics — the cardinality cap is enforced internally
+        /// using the increment result inside <see cref="AddSensor"/>, not via this property.
+        /// May briefly disagree with the underlying dictionary count during concurrent registration.
+        /// </summary>
+        public int Count => Volatile.Read(ref _sensorCount);
 
 
         internal SensorsStorage(CollectorOptions options, DataProcessor dataProcessor, ICollectorLogger logger)
@@ -47,26 +69,28 @@ namespace HSMDataCollector.Core
 
         public void Dispose()
         {
-            foreach (var sensor in Values)
+            foreach (var sensor in _sensors.Values)
             {
                 sensor.Dispose();
             }
         }
 
-        internal Task InitAsync() => Task.WhenAll(Values.Select(async s => await s.InitAsync().ConfigureAwait(false)));
+        internal Task InitAsync() => Task.WhenAll(_sensors.Values.Select(async s => await s.InitAsync().ConfigureAwait(false)));
 
-        internal Task StartAsync() => Task.WhenAll(Values.Select(async s => await s.StartAsync().ConfigureAwait(false)));
+        internal Task StartAsync() => Task.WhenAll(_sensors.Values.Select(async s => await s.StartAsync().ConfigureAwait(false)));
 
-        internal Task StopAsync() => Task.WhenAll(Values.Select(async s => await s.StopAsync().ConfigureAwait(false)));
+        internal Task StopAsync() => Task.WhenAll(_sensors.Values.Select(async s => await s.StopAsync().ConfigureAwait(false)));
 
-        public new bool TryRemove(string key, out ISensor value)
+        public bool TryRemove(string key, out ISensor value)
         {
-            if (!base.TryRemove(key, out value))
+            if (!_sensors.TryRemove(key, out value))
                 return false;
 
             Interlocked.Decrement(ref _sensorCount);
             return true;
         }
+
+        public bool TryGetValue(string key, out ISensor value) => _sensors.TryGetValue(key, out value);
 
 
         internal MonitoringRateSensor CreateRateSensor(string path, RateSensorOptions options)
@@ -145,7 +169,7 @@ namespace HSMDataCollector.Core
         {
             var path = sensor.SensorPath;
 
-            if (TryGetValue(path, out var oldSensor))
+            if (_sensors.TryGetValue(path, out var oldSensor))
                 return oldSensor;
 
             if (_dataProcessor.CanStartNewSensors)
@@ -173,7 +197,7 @@ namespace HSMDataCollector.Core
         {
             var path = sensor.SensorPath;
 
-            if (TryAdd(path, sensor))
+            if (_sensors.TryAdd(path, sensor))
             {
                 var count = Interlocked.Increment(ref _sensorCount);
                 if (count > _options.MaxSensors)
@@ -188,7 +212,7 @@ namespace HSMDataCollector.Core
                 return sensor;
             }
 
-            if (TryGetValue(path, out var existingSensor))
+            if (_sensors.TryGetValue(path, out var existingSensor))
             {
                 sensor.Dispose();
                 return existingSensor;

--- a/src/collector/HSMDataCollector/Core/SensorsStorage.cs
+++ b/src/collector/HSMDataCollector/Core/SensorsStorage.cs
@@ -218,7 +218,7 @@ namespace HSMDataCollector.Core
                 return existingSensor;
             }
 
-            throw new Exception($"Sensor with path {path} already exists");
+            throw new InvalidOperationException($"Sensor with path {path} already exists");
         }
 
         private T FillOptions<T, TDisplayUnit>(string path, SensorType type, T options)

--- a/src/collector/HSMDataCollector/DefaultSensors/BaseTemplates/FreeDiskSpacePredictionBase.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/BaseTemplates/FreeDiskSpacePredictionBase.cs
@@ -55,7 +55,7 @@ namespace HSMDataCollector.DefaultSensors
                     _currentChangeSpeed = 0.0;
                     _requestsCount = 0;
 
-                    _workTask = CollectorScheduler.Schedule(UpdateDiskSpeed, DateTime.UtcNow.Ceil(_calculateSpeedDelay) - DateTime.UtcNow, _calculateSpeedDelay, HandleException);
+                    _workTask = _dataProcessor.Scheduler.Schedule(UpdateDiskSpeed, DateTime.UtcNow.Ceil(_calculateSpeedDelay) - DateTime.UtcNow, _calculateSpeedDelay, HandleException);
                 }
             }
 

--- a/src/collector/HSMDataCollector/DefaultSensors/BaseTemplates/FreeDiskSpacePredictionBase.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/BaseTemplates/FreeDiskSpacePredictionBase.cs
@@ -27,7 +27,9 @@ namespace HSMDataCollector.DefaultSensors
         private long _requestsCount;
         private bool _isOffTime;
 
-        private ScheduledTask _workTask;
+        // Composed scheduling lifecycle for the disk-speed sampling loop (replaces a hand-rolled
+        // ScheduledTask + lock). The base MonitoringSensorBase owns its own send-loop handle.
+        private readonly ScheduledTaskHandle _workHandle;
 
         private bool IsCalibration => _requestsCount <= _calibrationRequests;
 
@@ -40,14 +42,18 @@ namespace HSMDataCollector.DefaultSensors
             _calculateSpeedDelay = TimeSpan.FromSeconds(DefaultSpaceCheckPeriodInSec);
             _calibrationRequests = options.CalibrationRequests;
             _diskInfo = diskInfo;
+
+            _workHandle = new ScheduledTaskHandle(_dataProcessor.Scheduler);
         }
 
 
         public override ValueTask<bool> StartAsync()
         {
+            // Guard the per-start state reset so a repeated StartAsync does not re-zero the running
+            // sampler. _locker still serializes the reset; the handle owns the schedule lifecycle.
             lock (_locker)
             {
-                if (_workTask == null)
+                if (!_workHandle.IsScheduled)
                 {
                     _lastSpeedCheckTime = DateTime.UtcNow;
                     _lastAvailableSpace = FreeSpace;
@@ -55,7 +61,7 @@ namespace HSMDataCollector.DefaultSensors
                     _currentChangeSpeed = 0.0;
                     _requestsCount = 0;
 
-                    _workTask = _dataProcessor.Scheduler.Schedule(UpdateDiskSpeed, DateTime.UtcNow.Ceil(_calculateSpeedDelay) - DateTime.UtcNow, _calculateSpeedDelay, HandleException);
+                    _workHandle.Start(UpdateDiskSpeed, DateTime.UtcNow.Ceil(_calculateSpeedDelay) - DateTime.UtcNow, _calculateSpeedDelay, HandleException);
                 }
             }
 
@@ -66,20 +72,8 @@ namespace HSMDataCollector.DefaultSensors
         {
             try
             {
-                ScheduledTask taskToWait = null;
-                lock (_locker)
-                {
-                    if (_workTask != null)
-                    {
-                        taskToWait = _workTask;
-                        _workTask = null;
-                    }
-                }
+                await _workHandle.StopAsync(waitForCurrentRun: true).ConfigureAwait(false);
 
-                if (taskToWait != null)
-                {
-                    await taskToWait.StopAsync(waitForCurrentRun: true).ConfigureAwait(false);
-                }
                 await base.StopAsync();
             }
             catch (OperationCanceledException) { }

--- a/src/collector/HSMDataCollector/DefaultSensors/IPerformanceCounter.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/IPerformanceCounter.cs
@@ -1,0 +1,34 @@
+using System;
+
+
+namespace HSMDataCollector.DefaultSensors
+{
+    /// <summary>
+    /// Abstraction over a single OS performance metric source. Isolates the Windows-only
+    /// <c>System.Diagnostics.PerformanceCounter</c> behind an interface so sensors do not depend on
+    /// the platform API directly. This makes the Windows sensors unit-testable on any OS (via a fake)
+    /// and leaves room for an alternative provider (native PDH, or a non-Windows source).
+    /// </summary>
+    internal interface IPerformanceCounter : IDisposable
+    {
+        /// <summary>Samples the current counter value.</summary>
+        double NextValue();
+    }
+
+
+    /// <summary>
+    /// Creates <see cref="IPerformanceCounter"/> instances. The default production implementation wraps
+    /// the real Windows performance-counter API; tests substitute a fake. Implementations must be
+    /// thread-safe for concurrent <see cref="Create"/> calls.
+    /// </summary>
+    internal interface IPerformanceCounterFactory
+    {
+        /// <summary>
+        /// Creates a counter for <paramref name="category"/>/<paramref name="counter"/>. When
+        /// <paramref name="instanceFilter"/> is non-empty, the factory resolves the first instance whose
+        /// name contains it and returns <c>null</c> if no such instance exists (the caller treats this as
+        /// "instance not found"). Other failures throw.
+        /// </summary>
+        IPerformanceCounter Create(string category, string counter, string instanceFilter = null);
+    }
+}

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Network/BaseSocketsSensor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Network/BaseSocketsSensor.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Threading.Tasks;
 using HSMDataCollector.Options;
 using HSMSensorDataObjects.SensorRequests;
@@ -12,11 +11,15 @@ namespace HSMDataCollector.DefaultSensors.Windows.Network
         private const string CategoryTcp4 = "TCPv4";
         private const string CategoryTcp6 = "TCPv6";
 
-        private PerformanceCounter _counterTCPv4;
-        private PerformanceCounter _counterTCPv6;
+        private IPerformanceCounter _counterTCPv4;
+        private IPerformanceCounter _counterTCPv6;
 
 
         protected abstract string CounterName { get; }
+
+        // Source of performance counters. Defaults to the real Windows API; overridden in tests with a
+        // fake. Internal-virtual so only same-assembly / friend-assembly (test) subclasses can substitute it.
+        internal virtual IPerformanceCounterFactory PerformanceCounterFactory => WindowsPerformanceCounterFactory.Instance;
 
 
         protected internal BaseSocketsSensor(MonitoringInstantSensorOptions options) : base(options) { }
@@ -26,8 +29,8 @@ namespace HSMDataCollector.DefaultSensors.Windows.Network
         {
             try
             {
-                _counterTCPv4 = new PerformanceCounter(CategoryTcp4, CounterName);
-                _counterTCPv6 = new PerformanceCounter(CategoryTcp6, CounterName);
+                _counterTCPv4 = PerformanceCounterFactory.Create(CategoryTcp4, CounterName);
+                _counterTCPv6 = PerformanceCounterFactory.Create(CategoryTcp6, CounterName);
             }
             catch (Exception ex)
             {

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Network/BaseSocketsSensor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Network/BaseSocketsSensor.cs
@@ -34,6 +34,11 @@ namespace HSMDataCollector.DefaultSensors.Windows.Network
             }
             catch (Exception ex)
             {
+                _counterTCPv4?.Dispose();
+                _counterTCPv4 = null;
+                _counterTCPv6?.Dispose();
+                _counterTCPv6 = null;
+
                 HandleException(new Exception($"Error initializing performance counter: {CategoryTcp4}/{CounterName}, {CategoryTcp6}/{CounterName}: {ex}"));
 
                 return new ValueTask<bool>(false);

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Service/WindowsServiceStatusSensor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Service/WindowsServiceStatusSensor.cs
@@ -37,7 +37,7 @@ namespace HSMDataCollector.DefaultSensors.Windows.Service
             {
                 if (_statusWatcher == null)
                 {
-                    _statusWatcher = CollectorScheduler.Schedule(CheckServiceStatus, _scanPeriod, _scanPeriod, HandleException);
+                    _statusWatcher = _dataProcessor.Scheduler.Schedule(CheckServiceStatus, _scanPeriod, _scanPeriod, HandleException);
                 }
             }
 

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/WindowsPerformanceCounterFactory.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/WindowsPerformanceCounterFactory.cs
@@ -1,0 +1,43 @@
+using System.Diagnostics;
+using System.Linq;
+
+
+namespace HSMDataCollector.DefaultSensors.Windows
+{
+    /// <summary>
+    /// Production <see cref="IPerformanceCounterFactory"/> that wraps the real Windows
+    /// <see cref="PerformanceCounter"/> / <see cref="PerformanceCounterCategory"/> APIs. All direct use
+    /// of those Windows-only types is confined to this class, so the sensor classes stay platform-neutral.
+    /// </summary>
+    internal sealed class WindowsPerformanceCounterFactory : IPerformanceCounterFactory
+    {
+        internal static readonly WindowsPerformanceCounterFactory Instance = new WindowsPerformanceCounterFactory();
+
+        public IPerformanceCounter Create(string category, string counter, string instanceFilter = null)
+        {
+            if (string.IsNullOrEmpty(instanceFilter))
+                return new WindowsPerformanceCounter(new PerformanceCounter(category, counter));
+
+            var resolvedInstance = new PerformanceCounterCategory(category)
+                .GetInstanceNames()
+                .FirstOrDefault(name => name.Contains(instanceFilter));
+
+            if (resolvedInstance == null)
+                return null;
+
+            return new WindowsPerformanceCounter(new PerformanceCounter(category, counter, resolvedInstance));
+        }
+
+
+        private sealed class WindowsPerformanceCounter : IPerformanceCounter
+        {
+            private readonly PerformanceCounter _counter;
+
+            internal WindowsPerformanceCounter(PerformanceCounter counter) => _counter = counter;
+
+            public double NextValue() => _counter.NextValue();
+
+            public void Dispose() => _counter.Dispose();
+        }
+    }
+}

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/WindowsSensorBase.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/WindowsSensorBase.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading.Tasks;
 using HSMDataCollector.Options;
 
@@ -11,7 +9,7 @@ namespace HSMDataCollector.DefaultSensors.Windows
     {
         protected const string TotalInstance = "_Total";
 
-        private PerformanceCounter _performanceCounter;
+        private IPerformanceCounter _performanceCounter;
 
 
         protected abstract string CategoryName { get; }
@@ -19,6 +17,11 @@ namespace HSMDataCollector.DefaultSensors.Windows
         protected abstract string CounterName { get; }
 
         protected virtual string InstanceName { get; }
+
+        // Source of performance counters. Defaults to the real Windows API; overridden in tests with a
+        // fake so these sensors can be exercised on any OS. Internal-virtual so only same-assembly /
+        // friend-assembly (test) subclasses can substitute it.
+        internal virtual IPerformanceCounterFactory PerformanceCounterFactory => WindowsPerformanceCounterFactory.Instance;
 
 
         internal WindowsSensorBase(BarSensorOptions options) : base(options) { }
@@ -28,21 +31,13 @@ namespace HSMDataCollector.DefaultSensors.Windows
         {
             try
             {
-                if (string.IsNullOrEmpty(InstanceName))
-                    _performanceCounter = new PerformanceCounter(CategoryName, CounterName);
-                else
+                _performanceCounter = PerformanceCounterFactory.Create(CategoryName, CounterName, InstanceName);
+
+                if (_performanceCounter == null)
                 {
-                    var category = new PerformanceCounterCategory(CategoryName);
-                    var instantName = category.GetInstanceNames().FirstOrDefault(u => u.Contains(InstanceName));
+                    HandleException(new ArgumentNullException($"Performance counter: {CategoryName}/{CounterName} instance {InstanceName} not found"));
 
-                    if (instantName == null)
-                    {
-                        HandleException(new ArgumentNullException($"Performance counter: {CategoryName}/{CounterName} instance {InstanceName} not found"));
-
-                        return new ValueTask<bool>(false);
-                    }
-
-                    _performanceCounter = new PerformanceCounter(CategoryName, CounterName, instantName);
+                    return new ValueTask<bool>(false);
                 }
             }
             catch (Exception ex)

--- a/src/collector/HSMDataCollector/Exceptions/MessageDeduplicator.cs
+++ b/src/collector/HSMDataCollector/Exceptions/MessageDeduplicator.cs
@@ -13,10 +13,25 @@ namespace HSMDataCollector.Exceptions
         private readonly TimeSpan _deduplicationWindow;
         private readonly int _maxMessages;
         private readonly Action<string> _action;
+        private readonly ICollectorScheduler _ownedScheduler;
 
         private readonly ScheduledTask _task;
 
+        /// <summary>
+        /// Compatibility constructor that creates and owns its own scheduler instance.
+        /// Prefer the internal overload that accepts a shared <see cref="ICollectorScheduler"/>.
+        /// </summary>
         public MessageDeduplicator(Action<string> action, TimeSpan window, int maxMessages)
+            : this(action, window, maxMessages, scheduler: null, ownsScheduler: true)
+        {
+        }
+
+        internal MessageDeduplicator(ICollectorScheduler scheduler, Action<string> action, TimeSpan window, int maxMessages)
+            : this(action, window, maxMessages, scheduler ?? throw new ArgumentNullException(nameof(scheduler)), ownsScheduler: false)
+        {
+        }
+
+        private MessageDeduplicator(Action<string> action, TimeSpan window, int maxMessages, ICollectorScheduler scheduler, bool ownsScheduler)
         {
             if (maxMessages <= 0)
                 throw new ArgumentOutOfRangeException(nameof(maxMessages), "Max messages must be greater than zero.");
@@ -26,11 +41,15 @@ namespace HSMDataCollector.Exceptions
             _deduplicationWindow = window;
             _maxMessages = maxMessages;
 
+            if (ownsScheduler)
+                _ownedScheduler = scheduler ?? new CollectorScheduler();
+            var effectiveScheduler = scheduler ?? _ownedScheduler;
+
             if (window != TimeSpan.Zero)
             {
                 var now = DateTime.UtcNow;
 
-                _task = CollectorScheduler.Schedule(Cleanup, now.Ceil(window) - now, window, ex => _action?.Invoke(ex.ToString()));
+                _task = effectiveScheduler.Schedule(Cleanup, now.Ceil(window) - now, window, ex => _action?.Invoke(ex.ToString()));
             }
         }
 
@@ -83,6 +102,7 @@ namespace HSMDataCollector.Exceptions
         public void Dispose()
         {
             _task?.Dispose();
+            _ownedScheduler?.Dispose();
         }
 
         private void Cleanup()

--- a/src/collector/HSMDataCollector/Exceptions/MessageDeduplicator.cs
+++ b/src/collector/HSMDataCollector/Exceptions/MessageDeduplicator.cs
@@ -18,8 +18,9 @@ namespace HSMDataCollector.Exceptions
         private readonly ScheduledTask _task;
 
         /// <summary>
-        /// Compatibility constructor that creates and owns its own scheduler instance.
-        /// Prefer the internal overload that accepts a shared <see cref="ICollectorScheduler"/>.
+        /// Compatibility constructor. For non-zero windows this instance creates and owns a
+        /// dedicated scheduler worker; zero-window instances do not schedule cleanup work.
+        /// Prefer the internal overload when a shared <see cref="ICollectorScheduler"/> is available.
         /// </summary>
         public MessageDeduplicator(Action<string> action, TimeSpan window, int maxMessages)
             : this(action, window, maxMessages, scheduler: null, ownsScheduler: true)

--- a/src/collector/HSMDataCollector/Exceptions/MessageDeduplicator.cs
+++ b/src/collector/HSMDataCollector/Exceptions/MessageDeduplicator.cs
@@ -41,16 +41,19 @@ namespace HSMDataCollector.Exceptions
             _deduplicationWindow = window;
             _maxMessages = maxMessages;
 
+            // No periodic cleanup runs when window is Zero (AddMessage short-circuits to direct
+            // invocation). Avoid spinning up a worker scheduler in that case — it would just idle
+            // until Dispose, holding a thread for nothing.
+            if (window == TimeSpan.Zero)
+                return;
+
             if (ownsScheduler)
                 _ownedScheduler = scheduler ?? new CollectorScheduler();
+
             var effectiveScheduler = scheduler ?? _ownedScheduler;
 
-            if (window != TimeSpan.Zero)
-            {
-                var now = DateTime.UtcNow;
-
-                _task = effectiveScheduler.Schedule(Cleanup, now.Ceil(window) - now, window, ex => _action?.Invoke(ex.ToString()));
-            }
+            var now = DateTime.UtcNow;
+            _task = effectiveScheduler.Schedule(Cleanup, now.Ceil(window) - now, window, ex => _action?.Invoke(ex.ToString()));
         }
 
 

--- a/src/collector/HSMDataCollector/Sensors/BarSensors/BarMonitoringSensorBase.cs
+++ b/src/collector/HSMDataCollector/Sensors/BarSensors/BarMonitoringSensorBase.cs
@@ -51,7 +51,7 @@ namespace HSMDataCollector.DefaultSensors
             {
                 if (_collectTask == null)
                 {
-                    _collectTask = CollectorScheduler.Schedule(CollectBar, _collectBarPeriod, _collectBarPeriod, HandleException);
+                    _collectTask = _dataProcessor.Scheduler.Schedule(CollectBar, _collectBarPeriod, _collectBarPeriod, HandleException);
                 }
             }
 

--- a/src/collector/HSMDataCollector/Sensors/BarSensors/BarMonitoringSensorBase.cs
+++ b/src/collector/HSMDataCollector/Sensors/BarSensors/BarMonitoringSensorBase.cs
@@ -19,9 +19,10 @@ namespace HSMDataCollector.DefaultSensors
         private readonly TimeSpan _barPeriod;
         private readonly int _precision;
 
-        private readonly object _locker = new object();
+        // Composed scheduling lifecycle for the bar-collect loop (the send loop is owned by the
+        // MonitoringSensorBase base via its own handle). Replaces a hand-rolled ScheduledTask + lock.
+        private readonly ScheduledTaskHandle _collectHandle;
 
-        private ScheduledTask _collectTask;
         protected BarType _internalBar;
 
         public override BarType Current => (BarType)_internalBar.Copy().Complete();
@@ -41,42 +42,24 @@ namespace HSMDataCollector.DefaultSensors
             _barPeriod = options.BarPeriod;
             _precision = options.Precision;
 
+            _collectHandle = new ScheduledTaskHandle(_dataProcessor.Scheduler);
+
             BuildNewBar();
         }
 
 
         public override ValueTask<bool> InitAsync()
         {
-            lock (_locker)
-            {
-                if (_collectTask == null)
-                {
-                    _collectTask = _dataProcessor.Scheduler.Schedule(CollectBar, _collectBarPeriod, _collectBarPeriod, HandleException);
-                }
-            }
+            _collectHandle.Start(CollectBar, _collectBarPeriod, _collectBarPeriod, HandleException);
 
             return base.InitAsync();
         }
 
         public override async ValueTask StopAsync()
         {
-            ScheduledTask taskToWait = null;
-
-            lock (_locker)
-            {
-                if (_collectTask != null)
-                {
-                    taskToWait = _collectTask;
-                    _collectTask = null;
-                }
-            }
-
             try
             {
-                if (taskToWait != null)
-                {
-                    await taskToWait.StopAsync(waitForCurrentRun: true).ConfigureAwait(false);
-                }
+                await _collectHandle.StopAsync(waitForCurrentRun: true).ConfigureAwait(false);
 
                 await base.StopAsync().ConfigureAwait(false);
             }

--- a/src/collector/HSMDataCollector/Sensors/MonitoringSensorBaseT.cs
+++ b/src/collector/HSMDataCollector/Sensors/MonitoringSensorBaseT.cs
@@ -13,9 +13,10 @@ namespace HSMDataCollector.DefaultSensors
     public abstract class MonitoringSensorBase<T, TDisplayUnit> : SensorBase<T, TDisplayUnit> where TDisplayUnit : struct, Enum
     {
         private readonly IMonitoringOptions _options;
-        private ScheduledTask _sendTask;
 
-        private readonly object _lock = new object();
+        // Composed scheduling lifecycle for the periodic send loop (replaces a hand-rolled
+        // ScheduledTask field + lock). The bar sensor composes a second handle for its collect loop.
+        private readonly ScheduledTaskHandle _sendHandle;
 
         protected virtual TimeSpan TimerDueTime => TimeSpan.Zero;
 
@@ -30,6 +31,8 @@ namespace HSMDataCollector.DefaultSensors
 
             if (_options.PostDataPeriod <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(_options.PostDataPeriod), "Post data period must be greater than zero.");
+
+            _sendHandle = new ScheduledTaskHandle(_dataProcessor.Scheduler);
         }
 
         public override ValueTask<bool> InitAsync()
@@ -93,35 +96,9 @@ namespace HSMDataCollector.DefaultSensors
             }
         }
 
-        private async ValueTask StopInternalAsync(bool waitForCurrentRun)
-        {
-            ScheduledTask taskToAwait = null;
+        private ValueTask StopInternalAsync(bool waitForCurrentRun) => _sendHandle.StopAsync(waitForCurrentRun);
 
-            lock (_lock)
-            {
-                if (_sendTask != null)
-                {
-                    taskToAwait = _sendTask;
-                    _sendTask = null;
-                }
-            }
-
-            if (taskToAwait != null)
-            {
-                await taskToAwait.StopAsync(waitForCurrentRun).ConfigureAwait(false);
-            }
-        }
-
-        private void StartSendTask()
-        {
-            lock (_lock)
-            {
-                if (_sendTask == null)
-                {
-                    _sendTask = _dataProcessor.Scheduler.Schedule(SendValueAction, TimerDueTime, PostTimePeriod, HandleException);
-                }
-            }
-        }
+        private void StartSendTask() => _sendHandle.Start(SendValueAction, TimerDueTime, PostTimePeriod, HandleException);
 
         private SensorValueBase BuildSensorValue()
         {

--- a/src/collector/HSMDataCollector/Sensors/MonitoringSensorBaseT.cs
+++ b/src/collector/HSMDataCollector/Sensors/MonitoringSensorBaseT.cs
@@ -118,7 +118,7 @@ namespace HSMDataCollector.DefaultSensors
             {
                 if (_sendTask == null)
                 {
-                    _sendTask = CollectorScheduler.Schedule(SendValueAction, TimerDueTime, PostTimePeriod, HandleException);
+                    _sendTask = _dataProcessor.Scheduler.Schedule(SendValueAction, TimerDueTime, PostTimePeriod, HandleException);
                 }
             }
         }

--- a/src/collector/HSMDataCollector/Threading/CollectorScheduler.cs
+++ b/src/collector/HSMDataCollector/Threading/CollectorScheduler.cs
@@ -25,7 +25,7 @@ namespace HSMDataCollector.Threading
 
         internal LinkedListNode<ScheduledTask> BucketNode { get; set; }
 
-        internal bool IsDisposed => _disposed;
+        internal bool IsDisposed => Volatile.Read(ref _disposed);
 
         internal bool IsRunning => Volatile.Read(ref _isRunning) == 1;
 
@@ -81,7 +81,7 @@ namespace HSMDataCollector.Threading
             Task taskToWait;
             lock (_lock)
             {
-                _disposed = true;
+                Volatile.Write(ref _disposed, true);
                 _scheduler.Remove(this);
                 taskToWait = _currentRun;
             }
@@ -94,7 +94,7 @@ namespace HSMDataCollector.Threading
         {
             lock (_lock)
             {
-                _disposed = true;
+                Volatile.Write(ref _disposed, true);
                 _scheduler.Remove(this);
             }
         }
@@ -113,10 +113,16 @@ namespace HSMDataCollector.Threading
             {
                 Interlocked.Exchange(ref _isRunning, 0);
 
+                // One-shot task self-disposes once its single run completes. Write under the lock so
+                // concurrent IsDisposed readers (e.g. CollectorScheduler.Loop's pre-dispatch check)
+                // observe a consistent value with every other writer of _disposed.
                 if (_period == Timeout.InfiniteTimeSpan)
                 {
-                    _disposed = true;
-                    _scheduler.Remove(this);
+                    lock (_lock)
+                    {
+                        Volatile.Write(ref _disposed, true);
+                        _scheduler.Remove(this);
+                    }
                 }
             }
         }
@@ -186,7 +192,16 @@ namespace HSMDataCollector.Threading
             lock (_lock)
                 AddTask(task);
 
-            _signal.Set();
+            // Mirrors Remove(): if Dispose() races past the _disposed guard above and
+            // disposes _signal before this Set runs, swallow the ObjectDisposedException —
+            // the worker is already shut down so there is nothing to wake.
+            try
+            {
+                _signal.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+            }
 
             return task;
         }
@@ -248,13 +263,15 @@ namespace HSMDataCollector.Threading
                 // Worker exceptions are surfaced via per-task onError; ignore here.
             }
 
-            _cancellation.Dispose();
-
-            // Only dispose _signal if the worker has actually exited. Otherwise the worker may still
-            // be inside _signal.Wait, and disposing here would throw ObjectDisposedException out of it.
-            // The signal is GC-collectable once unreachable.
+            // Only dispose the cancellation source and the signal if the worker has actually exited.
+            // If we time out and the worker later wakes from _signal.Wait, it will read
+            // _cancellation.Token (which throws ObjectDisposedException on a disposed CTS) and the
+            // worker task would fault unobserved. Both objects are GC-collectable when unreachable.
             if (workerExited)
+            {
+                _cancellation.Dispose();
                 _signal.Dispose();
+            }
         }
 
         internal static long GetTickCountMilliseconds() =>

--- a/src/collector/HSMDataCollector/Threading/CollectorScheduler.cs
+++ b/src/collector/HSMDataCollector/Threading/CollectorScheduler.cs
@@ -12,6 +12,7 @@ namespace HSMDataCollector.Threading
         private readonly Action<Exception> _onError;
         private readonly TimeSpan _period;
         private readonly object _lock = new object();
+        private readonly ICollectorScheduler _scheduler;
         private static readonly TimeSpan CurrentRunStopTimeout = TimeSpan.FromSeconds(1);
 
         private Task _currentRun = Task.CompletedTask;
@@ -37,8 +38,9 @@ namespace HSMDataCollector.Threading
             }
         }
 
-        internal ScheduledTask(Func<Task> action, TimeSpan delay, TimeSpan period, Action<Exception> onError)
+        internal ScheduledTask(ICollectorScheduler scheduler, Func<Task> action, TimeSpan delay, TimeSpan period, Action<Exception> onError)
         {
+            _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
             _action = action ?? throw new ArgumentNullException(nameof(action));
             _period = period;
             _onError = onError;
@@ -80,7 +82,7 @@ namespace HSMDataCollector.Threading
             lock (_lock)
             {
                 _disposed = true;
-                CollectorScheduler.Remove(this);
+                _scheduler.Remove(this);
                 taskToWait = _currentRun;
             }
 
@@ -93,7 +95,7 @@ namespace HSMDataCollector.Threading
             lock (_lock)
             {
                 _disposed = true;
-                CollectorScheduler.Remove(this);
+                _scheduler.Remove(this);
             }
         }
 
@@ -114,7 +116,7 @@ namespace HSMDataCollector.Threading
                 if (_period == Timeout.InfiniteTimeSpan)
                 {
                     _disposed = true;
-                    CollectorScheduler.Remove(this);
+                    _scheduler.Remove(this);
                 }
             }
         }
@@ -134,16 +136,30 @@ namespace HSMDataCollector.Threading
         }
     }
 
-    internal static class CollectorScheduler
+    /// <summary>
+    /// Bucketed timer-wheel scheduler. Owns a single worker task that dispatches due actions onto
+    /// the threadpool. Construct one per <see cref="Core.DataCollector"/>; sharing across collectors
+    /// is allowed but not required.
+    /// </summary>
+    internal sealed class CollectorScheduler : ICollectorScheduler
     {
-        private static readonly object _lock = new object();
-        private static readonly SortedDictionary<long, LinkedList<ScheduledTask>> _tasks = new SortedDictionary<long, LinkedList<ScheduledTask>>();
-        private static readonly ManualResetEventSlim _signal = new ManualResetEventSlim(false);
-        private static readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
-        private static readonly Task _worker = Task.Run(Loop);
+        private readonly object _lock = new object();
+        private readonly SortedDictionary<long, LinkedList<ScheduledTask>> _tasks = new SortedDictionary<long, LinkedList<ScheduledTask>>();
+        private readonly ManualResetEventSlim _signal = new ManualResetEventSlim(false);
+        private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
+        private readonly Task _worker;
+        private int _disposed;
 
-        internal static ScheduledTask Schedule(Action action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null)
+        public CollectorScheduler()
         {
+            _worker = Task.Run(Loop);
+        }
+
+        public ScheduledTask Schedule(Action action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null)
+        {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
             return Schedule(() =>
             {
                 action();
@@ -151,15 +167,21 @@ namespace HSMDataCollector.Threading
             }, delay, period, onError);
         }
 
-        internal static ScheduledTask Schedule(Func<Task> action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null)
+        public ScheduledTask Schedule(Func<Task> action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null)
         {
+            if (action == null)
+                throw new ArgumentNullException(nameof(action));
+
             if (period != Timeout.InfiniteTimeSpan && period <= TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(period), "Period must be greater than zero.");
 
             if (delay < TimeSpan.Zero)
                 throw new ArgumentOutOfRangeException(nameof(delay), "Delay cannot be negative.");
 
-            var task = new ScheduledTask(action, delay, period, onError);
+            if (Volatile.Read(ref _disposed) == 1)
+                throw new ObjectDisposedException(nameof(CollectorScheduler));
+
+            var task = new ScheduledTask(this, action, delay, period, onError);
 
             lock (_lock)
                 AddTask(task);
@@ -169,18 +191,76 @@ namespace HSMDataCollector.Threading
             return task;
         }
 
-        internal static void Remove(ScheduledTask task)
+        public void Remove(ScheduledTask task)
         {
+            if (task == null)
+                return;
+
+            // A ScheduledTask can outlive its scheduler if cleanup happens out of order
+            // (e.g. a sensor's StopAsync running after the scheduler is disposed). Guard
+            // both the dictionary mutation and the signal so we never touch disposed state.
+            if (Volatile.Read(ref _disposed) == 1)
+                return;
+
             lock (_lock)
                 RemoveTask(task);
 
-            _signal.Set();
+            try
+            {
+                _signal.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Lost the race with Dispose; nothing to wake.
+            }
+        }
+
+        public void Dispose()
+        {
+            if (Interlocked.Exchange(ref _disposed, 1) == 1)
+                return;
+
+            try
+            {
+                _cancellation.Cancel();
+            }
+            catch
+            {
+                // Cancellation token source may have been disposed concurrently; ignore.
+            }
+
+            try
+            {
+                _signal.Set();
+            }
+            catch (ObjectDisposedException)
+            {
+                // Already disposed by a concurrent path; ignore.
+            }
+
+            var workerExited = false;
+            try
+            {
+                workerExited = _worker.Wait(TimeSpan.FromSeconds(5));
+            }
+            catch
+            {
+                // Worker exceptions are surfaced via per-task onError; ignore here.
+            }
+
+            _cancellation.Dispose();
+
+            // Only dispose _signal if the worker has actually exited. Otherwise the worker may still
+            // be inside _signal.Wait, and disposing here would throw ObjectDisposedException out of it.
+            // The signal is GC-collectable once unreachable.
+            if (workerExited)
+                _signal.Dispose();
         }
 
         internal static long GetTickCountMilliseconds() =>
             (long)(Stopwatch.GetTimestamp() * (1000.0 / Stopwatch.Frequency));
 
-        private static void Loop()
+        private void Loop()
         {
             while (!_cancellation.IsCancellationRequested)
             {
@@ -269,7 +349,7 @@ namespace HSMDataCollector.Threading
             }
         }
 
-        private static void AddTask(ScheduledTask task)
+        private void AddTask(ScheduledTask task)
         {
             var key = task.NextRunMilliseconds;
             if (!_tasks.TryGetValue(key, out var bucket))
@@ -282,7 +362,7 @@ namespace HSMDataCollector.Threading
             task.BucketNode = bucket.AddLast(task);
         }
 
-        private static void RemoveTask(ScheduledTask task)
+        private void RemoveTask(ScheduledTask task)
         {
             var node = task.BucketNode;
             if (node == null)
@@ -300,7 +380,7 @@ namespace HSMDataCollector.Threading
             task.BucketKey = long.MinValue;
         }
 
-        private static void GetFirstBucket(out long key, out LinkedList<ScheduledTask> bucket)
+        private void GetFirstBucket(out long key, out LinkedList<ScheduledTask> bucket)
         {
             using (var enumerator = _tasks.GetEnumerator())
             {

--- a/src/collector/HSMDataCollector/Threading/CollectorScheduler.cs
+++ b/src/collector/HSMDataCollector/Threading/CollectorScheduler.cs
@@ -154,6 +154,7 @@ namespace HSMDataCollector.Threading
         private readonly ManualResetEventSlim _signal = new ManualResetEventSlim(false);
         private readonly CancellationTokenSource _cancellation = new CancellationTokenSource();
         private readonly Task _worker;
+        private static readonly TimeSpan WorkerStopTimeout = TimeSpan.FromSeconds(5);
         private int _disposed;
 
         public CollectorScheduler()
@@ -190,7 +191,12 @@ namespace HSMDataCollector.Threading
             var task = new ScheduledTask(this, action, delay, period, onError);
 
             lock (_lock)
+            {
+                if (Volatile.Read(ref _disposed) == 1)
+                    throw new ObjectDisposedException(nameof(CollectorScheduler));
+
                 AddTask(task);
+            }
 
             // Mirrors Remove(): if Dispose() races past the _disposed guard above and
             // disposes _signal before this Set runs, swallow the ObjectDisposedException —
@@ -211,9 +217,9 @@ namespace HSMDataCollector.Threading
             if (task == null)
                 return;
 
-            // A ScheduledTask can outlive its scheduler if cleanup happens out of order
-            // (e.g. a sensor's StopAsync running after the scheduler is disposed). Guard
-            // both the dictionary mutation and the signal so we never touch disposed state.
+            // A ScheduledTask can outlive its scheduler's Dispose if cleanup happens out
+            // of order (e.g. a sensor's StopAsync running after the scheduler is disposed).
+            // Guard both the dictionary mutation and the signal so we never touch disposed state.
             if (Volatile.Read(ref _disposed) == 1)
                 return;
 
@@ -256,11 +262,18 @@ namespace HSMDataCollector.Threading
             var workerExited = false;
             try
             {
-                workerExited = _worker.Wait(TimeSpan.FromSeconds(5));
+                workerExited = _worker.Wait(WorkerStopTimeout);
             }
             catch
             {
                 // Worker exceptions are surfaced via per-task onError; ignore here.
+            }
+
+            if (!workerExited)
+            {
+                Trace.TraceError(
+                    $"{nameof(CollectorScheduler)} worker did not stop within {WorkerStopTimeout}. " +
+                    "Scheduler handles were left undisposed to avoid faulting the worker task.");
             }
 
             // Only dispose the cancellation source and the signal if the worker has actually exited.

--- a/src/collector/HSMDataCollector/Threading/ICollectorScheduler.cs
+++ b/src/collector/HSMDataCollector/Threading/ICollectorScheduler.cs
@@ -11,10 +11,16 @@ namespace HSMDataCollector.Threading
     /// </summary>
     internal interface ICollectorScheduler : IDisposable
     {
+        /// <exception cref="ObjectDisposedException">The scheduler has already been disposed.</exception>
         ScheduledTask Schedule(Action action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null);
 
+        /// <exception cref="ObjectDisposedException">The scheduler has already been disposed.</exception>
         ScheduledTask Schedule(Func<Task> action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null);
 
+        /// <summary>
+        /// Removes a scheduled task if it is still queued. Implementations should no-op when the
+        /// task is null, already removed, or the scheduler has already been disposed.
+        /// </summary>
         void Remove(ScheduledTask task);
     }
 }

--- a/src/collector/HSMDataCollector/Threading/ICollectorScheduler.cs
+++ b/src/collector/HSMDataCollector/Threading/ICollectorScheduler.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+
+namespace HSMDataCollector.Threading
+{
+    /// <summary>
+    /// Schedules periodic and one-shot actions on a shared background worker. Implementations
+    /// must be thread-safe. Disposing the scheduler cancels its worker loop and prevents new
+    /// scheduling; in-flight task callbacks may still finish on their threadpool threads.
+    /// </summary>
+    internal interface ICollectorScheduler : IDisposable
+    {
+        ScheduledTask Schedule(Action action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null);
+
+        ScheduledTask Schedule(Func<Task> action, TimeSpan delay, TimeSpan period, Action<Exception> onError = null);
+
+        void Remove(ScheduledTask task);
+    }
+}

--- a/src/collector/HSMDataCollector/Threading/ScheduledTaskHandle.cs
+++ b/src/collector/HSMDataCollector/Threading/ScheduledTaskHandle.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading.Tasks;
+
+
+namespace HSMDataCollector.Threading
+{
+    /// <summary>
+    /// Composable lifecycle wrapper around a single periodic <see cref="ScheduledTask"/>. Encapsulates
+    /// the "schedule one action, start/stop/restart it, exactly once" boilerplate that monitoring and
+    /// bar sensors previously hand-rolled with their own field + lock. Sensors now <i>compose</i> one of
+    /// these per periodic action (send loop, bar-collect loop) instead of inheriting the timer plumbing.
+    ///
+    /// All members are thread-safe. Start and StopAsync are idempotent.
+    /// </summary>
+    internal sealed class ScheduledTaskHandle
+    {
+        private readonly ICollectorScheduler _scheduler;
+        private readonly object _lock = new object();
+
+        private ScheduledTask _task;
+
+        internal ScheduledTaskHandle(ICollectorScheduler scheduler)
+        {
+            _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
+        }
+
+        internal bool IsScheduled
+        {
+            get
+            {
+                lock (_lock)
+                    return _task != null;
+            }
+        }
+
+        /// <summary>
+        /// Schedules <paramref name="action"/> if it is not already scheduled. Idempotent: a second
+        /// call while running is a no-op (the existing schedule is kept).
+        /// </summary>
+        internal void Start(Action action, TimeSpan delay, TimeSpan period, Action<Exception> onError)
+        {
+            lock (_lock)
+            {
+                if (_task == null)
+                    _task = _scheduler.Schedule(action, delay, period, onError);
+            }
+        }
+
+        /// <summary>
+        /// Stops the scheduled action if running. Idempotent: a no-op when not scheduled.
+        /// </summary>
+        /// <param name="waitForCurrentRun">When true, awaits a bounded completion of an in-flight run.</param>
+        internal async ValueTask StopAsync(bool waitForCurrentRun = true)
+        {
+            ScheduledTask toStop;
+            lock (_lock)
+            {
+                toStop = _task;
+                _task = null;
+            }
+
+            if (toStop != null)
+                await toStop.StopAsync(waitForCurrentRun).ConfigureAwait(false);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Portability/cross-OS refactoring batch for HSMDataCollector. All changes are non-breaking to consumers (legacy API preserved); two source-only additions to `IDataCollector` are noted below.

## Epics included

- **#1055** — `CollectorScheduler` static → per-collector instance behind `ICollectorScheduler`; injected through `DataProcessor`; used by all sensor call sites and `MessageDeduplicator`.
- **#1056 part 1** — `SensorsStorage` composition (private `ConcurrentDictionary`) instead of inheriting it.
- **#1056 part 2** — sensor scheduling extracted into a composed `ScheduledTaskHandle`; `MonitoringSensorBase` / `BarMonitoringSensorBase` / `FreeDiskSpacePredictionBase` compose it instead of hand-rolling timer plumbing. Public API and class hierarchy unchanged.
- **#1057** — `ILifecycleListener` observer interface (portable equivalent of the lifecycle events) + fluent sensor builders (`InstantSensor<T>`/`BarSensor<T>`/`RateSensor` extension-method facade over the existing options-based factories).
- **#1058** — formalized two-phase sensor registration contract (`CanRegisterSensors`): Stopped → queue, Starting/Running → start now, Stopping/Disposed → reject. New `IsAcceptingRegistrations`. Also fixed a latent double-start on path collision.
- **#1059 (part)** — `PerformanceCounter` isolated behind `IPerformanceCounterFactory`; the Windows-only API now lives only in `WindowsPerformanceCounterFactory`. Windows sensors are now unit-testable on any OS via a fake factory.

Plus the in-flight review fixes folded in along the way (lifecycle event-ordering / dispose-race / Start-Stop-race / reentrancy hardening from PR #1060 follow-ups).

## Release notes (source-only, not binary-breaking)
- `IDataCollector` gains `IsAcceptingRegistrations` and `AddLifecycleListener(...)` (only in-repo implementer is `DataCollector`).
- `CollectorStatus` gains a terminal `Disposed` value; `Status` returns it after `Dispose()`.
- Registering a sensor during Stopping/Disposed is now rejected (logged) instead of silently added.

## Follow-ups (separate issues)
- **#1065** — migrate Linux default sensors from shelling out to `top`/`free` to direct `/proc` reads behind the same metric-source seam.

## Tests
150 collector unit tests pass on net48 (9 soak/platform-gated skipped). Each epic was reviewed before commit.