### PR TITLE
Native conformance CI lane: build + ctest on Windows/Linux (#1094)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 *.sh text eol=lf
-
+# Conformance fixtures must be byte-identical on every platform: the corpus is
+# parsed by multiple language drivers, and CRLF checkouts broke the native one.
+*.hsmtest text eol=lf

--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -1,0 +1,46 @@
+name: Native collector conformance
+
+# Builds the native C++ collector spike and runs the shared conformance corpus
+# (tests/conformance/collector/*.hsmtest) against it via ctest, on Windows and
+# Linux. The same corpus runs against the .NET collector in collector-unit-tests
+# (CollectorConformanceTests) — together they form the parity gate of epic #1093.
+
+on:
+  push:
+    branches: [master, develop]
+    paths:
+      - 'src/native/**'
+      - 'tests/conformance/**'
+      - '.github/workflows/native-collector-conformance.yml'
+  pull_request:
+    # ready_for_review is required so tests run when a draft is marked ready
+    # (marking ready does not emit a synchronize event).
+    types: [opened, synchronize, reopened, ready_for_review]
+    # No paths filter — this lane is intended as a required check and must
+    # always report status. The build is two translation units; it is cheap.
+  workflow_dispatch:
+
+jobs:
+  native-conformance:
+    # Skip on draft PRs only. Non-PR events (push/workflow_dispatch) have no
+    # pull_request payload, so they must still run — hence the event_name guard.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure
+        run: cmake -S src/native/collector_spike -B build/native-spike
+
+      - name: Build
+        run: cmake --build build/native-spike --config Release --parallel
+
+      # Runs both lanes registered in the spike's CMakeLists:
+      # - native_* regression tests (C ABI / validation / JSON escaping)
+      # - conformance_* fixtures — the shared .hsmtest corpus
+      - name: Test
+        run: ctest --test-dir build/native-spike -C Release --output-on-failure

--- a/docs/initiatives/cpp-collector-port-spike.md
+++ b/docs/initiatives/cpp-collector-port-spike.md
@@ -641,6 +641,32 @@ Verification: managed conformance 156/156 (×3 repeat runs), full managed
 suite 453/453 green (9 skips pre-existing); C++ ctest 43/43;
 rate/function/file fixtures flake-screened 30 consecutive runs green.
 
+### 2026-06-12: native conformance CI lane (Windows + Linux)
+
+Until now the native driver ran only on developer machines — parity could
+regress silently on every merge. New workflow
+`.github/workflows/native-collector-conformance.yml` builds the spike and runs
+the full ctest suite (native_* regression + all 19 conformance fixtures) on
+`windows-latest` and `ubuntu-latest`, on every PR (no paths filter, same
+required-check convention as the collector lanes) and on pushes touching
+`src/native/**` / `tests/conformance/**`.
+
+First Linux run surfaced two portability gaps, both fixed:
+
+- **CRLF fixtures broke the native parser on POSIX**: `std::getline` keeps the
+  `'\r'` on Linux, corrupting the last field of every line (16 of 19 fixtures
+  failed; the 3 LF-authored ones passed). Fixed twice over: the driver strips a
+  trailing `'\r'` per line, and `.gitattributes` pins `*.hsmtest text eol=lf`
+  so the corpus is byte-identical on every platform (the managed driver and
+  Windows text-mode `ifstream` are indifferent).
+- **Missing pthread link**: the spike uses `std::thread`/`condition_variable`;
+  CMake now does `find_package(Threads REQUIRED)` and links
+  `Threads::Threads` (gcc without `-pthread` is UB-adjacent at runtime).
+
+gcc 11 `-Wall -Wextra -Wpedantic` compiles both translation units warning-free;
+all 19 fixtures + 24 regression tests pass under Linux (WSL Ubuntu 22.04) and
+43/43 under MSVC.
+
 ## Cross-Cutting Port Invariants
 
 Behavioral invariants every port must uphold that are NOT expressible as

--- a/src/native/collector_spike/CMakeLists.txt
+++ b/src/native/collector_spike/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.20)
 
 project(HsmCollectorNativeSpike LANGUAGES CXX)
 
+# The collector uses std::thread/std::condition_variable; on POSIX toolchains
+# this needs an explicit pthread link (gcc without -pthread links but may
+# crash at runtime).
+find_package(Threads REQUIRED)
+
 add_library(hsm_collector_spike STATIC
     src/hsm_collector.cpp
 )
@@ -12,6 +17,8 @@ target_include_directories(hsm_collector_spike
 )
 
 target_compile_features(hsm_collector_spike PUBLIC cxx_std_17)
+
+target_link_libraries(hsm_collector_spike PUBLIC Threads::Threads)
 
 if(MSVC)
     target_compile_options(hsm_collector_spike PRIVATE /W4 /permissive-)

--- a/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
+++ b/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
@@ -472,6 +472,11 @@ namespace
 
         while (std::getline(input, line))
         {
+            // Fixtures may be checked out with CRLF endings (git autocrlf on Windows);
+            // std::getline keeps the '\r' on POSIX, which would corrupt the last field.
+            if (!line.empty() && line.back() == '\r')
+                line.pop_back();
+
             if (line.empty() || line[0] == '#')
                 continue;
 


### PR DESCRIPTION
Part of #1094 / epic #1093 ("the conformance CI lane itself lands much earlier, with 1").

## Why

The native conformance driver ran only on developer machines — .NET/C++ parity could regress silently on every merge. The shared corpus (`tests/conformance/collector/*.hsmtest`) already runs against the managed collector in `collector-unit-tests`; this adds the missing native half.

## What

- **New workflow** `native-collector-conformance.yml`: cmake build + full ctest (24 `native_*` regression tests + 19 conformance fixtures) on `windows-latest` **and** `ubuntu-latest`. No paths filter on `pull_request` (same required-check convention the collector lanes adopted); paths-filtered on push to master/develop.
- **CRLF portability fix** (found by the first Linux run): `std::getline` keeps `'\r'` on POSIX, corrupting the last field of every fixture line — 16/19 fixtures failed (the 3 LF-authored ones passed). Fixed twice over: the driver strips a trailing `'\r'` per line, and `.gitattributes` pins `*.hsmtest text eol=lf` so the corpus is byte-identical on every platform (the index already stored LF; only checkouts varied).
- **Threads link**: `find_package(Threads REQUIRED)` + `Threads::Threads` — the spike uses `std::thread`/`condition_variable`, gcc/clang need `-pthread`.

## Verification

- Linux (WSL Ubuntu 22.04, gcc 11): builds warning-free with `-Wall -Wextra -Wpedantic`; 19/19 fixtures + 24/24 regression tests pass.
- Windows (MSVC 2022): ctest 43/43.
- The new lane runs on this very PR — both matrix legs must be green below.

## Follow-up (admin)

Once this lane is green on master, add `native-conformance (windows-latest)` / `native-conformance (ubuntu-latest)` to the "Protect master" required checks (alongside the still-pending `collector-unit-tests` item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)