### PR TITLE
Conformance driver meta-suite: 10 must-fail fixtures (test the tests)

### DIFF
--- a/docs/initiatives/cpp-collector-port-spike.md
+++ b/docs/initiatives/cpp-collector-port-spike.md
@@ -667,6 +667,35 @@ gcc 11 `-Wall -Wextra -Wpedantic` compiles both translation units warning-free;
 all 19 fixtures + 24 regression tests pass under Linux (WSL Ubuntu 22.04) and
 43/43 under MSVC.
 
+### 2026-06-12: driver meta-suite — must-fail fixtures ("test the tests")
+
+A green corpus proves nothing if a driver silently skips or rubber-stamps an
+assertion — #1094 calls this out as mutation testing of the harness. New
+`tests/conformance/collector/meta/` holds 10 single-case fixtures, each with
+exactly one deliberately WRONG expectation; a correct driver MUST fail it.
+Covered mutations: polled `expect_sent_count` overcount + exact-zero mismatch,
+`expect_payload_contains` / `expect_payload_not_contains`,
+`expect_bar_field` (wrong mean), `expect_each_value_once` (missing value),
+`expect_payload_value_sequence` (wrong start), `expect_eventually_value_above`
+(unreachable threshold), `expect_no_new_payloads_for_ms` (traffic arriving),
+and the unknown-action guard (a typo'd verb fails loudly, never skips).
+
+Runner contract (both drivers): a crash is NOT detection — the contract run is
+wrapped in-process and must surface a thrown assertion/contract failure.
+Managed: `Meta_must_fail_fixture_is_rejected_by_the_driver` theory over
+`meta/*.hsmtest` (the normal discovery globs non-recursively, so meta fixtures
+never enter the regular corpus). Native: `meta_must_fail` entry +
+`add_meta_conformance_test` CMake registrations. Both enforce one-case-per-file
+(a driver aborts a fixture on the first failing step, so a second mutation
+would never be proven).
+
+Timing-sensitive must-fails are biased so the only flake direction is benign:
+`expect_no_new_payloads_for_ms|1000` over a 100 ms post period needs a full
+second of scheduler stall to fake a pass (screened 20× both legs).
+
+Verification: managed meta 10/10 + full suite 464/464 green (9 skips
+pre-existing); MSVC ctest 53/53; gcc (WSL) meta 10/10.
+
 ## Cross-Cutting Port Invariants
 
 Behavioral invariants every port must uphold that are NOT expressible as

--- a/src/collector/HSMDataCollector.Tests/CollectorConformanceTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorConformanceTests.cs
@@ -53,6 +53,56 @@ namespace HSMDataCollector.Tests
             }
         }
 
+        // Meta-suite ("test the tests", #1094): every fixture under meta/ carries a deliberately
+        // wrong expectation, and a correct driver MUST fail it. A driver that passes one is not
+        // evaluating the assertion it claims to evaluate. A crash is not detection — the case
+        // must surface as a thrown assertion/contract failure.
+        [Theory]
+        [MemberData(nameof(CollectorMetaMustFailCases))]
+        public async Task Meta_must_fail_fixture_is_rejected_by_the_driver(string caseName, IReadOnlyList<ContractStep> steps)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(caseName));
+
+            var state = new ContractState();
+            Exception detected = null;
+
+            try
+            {
+                foreach (var step in steps)
+                    await ExecuteStepAsync(state, step).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                detected = ex;
+            }
+            finally
+            {
+                if (state.Collector != null)
+                    await state.Collector.Stop().ConfigureAwait(false);
+
+                state.Collector?.Dispose();
+            }
+
+            Assert.True(detected != null, $"Must-fail fixture '{caseName}' passed — the driver is not detecting wrong expectations.");
+        }
+
+        public static IEnumerable<object[]> CollectorMetaMustFailCases()
+        {
+            foreach (var contractFile in FindMetaContractFiles())
+            {
+                var contractName = Path.GetFileNameWithoutExtension(contractFile);
+                var cases = ReadContractCases(contractFile);
+
+                // Drivers abort a fixture on the first failing step, so a second case in a
+                // must-fail fixture would never be proven — one mutation per file.
+                if (cases.Count != 1)
+                    throw new InvalidOperationException($"Meta fixture '{contractName}' must contain exactly one case.");
+
+                foreach (var testCase in cases)
+                    yield return new object[] { contractName + ":" + testCase.Key, testCase.Value };
+            }
+        }
+
         private static async Task ExecuteStepAsync(ContractState state, ContractStep step)
         {
             switch (step.Action)
@@ -1198,7 +1248,13 @@ namespace HSMDataCollector.Tests
             return cases.ToDictionary(x => x.Key, x => (IReadOnlyList<ContractStep>)x.Value, StringComparer.Ordinal);
         }
 
