### PR TITLE
ci: skip review and PR builds on draft pull requests

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,10 +2,15 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # ready_for_review is required so the review runs when a draft is marked ready
+    # (marking ready does not emit a synchronize event).
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   claude-review:
+    # Skip review while the PR is a draft. This workflow only triggers on pull_request,
+    # so the draft flag is always present.
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/collector-integration-tests.yml
+++ b/.github/workflows/collector-integration-tests.yml
@@ -8,6 +8,9 @@ on:
       - 'src/api/**'
       - 'src/collector/HSMDataCollector.IntegrationTests/**'
   pull_request:
+    # ready_for_review is required so tests run when a draft is marked ready
+    # (marking ready does not emit a synchronize event).
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - 'src/collector/**'
       - 'src/api/**'
@@ -18,6 +21,9 @@ on:
 
 jobs:
   integration-tests:
+    # Skip on draft PRs only. Non-PR events (push/schedule/workflow_dispatch) have no
+    # pull_request payload, so they must still run — hence the event_name guard.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/hsm_cpp_wrapper_build.yml
+++ b/.github/workflows/hsm_cpp_wrapper_build.yml
@@ -2,16 +2,22 @@ name: hsm-wrapper-build
 
 on:
   push:
-    branches: 
+    branches:
       - hsm-cpp-wrapper
   pull_request:
-    branches: 
+    # ready_for_review is required so the build runs when a draft is marked ready
+    # (marking ready does not emit a synchronize event).
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
       - hsm-cpp-wrapper
 
   workflow_dispatch:
 
 jobs:
   build:
+    # Skip on draft PRs only. Non-PR events (push/workflow_dispatch) have no
+    # pull_request payload, so they must still run — hence the event_name guard.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
 
     runs-on: windows-latest
 


### PR DESCRIPTION
## Summary

Draft PRs were triggering `claude-review`, the collector integration tests, and the C++ wrapper build on every push — the `pull_request` `synchronize` event fires regardless of draft status.

This gates all three `pull_request`-triggered workflows on non-draft state and adds `ready_for_review` to their trigger types.

## Changes

- **claude-review.yml** — `if: github.event.pull_request.draft == false` (pull_request-only workflow, flag always present).
- **collector-integration-tests.yml** & **hsm_cpp_wrapper_build.yml** — also run on push/schedule/workflow_dispatch (no PR payload), so they use `github.event_name != 'pull_request' || github.event.pull_request.draft == false` to keep non-PR runs working.
- All three: added `ready_for_review` to `types`, so a PR whose commits were all pushed while draft still triggers when marked ready (marking ready doesn't emit `synchronize`).

## Behavior

| Event | draft | Runs? |
|---|---|---|
| Push to draft PR (`synchronize`) | true | ⏭️ skipped |
| PR opened non-draft (`opened`) | false | ✅ |
| Draft → Ready (`ready_for_review`) | false | ✅ |
| Push to normal PR (`synchronize`) | false | ✅ |
| push / schedule / workflow_dispatch | n/a | ✅ (unaffected) |

## Note

`pull_request` workflows run from the **base-branch** definition, so this only takes effect for PRs opened/updated after it lands on master. The current PRs in flight will still use the old config until merged.

Other workflows (tests, server-build, the nuget builds, ping-module) trigger only on `workflow_dispatch`/`push` and are unaffected. `claude-agent` reacts to `@claude` mentions in comments/reviews and is intentionally left enabled on drafts.