-        private static IReadOnlyList<string> FindContractFiles()
+        private static IReadOnlyList<string> FindContractFiles() =>
+            Directory.GetFiles(FindContractDirectory(), "*.hsmtest").OrderBy(x => x, StringComparer.Ordinal).ToArray();
+
+        private static IReadOnlyList<string> FindMetaContractFiles() =>
+            Directory.GetFiles(Path.Combine(FindContractDirectory(), "meta"), "*.hsmtest").OrderBy(x => x, StringComparer.Ordinal).ToArray();
+
+        private static string FindContractDirectory()
         {
             var directory = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
 
@@ -1206,7 +1262,7 @@ namespace HSMDataCollector.Tests
             {
                 var candidate = Path.Combine(directory.FullName, "tests", "conformance", "collector");
                 if (Directory.Exists(candidate))
-                    return Directory.GetFiles(candidate, "*.hsmtest").OrderBy(x => x, StringComparer.Ordinal).ToArray();
+                    return candidate;
 
                 directory = directory.Parent;
             }

--- a/src/native/collector_spike/CMakeLists.txt
+++ b/src/native/collector_spike/CMakeLists.txt
@@ -103,3 +103,26 @@ add_conformance_test(conformance_flush_contract flush_contract.hsmtest)
 add_conformance_test(conformance_rate_contract rate_contract.hsmtest)
 add_conformance_test(conformance_function_contract function_contract.hsmtest)
 add_conformance_test(conformance_file_contract file_contract.hsmtest)
+
+# Meta-suite ("test the tests"): must-FAIL fixtures with deliberately wrong
+# expectations; the meta_must_fail runner passes only when the driver detects
+# the failure. See tests/conformance/collector/meta/README.md.
+function(add_meta_conformance_test fixture)
+    get_filename_component(name ${fixture} NAME_WE)
+    add_test(
+        NAME ${name}
+        COMMAND hsm_collector_spike_tests meta_must_fail
+                ${CMAKE_CURRENT_SOURCE_DIR}/../../../tests/conformance/collector/meta/${fixture}
+    )
+endfunction()
+
+add_meta_conformance_test(meta_bar_field_wrong_mean.hsmtest)
+add_meta_conformance_test(meta_each_value_once_missing.hsmtest)
+add_meta_conformance_test(meta_eventually_value_above_unreachable.hsmtest)
+add_meta_conformance_test(meta_no_new_payloads_but_arriving.hsmtest)
+add_meta_conformance_test(meta_payload_contains_wrong_value.hsmtest)
+add_meta_conformance_test(meta_payload_not_contains_present.hsmtest)
+add_meta_conformance_test(meta_sent_count_overcount.hsmtest)
+add_meta_conformance_test(meta_sent_count_zero_but_sent.hsmtest)
+add_meta_conformance_test(meta_unknown_action_rejected.hsmtest)
+add_meta_conformance_test(meta_value_sequence_wrong_start.hsmtest)

--- a/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
+++ b/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
@@ -1815,6 +1815,28 @@ namespace
         }
     }
 
+    // Meta-suite ("test the tests", #1094): the fixture carries a deliberately wrong
+    // expectation, and a correct driver MUST fail it. The contract run is wrapped in-process
+    // so a crash still fails the meta test — a segfault is not "detection".
+    void RunConformanceContractExpectFailure(const std::string& path)
+    {
+        // Drivers abort a fixture on the first failing step, so a second case in a
+        // must-fail fixture would never be proven — one mutation per file.
+        Require(ReadConformanceFile(path).size() == 1, "meta fixture must contain exactly one case");
+
+        try
+        {
+            RunConformanceContract(path);
+        }
+        catch (const std::exception& ex)
+        {
+            std::cout << "must-fail fixture failed as required: " << ex.what() << '\n';
+            return;
+        }
+
+        throw std::runtime_error("Must-fail fixture unexpectedly passed: " + path);
+    }
+
     void NativeInvalidArgumentClearsOutParams()
     {
         auto* collector = reinterpret_cast<hsm_collector_t*>(static_cast<uintptr_t>(1));
@@ -2214,6 +2236,7 @@ namespace
             { "conformance_rate_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "conformance_function_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "conformance_file_contract", [](const std::string& path) { RunConformanceContract(path); } },
+            { "meta_must_fail", [](const std::string& path) { RunConformanceContractExpectFailure(path); } },
         };
 
         return tests;

--- a/tests/conformance/collector/meta/README.md
+++ b/tests/conformance/collector/meta/README.md
@@ -1,0 +1,29 @@
+# Conformance meta-suite — must-FAIL fixtures
+
+Mutation tests for the conformance drivers themselves ("test the tests",
+epic #1093 / workstream #1094). Every fixture in this directory contains a
+deliberately WRONG expectation: a correct driver MUST fail the case. A driver
+that passes any of these fixtures is broken — it is not actually evaluating
+the assertion it claims to evaluate, and a green corpus run proves nothing.
+
+Rules:
+
+- **One case per fixture.** Drivers abort a fixture on the first failing step,
+  so a second case would never be proven. Both runners enforce this.
+- Each fixture targets exactly one assert-verb family (one mutation), so a
+  regression in a single verb is pinpointed by a single meta test.
+- A *crash* is not detection. The must-fail runners require the driver to
+  REPORT a contract failure (an exception/assertion), not to die: the managed
+  runner catches and demands an exception, the native runner wraps the
+  contract run in try/catch inside the same process — a segfault still fails
+  the meta test.
+- These fixtures are intentionally invisible to the normal corpus discovery
+  (the managed driver globs `tests/conformance/collector/*.hsmtest`
+  non-recursively; the native driver registers fixtures explicitly). They run
+  through dedicated must-fail entry points in both drivers.
+
+Covered verb families: `expect_sent_count` (both polling-timeout and exact
+mismatch directions), `expect_payload_contains`, `expect_payload_not_contains`,
+`expect_bar_field`, `expect_each_value_once`, `expect_payload_value_sequence`,
+`expect_eventually_value_above`, `expect_no_new_payloads_for_ms`, and the
+unknown-action guard (a typo'd verb must fail loudly, never skip silently).

--- a/tests/conformance/collector/meta/meta_bar_field_wrong_mean.hsmtest
+++ b/tests/conformance/collector/meta/meta_bar_field_wrong_mean.hsmtest
@@ -1,0 +1,13 @@
+# MUST-FAIL: the bar aggregates 1..5 (mean 3) but the fixture demands mean 999.
+# Proves expect_bar_field reads the aggregated payload fields.
+meta_bar_field_wrong_mean|create_collector
+meta_bar_field_wrong_mean|create_int_bar_sensor|meta/bar/wrong-mean|3600000|0
+meta_bar_field_wrong_mean|start
+meta_bar_field_wrong_mean|add_bar_int|0|1
+meta_bar_field_wrong_mean|add_bar_int|0|2
+meta_bar_field_wrong_mean|add_bar_int|0|3
+meta_bar_field_wrong_mean|add_bar_int|0|4
+meta_bar_field_wrong_mean|add_bar_int|0|5
+meta_bar_field_wrong_mean|stop
+meta_bar_field_wrong_mean|expect_sent_count|1
+meta_bar_field_wrong_mean|expect_bar_field|0|mean|999

--- a/tests/conformance/collector/meta/meta_each_value_once_missing.hsmtest
+++ b/tests/conformance/collector/meta/meta_each_value_once_missing.hsmtest
@@ -1,0 +1,17 @@
+# MUST-FAIL: values 0..9 are delivered but the fixture demands [0, 11) — value
+# 10 is missing. Proves expect_each_value_once detects lost values.
+meta_each_value_once_missing|create_collector
+meta_each_value_once_missing|create_int_sensor|meta/each-once/missing
+meta_each_value_once_missing|start
+meta_each_value_once_missing|add_int|0|0|Ok|v
+meta_each_value_once_missing|add_int|0|1|Ok|v
+meta_each_value_once_missing|add_int|0|2|Ok|v
+meta_each_value_once_missing|add_int|0|3|Ok|v
+meta_each_value_once_missing|add_int|0|4|Ok|v
+meta_each_value_once_missing|add_int|0|5|Ok|v
+meta_each_value_once_missing|add_int|0|6|Ok|v
+meta_each_value_once_missing|add_int|0|7|Ok|v
+meta_each_value_once_missing|add_int|0|8|Ok|v
+meta_each_value_once_missing|add_int|0|9|Ok|v
+meta_each_value_once_missing|stop
+meta_each_value_once_missing|expect_each_value_once|0|11

--- a/tests/conformance/collector/meta/meta_eventually_value_above_unreachable.hsmtest
+++ b/tests/conformance/collector/meta/meta_eventually_value_above_unreachable.hsmtest
@@ -1,0 +1,7 @@
+# MUST-FAIL: the rate sensor receives no increments, so every post is 0 and
+# the threshold 5 is never crossed. Proves expect_eventually_value_above times
+# out and fails instead of passing vacuously (1 second deadline).
+meta_eventually_value_above_unreachable|create_collector
+meta_eventually_value_above_unreachable|create_rate_sensor|meta/rate/flat|150
+meta_eventually_value_above_unreachable|start
+meta_eventually_value_above_unreachable|expect_eventually_value_above|5|1

--- a/tests/conformance/collector/meta/meta_no_new_payloads_but_arriving.hsmtest
+++ b/tests/conformance/collector/meta/meta_no_new_payloads_but_arriving.hsmtest
@@ -1,0 +1,8 @@
+# MUST-FAIL: a function sensor posts every 100 ms, so new payloads keep
+# arriving during the 1000 ms quiet window the fixture demands. Proves
+# expect_no_new_payloads_for_ms detects traffic (the window is 10 post
+# periods wide, so a stalled scheduler cannot fake a pass).
+meta_no_new_payloads_but_arriving|create_collector
+meta_no_new_payloads_but_arriving|create_function_int_sensor|meta/func/busy|100|42
+meta_no_new_payloads_but_arriving|start
+meta_no_new_payloads_but_arriving|expect_no_new_payloads_for_ms|1000

--- a/tests/conformance/collector/meta/meta_payload_contains_wrong_value.hsmtest
+++ b/tests/conformance/collector/meta/meta_payload_contains_wrong_value.hsmtest
@@ -1,0 +1,9 @@
+# MUST-FAIL: the payload carries Value 1 but the fixture demands Value 999.
+# Proves expect_payload_contains actually inspects the serialized payload.
+meta_payload_contains_wrong_value|create_collector
+meta_payload_contains_wrong_value|create_int_sensor|meta/payload/contains
+meta_payload_contains_wrong_value|start
+meta_payload_contains_wrong_value|add_int|0|1|Ok|real value is one
+meta_payload_contains_wrong_value|stop
+meta_payload_contains_wrong_value|expect_sent_count|1
+meta_payload_contains_wrong_value|expect_payload_contains|0|"Value":999

--- a/tests/conformance/collector/meta/meta_payload_not_contains_present.hsmtest
+++ b/tests/conformance/collector/meta/meta_payload_not_contains_present.hsmtest
@@ -1,0 +1,9 @@
+# MUST-FAIL: the forbidden substring IS present in the payload. Proves
+# expect_payload_not_contains is a real negative assertion, not a no-op.
+meta_payload_not_contains_present|create_collector
+meta_payload_not_contains_present|create_int_sensor|meta/payload/not-contains
+meta_payload_not_contains_present|start
+meta_payload_not_contains_present|add_int|0|1|Ok|present
+meta_payload_not_contains_present|stop
+meta_payload_not_contains_present|expect_sent_count|1
+meta_payload_not_contains_present|expect_payload_not_contains|0|"Value":1

--- a/tests/conformance/collector/meta/meta_sent_count_overcount.hsmtest
+++ b/tests/conformance/collector/meta/meta_sent_count_overcount.hsmtest
@@ -1,0 +1,9 @@
+# MUST-FAIL: one value is sent but the fixture expects two. Proves the driver
+# fails a polled expect_sent_count that never reaches the expected count
+# (1 second poll deadline keeps the meta run fast).
+meta_sent_count_overcount|create_collector
+meta_sent_count_overcount|create_int_sensor|meta/sent-count/overcount
+meta_sent_count_overcount|start
+meta_sent_count_overcount|add_int|0|1|Ok|only one value
+meta_sent_count_overcount|stop
+meta_sent_count_overcount|expect_sent_count|2|1

--- a/tests/conformance/collector/meta/meta_sent_count_zero_but_sent.hsmtest
+++ b/tests/conformance/collector/meta/meta_sent_count_zero_but_sent.hsmtest
@@ -1,0 +1,9 @@
+# MUST-FAIL: a value IS delivered but the fixture expects zero. Proves the
+# driver fails the exact (no-timeout) expect_sent_count direction — overcounts
+# are detected, not only undercounts.
+meta_sent_count_zero_but_sent|create_collector
+meta_sent_count_zero_but_sent|create_int_sensor|meta/sent-count/zero
+meta_sent_count_zero_but_sent|start
+meta_sent_count_zero_but_sent|add_int|0|1|Ok|delivered
+meta_sent_count_zero_but_sent|stop
+meta_sent_count_zero_but_sent|expect_sent_count|0

--- a/tests/conformance/collector/meta/meta_unknown_action_rejected.hsmtest
+++ b/tests/conformance/collector/meta/meta_unknown_action_rejected.hsmtest
@@ -1,0 +1,3 @@
+# MUST-FAIL: the verb does not exist. Proves drivers fail loudly on unknown
+# actions instead of skipping them — a silently skipped assert is a fake green.
+meta_unknown_action_rejected|definitely_not_a_real_action|some-arg

--- a/tests/conformance/collector/meta/meta_value_sequence_wrong_start.hsmtest
+++ b/tests/conformance/collector/meta/meta_value_sequence_wrong_start.hsmtest
@@ -1,0 +1,12 @@
+# MUST-FAIL: the delivered sequence starts at 0 but the fixture demands it
+# start at 100. Proves expect_payload_value_sequence compares actual values.
+meta_value_sequence_wrong_start|create_collector
+meta_value_sequence_wrong_start|create_int_sensor|meta/sequence/wrong-start
+meta_value_sequence_wrong_start|start
+meta_value_sequence_wrong_start|add_int|0|0|Ok|v
+meta_value_sequence_wrong_start|add_int|0|1|Ok|v
+meta_value_sequence_wrong_start|add_int|0|2|Ok|v
+meta_value_sequence_wrong_start|add_int|0|3|Ok|v
+meta_value_sequence_wrong_start|add_int|0|4|Ok|v
+meta_value_sequence_wrong_start|stop
+meta_value_sequence_wrong_start|expect_payload_value_sequence|0|5|100


### PR DESCRIPTION
Part of #1094 / epic #1093 — the "driver meta-suite (mutation testing of the harness)" item.

## Why

A green corpus proves nothing if a driver silently skips or rubber-stamps an assertion: break `expect_payload_contains` in either driver and every fixture stays green while checking nothing. #1094 calls this out explicitly: *"a green corpus means nothing without it"*.

## What

**10 single-case must-FAIL fixtures** in `tests/conformance/collector/meta/` — each carries exactly one deliberately wrong expectation; a correct driver MUST fail it. One mutation per assert-verb family:

| Fixture | Proves the driver detects |
|---|---|
| `meta_sent_count_overcount` | polled `expect_sent_count` that never reaches the target (1s deadline) |
| `meta_sent_count_zero_but_sent` | the exact direction — overcounts, not only undercounts |
| `meta_payload_contains_wrong_value` | wrong substring vs the serialized payload |
| `meta_payload_not_contains_present` | the negative assertion is not a no-op |
| `meta_bar_field_wrong_mean` | aggregated bar fields are actually read |
| `meta_each_value_once_missing` | a lost value in the exactly-once set |
| `meta_value_sequence_wrong_start` | sequence values are compared |
| `meta_eventually_value_above_unreachable` | the poll times out and fails, not passes vacuously |
| `meta_no_new_payloads_but_arriving` | traffic during the quiet window |
| `meta_unknown_action_rejected` | a typo'd verb fails loudly, never skips silently |

**Runner contract (both drivers): a crash is NOT detection.** The contract run is wrapped in-process and must surface a thrown assertion/contract failure — deliberately not ctest `WILL_FAIL`, which would count a segfault as a pass.

- Managed: `Meta_must_fail_fixture_is_rejected_by_the_driver` theory over `meta/*.hsmtest`. Normal discovery globs `*.hsmtest` non-recursively, so meta fixtures never enter the regular corpus.
- Native: `meta_must_fail` runner + `add_meta_conformance_test` CMake registrations (runs in the #1110 CI lane automatically).
- Both runners enforce **one case per fixture** — drivers abort a fixture on the first failing step, so a second mutation would never be proven.

Deviation from the #1094 wording: the issue suggests a *separate CI lane*; these run inside the existing test suites of both drivers instead (10 cases, ~5s) — a dedicated lane would be pure overhead. Flagging for review.

## Verification

- Managed: meta 10/10, full suite 464/464 (9 pre-existing skips).
- Native MSVC: ctest 53/53 (43 existing + 10 meta).
- Native gcc 11 (WSL Ubuntu 22.04): meta 10/10, warning-free build.
- Timing-sensitive cases biased so the only flake direction is benign (`expect_no_new_payloads_for_ms|1000` vs 100 ms post period needs a 1 s scheduler stall to fake a pass); screened 20×.

🤖 Generated with [Claude Code](https://claude.com/claude-code)