### PR TITLE
Registration conformance: AddOrUpdate contract across languages (#1094)

### DIFF
--- a/src/collector/HSMDataCollector.Tests/CollectorConformanceTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorConformanceTests.cs
@@ -155,6 +155,27 @@ namespace HSMDataCollector.Tests
                     AddSensor(state, state.EnumSensors, state.Collector.CreateEnumSensor(ExpandTextToken(step.Arg(0))));
                     break;
 
+                case "create_int_sensor_with_options":
+                    AddSensor(state, state.IntSensors, state.Collector.CreateIntSensor(
+                        ExpandTextToken(step.Arg(0)),
+                        new InstantSensorOptions
+                        {
+                            TTL = long.Parse(step.Arg(1)) > 0 ? TimeSpan.FromMilliseconds(long.Parse(step.Arg(1))) : (TimeSpan?)null,
+                            SensorUnit = int.Parse(step.Arg(2)) >= 0 ? (Unit)int.Parse(step.Arg(2)) : (Unit?)null,
+                            Description = ExpandTextToken(step.Arg(3)),
+                        }));
+                    break;
+
+                case "create_enum_sensor_with_options":
+                    AddSensor(state, state.EnumSensors, state.Collector.CreateEnumSensor(
+                        ExpandTextToken(step.Arg(0)),
+                        new EnumSensorOptions
+                        {
+                            Description = ExpandTextToken(step.Arg(1)),
+                            EnumOptions = ParseEnumOptions(step.Arg(2)),
+                        }));
+                    break;
+
                 case "create_last_int_sensor":
                     AddSensor(state, state.IntSensors, state.Collector.CreateLastValueIntSensor(step.Arg(0), int.Parse(step.Arg(1))));
                     break;
@@ -336,6 +357,20 @@ namespace HSMDataCollector.Tests
 
                 case "expect_payload_contains":
                     Assert.Contains(step.Arg(1), PayloadText(state.Sender.Values[int.Parse(step.Arg(0))]));
+                    break;
+
+                case "expect_registration_count":
+                    var registrationTimeout = step.TryArg(1, out var registrationSeconds)
+                        ? TimeSpan.FromSeconds(int.Parse(registrationSeconds))
+                        : TimeSpan.FromSeconds(2);
+
+                    Assert.True(
+                        await state.Sender.WaitForRegistrationCountAsync(int.Parse(step.Arg(0)), registrationTimeout).ConfigureAwait(false),
+                        $"Expected {step.Arg(0)} registration(s), got {state.Sender.Registrations.Count}.");
+                    break;
+
+                case "expect_registration_contains":
+                    Assert.Contains(step.Arg(1), RegistrationText(state.Sender.Registrations[int.Parse(step.Arg(0))]));
                     break;
 
                 case "expect_payload_not_contains":
@@ -1028,6 +1063,53 @@ namespace HSMDataCollector.Tests
             Assert.Equal(enumCount, payloads.Count(payload => payload.Contains("\"Type\":10,")));
         }
 
+        // Canonical cross-language registration (AddOrUpdateSensorRequest) text — fixed field
+        // order; the portable subset only (alerts and managed-only flags are asserted by
+        // language-local tests). TTLTicks are .NET ticks (ttl_ms * 10000).
+        private static string RegistrationText(AddOrUpdateSensorRequest request)
+        {
+            var ttls = request.TTLs == null
+                ? "null"
+                : "[" + string.Join(",", request.TTLs.Select(t => t?.ToString(CultureInfo.InvariantCulture) ?? "null")) + "]";
+
+            var enums = request.EnumOptions == null
+                ? "null"
+                : "[" + string.Join(",", request.EnumOptions.Select(o =>
+                    $"{{\"Key\":{o.Key},\"Value\":\"{EscapeJson(o.Value)}\",\"Color\":{o.Color},\"Description\":\"{EscapeJson(o.Description)}\"}}")) + "]";
+
+            return "{" +
+                   "\"Command\":\"AddOrUpdate\"," +
+                   $"\"Path\":\"{EscapeJson(request.Path)}\"," +
+                   $"\"SensorType\":{(request.SensorType.HasValue ? ((int)request.SensorType.Value).ToString(CultureInfo.InvariantCulture) : "null")}," +
+                   $"\"TTLTicks\":{ttls}," +
+                   $"\"OriginalUnit\":{(request.OriginalUnit.HasValue ? ((int)request.OriginalUnit.Value).ToString(CultureInfo.InvariantCulture) : "null")}," +
+                   $"\"Description\":{(request.Description == null ? "null" : "\"" + EscapeJson(request.Description) + "\"")}," +
+                   $"\"EnumOptions\":{enums}" +
+                   "}";
+        }
+
+        // "key:value:color:description;key:value:color:description;..." — values must not
+        // contain ':' or ';' (fixture authoring constraint).
+        private static List<EnumOption> ParseEnumOptions(string text)
+        {
+            var options = new List<EnumOption>();
+
+            foreach (var part in text.Split(';'))
+            {
+                var fields = part.Split(':');
+                if (fields.Length != 4)
+                    throw new InvalidOperationException($"Invalid enum option '{part}' — expected key:value:color:description.");
+
+                options.Add(new EnumOption(
+                    int.Parse(fields[0], CultureInfo.InvariantCulture),
+                    fields[1],
+                    fields[3],
+                    int.Parse(fields[2], CultureInfo.InvariantCulture)));
+            }
+
+            return options;
+        }
+
         private static string PayloadText(SensorValueBase value)
         {
             if (value is BarSensorValueBase bar)
@@ -1386,7 +1468,45 @@ namespace HSMDataCollector.Tests
                 return default;
             }
 
-            public ValueTask<PackageSendingInfo> SendCommandAsync(IEnumerable<CommandRequestBase> commands, CancellationToken token) => default;
+            // Sensor registrations (AddOrUpdateSensorRequest) are part of the recorded contract
+            // (registration_contract.hsmtest); they do not consume fail/hang injection.
+            public ValueTask<PackageSendingInfo> SendCommandAsync(IEnumerable<CommandRequestBase> commands, CancellationToken token)
+            {
+                lock (_lock)
+                {
+                    foreach (var command in commands)
+                        if (command is AddOrUpdateSensorRequest registration)
+                            _registrations.Add(registration);
+                }
+
+                return default;
+            }
+
+            public IReadOnlyList<AddOrUpdateSensorRequest> Registrations
+            {
+                get
+                {
+                    lock (_lock)
+                        return _registrations.ToList();
+                }
+            }
+
+            public async Task<bool> WaitForRegistrationCountAsync(int count, TimeSpan timeout)
+            {
+                var stopAt = DateTime.UtcNow + timeout;
+
+                while (DateTime.UtcNow < stopAt)
+                {
+                    if (Registrations.Count == count)
+                        return true;
+
+                    await Task.Delay(10).ConfigureAwait(false);
+                }
+
+                return Registrations.Count == count;
+            }
+
+            private readonly List<AddOrUpdateSensorRequest> _registrations = new List<AddOrUpdateSensorRequest>();
 
             // File payloads are part of the recorded contract (file_contract.hsmtest); they do not
             // consume fail/hang injection — those fixtures target the data queue only.

--- a/src/native/collector_spike/CMakeLists.txt
+++ b/src/native/collector_spike/CMakeLists.txt
@@ -104,6 +104,7 @@ add_conformance_test(conformance_rate_contract rate_contract.hsmtest)
 add_conformance_test(conformance_function_contract function_contract.hsmtest)
 add_conformance_test(conformance_file_contract file_contract.hsmtest)
 add_conformance_test(conformance_number_format_contract number_format_contract.hsmtest)
+add_conformance_test(conformance_registration_contract registration_contract.hsmtest)
 
 # Meta-suite ("test the tests"): must-FAIL fixtures with deliberately wrong
 # expectations; the meta_must_fail runner passes only when the driver detects

--- a/src/native/collector_spike/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector_spike/include/hsm_collector/hsm_collector.h
@@ -91,6 +91,41 @@ hsm_result_t hsm_collector_create_enum_sensor(
     hsm_collector_t* collector,
     const char* path,
     hsm_sensor_t** out_sensor);
+/* Sensor registration metadata (the AddOrUpdate command in the managed collector).
+   Every sensor registers on every collector start, and immediately when created while
+   the collector is running. The recorded registration JSON is the canonical
+   cross-language registration text (see registration_contract.hsmtest). */
+typedef struct hsm_enum_option_t
+{
+    int32_t key;
+    const char* value;
+    int32_t color;
+    const char* description;
+} hsm_enum_option_t;
+
+/* ttl_ms <= 0 => no TTL; unit < 0 => unset (codes per the managed Unit enum);
+   description may be NULL (instant sensors default to an empty description). */
+hsm_result_t hsm_collector_create_int_sensor_with_options(
+    hsm_collector_t* collector,
+    const char* path,
+    int64_t ttl_ms,
+    int32_t unit,
+    const char* description,
+    hsm_sensor_t** out_sensor);
+hsm_result_t hsm_collector_create_enum_sensor_with_options(
+    hsm_collector_t* collector,
+    const char* path,
+    const char* description,
+    const hsm_enum_option_t* enum_options,
+    size_t enum_option_count,
+    hsm_sensor_t** out_sensor);
+
+size_t hsm_collector_registration_count(const hsm_collector_t* collector);
+hsm_result_t hsm_collector_get_registration_json(
+    const hsm_collector_t* collector,
+    size_t index,
+    const char** out_json);
+
 hsm_result_t hsm_collector_create_last_value_int_sensor(
     hsm_collector_t* collector,
     const char* path,

--- a/src/native/collector_spike/src/hsm_collector.cpp
+++ b/src/native/collector_spike/src/hsm_collector.cpp
@@ -205,6 +205,67 @@ namespace
         return text;
     }
 
+    struct EnumOptionData
+    {
+        int32_t key = 0;
+        std::string value;
+        int32_t color = 0;
+        std::string description;
+    };
+
+    // Portable registration-option subset mirroring the managed sensor options
+    // (registration_contract.hsmtest). has_description=false => "Description":null —
+    // managed instant creates default to "", every other sensor family defaults to null.
+    struct RegistrationOptions
+    {
+        int64_t ttl_ms = 0;
+        int32_t unit = -1;
+        bool has_description = false;
+        std::string description;
+        bool has_enum_options = false;
+        std::vector<EnumOptionData> enum_options;
+    };
+
+    RegistrationOptions InstantRegistrationDefaults()
+    {
+        RegistrationOptions options;
+        options.has_description = true;
+        return options;
+    }
+
+    // Canonical cross-language registration text — must stay byte-identical to the C#
+    // harness RegistrationText (fixed field order; TTL in .NET ticks = ms * 10000).
+    std::string BuildRegistrationJson(const std::string& path, hsm_sensor_type_t type, const RegistrationOptions& options)
+    {
+        std::string ttl_text = "null";
+        if (options.ttl_ms > 0)
+            ttl_text = "[" + std::to_string(options.ttl_ms * 10000) + "]";
+
+        std::string enums_text = "null";
+        if (options.has_enum_options)
+        {
+            enums_text = "[";
+            for (size_t i = 0; i < options.enum_options.size(); ++i)
+            {
+                const auto& option = options.enum_options[i];
+                if (i > 0)
+                    enums_text += ",";
+                enums_text += "{\"Key\":" + std::to_string(option.key) +
+                              ",\"Value\":\"" + EscapeJson(option.value) +
+                              "\",\"Color\":" + std::to_string(option.color) +
+                              ",\"Description\":\"" + EscapeJson(option.description) + "\"}";
+            }
+            enums_text += "]";
+        }
+
+        return "{\"Command\":\"AddOrUpdate\",\"Path\":\"" + EscapeJson(path) +
+               "\",\"SensorType\":" + std::to_string(static_cast<int>(type)) +
+               ",\"TTLTicks\":" + ttl_text +
+               ",\"OriginalUnit\":" + (options.unit >= 0 ? std::to_string(options.unit) : "null") +
+               ",\"Description\":" + (options.has_description ? "\"" + EscapeJson(options.description) + "\"" : "null") +
+               ",\"EnumOptions\":" + enums_text + "}";
+    }
+
     // C# Math.Round(value, precision, MidpointRounding.AwayFromZero) — std::round is
     // half-away-from-zero, matching the double-bar field rounding contract.
     double RoundAwayFromZero(double value, int precision)
@@ -514,6 +575,12 @@ namespace
         hsm_sensor_type_t Type() const;
         bool IsLastValue() const;
 
+        // Immutable after creation: set under the collector lock before the sensor is
+        // published into the registry, so it is safe to read under the collector lock
+        // without taking the sensor lock (the lock order stays one-way).
+        void SetRegistrationJson(std::string json) { registration_json_ = std::move(json); }
+        const std::string& RegistrationJson() const { return registration_json_; }
+
     private:
         hsm_result_t AddValueJson(std::string value_json, hsm_sensor_status_t status, const char* comment);
 
@@ -549,6 +616,8 @@ namespace
         // File sensor identity.
         std::string file_name_;
         std::string file_extension_;
+
+        std::string registration_json_;
     };
 
     class NativeCollector : public std::enable_shared_from_this<NativeCollector>
@@ -590,6 +659,13 @@ namespace
                 sensors_snapshot.reserve(sensors_.size());
                 for (const auto& sensor : sensors_)
                     sensors_snapshot.push_back(sensor.second);
+
+                // Every start re-registers every sensor (mirrors C# InitAsync sending the
+                // AddOrUpdate command per start). RegistrationJson is immutable, so reading
+                // it under the collector lock keeps the one-way lock order. Map iteration
+                // order is unspecified — multi-sensor fixtures assert counts only.
+                for (const auto& sensor : sensors_)
+                    registrations_.push_back(sensor.second->RegistrationJson());
 
                 ClearError();
             }
@@ -665,7 +741,8 @@ namespace
             hsm_sensor_type_t type,
             bool is_last_value,
             const std::string& default_value_json,
-            std::shared_ptr<NativeSensor>& out_sensor)
+            std::shared_ptr<NativeSensor>& out_sensor,
+            const RegistrationOptions& registration = InstantRegistrationDefaults())
         {
             if (!IsValidPath(path))
                 return SetError(HSM_RESULT_INVALID_ARGUMENT, "Sensor path must not be empty.");
@@ -691,6 +768,7 @@ namespace
             }
 
             auto sensor = std::make_shared<NativeSensor>(weak_from_this(), sensor_path, type, is_last_value, default_value_json);
+            RegisterSensorLocked(sensor, type, sensor_path, registration);
             sensors_.emplace(sensor_path, sensor);
             out_sensor = std::move(sensor);
 
@@ -726,6 +804,7 @@ namespace
             }
 
             auto sensor = std::make_shared<NativeSensor>(weak_from_this(), sensor_path, type, bar_period_ms, precision);
+            RegisterSensorLocked(sensor, type, sensor_path, RegistrationOptions{});
             sensors_.emplace(sensor_path, sensor);
             out_sensor = std::move(sensor);
 
@@ -771,6 +850,7 @@ namespace
             auto sensor = std::make_shared<NativeSensor>(
                 weak_from_this(), sensor_path, type, post_period_ms,
                 int_function, int_values_function, function_user_data, max_cache_size);
+            RegisterSensorLocked(sensor, type, sensor_path, RegistrationOptions{});
             sensors_.emplace(sensor_path, sensor);
             out_sensor = std::move(sensor);
 
@@ -806,6 +886,7 @@ namespace
 
             auto sensor = std::make_shared<NativeSensor>(
                 weak_from_this(), sensor_path, CopyString(default_file_name), CopyString(extension));
+            RegisterSensorLocked(sensor, HSM_SENSOR_TYPE_FILE, sensor_path, RegistrationOptions{});
             sensors_.emplace(sensor_path, sensor);
             out_sensor = std::move(sensor);
 
@@ -928,6 +1009,30 @@ namespace
             return HSM_RESULT_OK;
         }
 
+        size_t RegistrationCount() const
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            return registrations_.size();
+        }
+
+        hsm_result_t RegistrationJson(size_t index, const char** out_json) const
+        {
+            if (out_json == nullptr)
+                return HSM_RESULT_INVALID_ARGUMENT;
+
+            std::lock_guard<std::mutex> guard(mutex_);
+
+            if (index >= registrations_.size())
+            {
+                *out_json = nullptr;
+                return SetError(HSM_RESULT_NOT_FOUND, "Registration was not found.");
+            }
+
+            *out_json = registrations_[index].c_str();
+            ClearError();
+            return HSM_RESULT_OK;
+        }
+
         const char* LastError() const
         {
             std::lock_guard<std::mutex> guard(mutex_);
@@ -949,6 +1054,21 @@ namespace
         std::string BuildSensorPath(const std::string& path) const
         {
             return JoinPathParts({ computer_name_, module_, path });
+        }
+
+        // Caller holds mutex_. New sensors register immediately when the collector is
+        // already running (mirrors C# InitAsync on dynamic creation); sensors created
+        // before Start are registered by the Start loop.
+        void RegisterSensorLocked(
+            const std::shared_ptr<NativeSensor>& sensor,
+            hsm_sensor_type_t type,
+            const std::string& sensor_path,
+            const RegistrationOptions& registration)
+        {
+            sensor->SetRegistrationJson(BuildRegistrationJson(sensor_path, type, registration));
+
+            if (state_ == CollectorState::Running)
+                registrations_.push_back(sensor->RegistrationJson());
         }
 
         // FIFO send queue. Lock discipline: `queue_mutex_` and `mutex_` are never held together —
@@ -1177,6 +1297,7 @@ namespace
         CollectorState state_ = CollectorState::Stopped;
         std::unordered_map<std::string, std::shared_ptr<NativeSensor>> sensors_;
         std::vector<std::string> sent_values_;
+        std::vector<std::string> registrations_;
         mutable std::string last_error_;
 
         std::mutex queue_mutex_;
@@ -1590,7 +1711,8 @@ static hsm_result_t CreateSensor(
     hsm_sensor_type_t type,
     bool is_last_value,
     const std::string& default_value_json,
-    hsm_sensor_t** out_sensor);
+    hsm_sensor_t** out_sensor,
+    const RegistrationOptions& registration = InstantRegistrationDefaults());
 
 hsm_result_t hsm_collector_create(const hsm_collector_options_t* options, hsm_collector_t** out_collector)
 {
@@ -1748,7 +1870,8 @@ static hsm_result_t CreateSensor(
     hsm_sensor_type_t type,
     bool is_last_value,
     const std::string& default_value_json,
-    hsm_sensor_t** out_sensor)
+    hsm_sensor_t** out_sensor,
+    const RegistrationOptions& registration)
 {
     if (out_sensor != nullptr)
         *out_sensor = nullptr;
@@ -1757,12 +1880,76 @@ static hsm_result_t CreateSensor(
         return HSM_RESULT_INVALID_ARGUMENT;
 
     std::shared_ptr<NativeSensor> sensor;
-    const auto result = collector->impl->CreateSensor(path, type, is_last_value, default_value_json, sensor);
+    const auto result = collector->impl->CreateSensor(path, type, is_last_value, default_value_json, sensor, registration);
     if (result != HSM_RESULT_OK)
         return result;
 
     *out_sensor = new hsm_sensor_t{ std::move(sensor) };
     return HSM_RESULT_OK;
+}
+
+hsm_result_t hsm_collector_create_int_sensor_with_options(
+    hsm_collector_t* collector,
+    const char* path,
+    int64_t ttl_ms,
+    int32_t unit,
+    const char* description,
+    hsm_sensor_t** out_sensor)
+{
+    auto registration = InstantRegistrationDefaults();
+    registration.ttl_ms = ttl_ms;
+    registration.unit = unit;
+    registration.description = CopyString(description);
+
+    return CreateSensor(collector, path, HSM_SENSOR_TYPE_INT, false, std::string{}, out_sensor, registration);
+}
+
+hsm_result_t hsm_collector_create_enum_sensor_with_options(
+    hsm_collector_t* collector,
+    const char* path,
+    const char* description,
+    const hsm_enum_option_t* enum_options,
+    size_t enum_option_count,
+    hsm_sensor_t** out_sensor)
+{
+    if (enum_options == nullptr && enum_option_count > 0)
+    {
+        if (out_sensor != nullptr)
+            *out_sensor = nullptr;
+        return HSM_RESULT_INVALID_ARGUMENT;
+    }
+
+    auto registration = InstantRegistrationDefaults();
+    registration.description = CopyString(description);
+    registration.has_enum_options = true;
+    registration.enum_options.reserve(enum_option_count);
+    for (size_t i = 0; i < enum_option_count; ++i)
+        registration.enum_options.push_back(EnumOptionData{
+            enum_options[i].key,
+            CopyString(enum_options[i].value),
+            enum_options[i].color,
+            CopyString(enum_options[i].description) });
+
+    return CreateSensor(collector, path, HSM_SENSOR_TYPE_ENUM, false, std::string{}, out_sensor, registration);
+}
+
+size_t hsm_collector_registration_count(const hsm_collector_t* collector)
+{
+    if (collector == nullptr)
+        return 0;
+
+    return collector->impl->RegistrationCount();
+}
+
+hsm_result_t hsm_collector_get_registration_json(const hsm_collector_t* collector, size_t index, const char** out_json)
+{
+    if (out_json != nullptr)
+        *out_json = nullptr;
+
+    if (collector == nullptr)
+        return HSM_RESULT_INVALID_ARGUMENT;
+
+    return collector->impl->RegistrationJson(index, out_json);
 }
 
 static hsm_result_t CreateBarSensor(

--- a/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
+++ b/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
@@ -276,6 +276,30 @@ namespace
         return SentJson(collector, 0);
     }
 
+    bool WaitForRegistrationCountEquals(hsm_collector_t* collector, size_t expected, int timeout_ms = 2000)
+    {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::milliseconds(timeout_ms);
+
+        while (std::chrono::steady_clock::now() < deadline)
+        {
+            if (hsm_collector_registration_count(collector) == expected)
+                return true;
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+
+        return hsm_collector_registration_count(collector) == expected;
+    }
+
+    std::string RegistrationJson(hsm_collector_t* collector, size_t index)
+    {
+        const char* json = nullptr;
+        Require(
+            hsm_collector_get_registration_json(collector, index, &json) == HSM_RESULT_OK && json != nullptr,
+            "registration json was not found");
+        return json;
+    }
+
     std::string NumberFieldFromPayload(const std::string& payload, const std::string& field)
     {
         const auto key = "\"" + field + "\":";
@@ -307,16 +331,21 @@ namespace
         return payload.substr(value_start, end - value_start);
     }
 
-    std::vector<std::string> SplitLine(const std::string& line)
+    std::vector<std::string> SplitBy(const std::string& text, char separator)
     {
         std::vector<std::string> parts;
         std::string part;
-        std::istringstream input(line);
+        std::istringstream input(text);
 
-        while (std::getline(input, part, '|'))
+        while (std::getline(input, part, separator))
             parts.push_back(part);
 
         return parts;
+    }
+
+    std::vector<std::string> SplitLine(const std::string& line)
+    {
+        return SplitBy(line, '|');
     }
 
     int ToInt(const std::string& value)
@@ -586,6 +615,56 @@ namespace
             Require(step.size() >= 2, "create_enum_sensor requires path");
             const auto path = ExpandTextToken(step[1]);
             state.sensors.push_back(CreateEnumSensor(state.collector.value, path.c_str()));
+            return;
+        }
+
+        if (action == "create_int_sensor_with_options")
+        {
+            Require(step.size() >= 5, "create_int_sensor_with_options requires path, ttl_ms, unit, description");
+            const auto path = ExpandTextToken(step[1]);
+            const auto description = ExpandTextToken(step[4]);
+
+            SensorHandle sensor;
+            Require(
+                hsm_collector_create_int_sensor_with_options(
+                    state.collector.value, path.c_str(),
+                    static_cast<int64_t>(std::stoll(step[2])), ToInt(step[3]),
+                    description.c_str(), &sensor.value) == HSM_RESULT_OK,
+                "sensor create with options failed");
+
+            state.sensors.push_back(std::move(sensor));
+            return;
+        }
+
+        if (action == "create_enum_sensor_with_options")
+        {
+            Require(step.size() >= 4, "create_enum_sensor_with_options requires path, description, options");
+            const auto path = ExpandTextToken(step[1]);
+            const auto description = ExpandTextToken(step[2]);
+
+            // "key:value:color:description;..." — keep the string storage alive across the call.
+            std::vector<std::vector<std::string>> parsed;
+            for (const auto& part : SplitBy(step[3], ';'))
+            {
+                auto fields = SplitBy(part, ':');
+                Require(fields.size() == 4, "enum option must be key:value:color:description");
+                parsed.push_back(std::move(fields));
+            }
+
+            std::vector<hsm_enum_option_t> options;
+            options.reserve(parsed.size());
+            for (const auto& fields : parsed)
+                options.push_back(hsm_enum_option_t{
+                    ToInt(fields[0]), fields[1].c_str(), ToInt(fields[2]), fields[3].c_str() });
+
+            SensorHandle sensor;
+            Require(
+                hsm_collector_create_enum_sensor_with_options(
+                    state.collector.value, path.c_str(), description.c_str(),
+                    options.data(), options.size(), &sensor.value) == HSM_RESULT_OK,
+                "enum sensor create with options failed");
+
+            state.sensors.push_back(std::move(sensor));
             return;
         }
 
@@ -1204,6 +1283,26 @@ namespace
 
             const auto count = hsm_collector_sent_count(state.collector.value);
             Require(count <= maximum, ("sent count exceeded the expected maximum: " + std::to_string(count)).c_str());
+            return;
+        }
+
+        if (action == "expect_registration_count")
+        {
+            Require(step.size() >= 2, "expect_registration_count requires count");
+            const auto expected = static_cast<size_t>(ToInt(step[1]));
+            const auto timeout_ms = step.size() >= 3 ? ToInt(step[2]) * 1000 : 2000;
+
+            Require(
+                WaitForRegistrationCountEquals(state.collector.value, expected, timeout_ms),
+                ("registration count did not match: expected " + step[1] +
+                 ", got " + std::to_string(hsm_collector_registration_count(state.collector.value))).c_str());
+            return;
+        }
+
+        if (action == "expect_registration_contains")
+        {
+            Require(step.size() >= 3, "expect_registration_contains requires index and substring");
+            Contains(RegistrationJson(state.collector.value, static_cast<size_t>(ToInt(step[1]))), step[2]);
             return;
         }
 
@@ -2237,6 +2336,7 @@ namespace
             { "conformance_function_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "conformance_file_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "conformance_number_format_contract", [](const std::string& path) { RunConformanceContract(path); } },
+            { "conformance_registration_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "meta_must_fail", [](const std::string& path) { RunConformanceContractExpectFailure(path); } },
         };
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -105,6 +105,8 @@ into the per-case creation order of that sensor kind (0-based).
 | `create_function_int_sensor\|path\|post_period_ms\|constant` | driver callback returns `constant` |
 | `create_values_function_int_sum_sensor\|path\|post_period_ms\|max_cache_size` | driver callback sums the sliding-window snapshot |
 | `create_file_sensor\|path\|default_file_name\|extension` | string-content file sensor (disk `SendFile` is not portable) |
+| `create_int_sensor_with_options\|path\|ttl_ms\|unit\|description` | `ttl_ms=0` ⇒ no TTL; `unit=-1` ⇒ unset (codes per the managed `Unit` enum) |
+| `create_enum_sensor_with_options\|path\|description\|key:value:color:desc[;...]` | enum sensor with `EnumOptions` (values must not contain `:` or `;`) |
 | `dispose_sensor\|sensor_index` | release without flushing |
 | `expect_create_int_sensor_rejected\|path`, `expect_create_last_*_sensor_rejected\|path\|default_value` | creation validation throws |
 | `expect_conflicting_mixed_creates_rejected_parallel\|worker_count\|path_count\|path_prefix` | type conflicts on one path rejected under parallel registration |
@@ -154,6 +156,8 @@ Polling assertions re-check until the deadline, then fail.
 | `expect_bar_open_close_aligned\|payload_index\|period_ms` | close−open == period and open % period == 0 (unix ms) |
 | `expect_all_bars_aligned\|period_ms` / `expect_bar_open_times_increasing` | invariants over all bar payloads |
 | `expect_eventually_payload_contains\|substring\|timeout_s` | polls any payload for the substring |
+| `expect_registration_count\|count[\|timeout_s]` | polls the recorded AddOrUpdate registrations (every sensor registers on every start; immediately when created while running) |
+| `expect_registration_contains\|index\|substring` | substring of the canonical registration text: `{"Command":"AddOrUpdate","Path":"...","SensorType":N,"TTLTicks":[...]\|null,"OriginalUnit":N\|null,"Description":"..."\|null,"EnumOptions":[{"Key":k,"Value":"v","Color":c,"Description":"d"},...]\|null}` — full path incl. identity prefix; TTL in .NET ticks |
 | `expect_eventually_value_above\|threshold\|timeout_s` | polls numeric payload values; fails (not passes) on timeout |
 | `expect_no_new_payloads_for_ms\|ms` | baseline now; no new payloads during the window |
 

--- a/tests/conformance/collector/registration_contract.hsmtest
+++ b/tests/conformance/collector/registration_contract.hsmtest
@@ -1,0 +1,68 @@
+# HSM collector conformance v1 — sensor registration (AddOrUpdateSensorRequest) contract.
+# New verbs:
+# create_int_sensor_with_options|path|ttl_ms|unit|description   (ttl_ms=0 => no TTL; unit=-1 => unset; unit codes per HSMSensorDataObjects Unit enum)
+# create_enum_sensor_with_options|path|description|key:value:color:desc[;key:value:color:desc...]
+# expect_registration_count|count|[timeout_s]                    (polls like expect_sent_count)
+# expect_registration_contains|index|substring                   (canonical registration text)
+# Canonical registration text (portable subset; fixed order):
+# {"Command":"AddOrUpdate","Path":"...","SensorType":N,"TTLTicks":[t|null,...]|null,
+#  "OriginalUnit":N|null,"Description":"..."|null,"EnumOptions":[{"Key":k,"Value":"v","Color":c,"Description":"d"},...]|null}
+# Contract notes:
+# - Every sensor registers itself when the collector starts (one AddOrUpdate per sensor);
+#   a sensor created while the collector is running registers immediately.
+# - TTLTicks are .NET ticks (ttl_ms * 10000).
+# - The registration Path is the FULL sensor path including the collector identity prefix
+#   (computer/module) — anchor path asserts with a trailing quote, not a leading one.
+# - Alerts and managed-only registration flags are NOT part of the portable subset; they are
+#   pinned by language-local unit tests.
+
+plain_int_sensor_registers_on_start|create_collector
+plain_int_sensor_registers_on_start|create_int_sensor|contract/registration/basic
+plain_int_sensor_registers_on_start|start
+plain_int_sensor_registers_on_start|stop
+plain_int_sensor_registers_on_start|expect_registration_count|1
+plain_int_sensor_registers_on_start|expect_registration_contains|0|contract/registration/basic"
+plain_int_sensor_registers_on_start|expect_registration_contains|0|"SensorType":1,
+plain_int_sensor_registers_on_start|expect_registration_contains|0|"TTLTicks":null
+plain_int_sensor_registers_on_start|expect_registration_contains|0|"OriginalUnit":null
+
+int_sensor_registers_ttl_unit_description|create_collector
+int_sensor_registers_ttl_unit_description|create_int_sensor_with_options|contract/registration/options|60000|1|queue depth
+int_sensor_registers_ttl_unit_description|start
+int_sensor_registers_ttl_unit_description|stop
+int_sensor_registers_ttl_unit_description|expect_registration_count|1
+int_sensor_registers_ttl_unit_description|expect_registration_contains|0|"TTLTicks":[600000000]
+int_sensor_registers_ttl_unit_description|expect_registration_contains|0|"OriginalUnit":1,
+int_sensor_registers_ttl_unit_description|expect_registration_contains|0|"Description":"queue depth"
+
+enum_sensor_registers_enum_options|create_collector
+enum_sensor_registers_enum_options|create_enum_sensor_with_options|contract/registration/enum|states|0:Idle:65280:nothing to do;1:Busy:16711680:working hard
+enum_sensor_registers_enum_options|start
+enum_sensor_registers_enum_options|stop
+enum_sensor_registers_enum_options|expect_registration_count|1
+enum_sensor_registers_enum_options|expect_registration_contains|0|"SensorType":10,
+enum_sensor_registers_enum_options|expect_registration_contains|0|"EnumOptions":[{"Key":0,"Value":"Idle","Color":65280,"Description":"nothing to do"},{"Key":1,"Value":"Busy","Color":16711680,"Description":"working hard"}]
+enum_sensor_registers_enum_options|expect_registration_contains|0|"Description":"states"
+
+each_sensor_registers_once|create_collector
+each_sensor_registers_once|create_int_sensor|contract/registration/multi/a
+each_sensor_registers_once|create_double_sensor|contract/registration/multi/b
+each_sensor_registers_once|create_string_sensor|contract/registration/multi/c
+each_sensor_registers_once|start
+each_sensor_registers_once|stop
+each_sensor_registers_once|expect_registration_count|3
+
+sensor_created_while_running_registers|create_collector
+sensor_created_while_running_registers|start
+sensor_created_while_running_registers|create_int_sensor|contract/registration/dynamic
+sensor_created_while_running_registers|expect_registration_count|1|5
+sensor_created_while_running_registers|stop
+
+restart_reregisters_sensor|create_collector
+restart_reregisters_sensor|create_int_sensor|contract/registration/restart
+restart_reregisters_sensor|start
+restart_reregisters_sensor|stop
+restart_reregisters_sensor|expect_registration_count|1
+restart_reregisters_sensor|start
+restart_reregisters_sensor|stop
+restart_reregisters_sensor|expect_registration_count|2


### PR DESCRIPTION
Part of #1094 / epic #1093 — the **registration assertions** item.

## The gap it closes

The corpus never looked at sensor registration (`AddOrUpdateSensorRequest`): TTL, units, descriptions and EnumOptions could silently diverge between collectors, and the registration *timing* contract (when AddOrUpdate is sent) was unpinned.

## What

- **`registration_contract.hsmtest`** (6 cases): plain sensor registers on start; TTL (.NET ticks) + `OriginalUnit` + `Description` round-trip; `EnumOptions` array (key/value/color/description) exact canonical text; one registration per sensor; a sensor created while running registers immediately; **restart re-registers** (pinned: managed `InitAsync` sends AddOrUpdate on every start).
- **New verbs** (added to the DSL README): `create_int_sensor_with_options`, `create_enum_sensor_with_options`, `expect_registration_count` (polling), `expect_registration_contains` over a canonical registration text — fixed field order, portable subset only (alerts and managed-only flags stay pinned by language-local tests).
- **C# driver**: `RecordingSender` now records `AddOrUpdateSensorRequest` commands (was `=> default`); canonical `RegistrationText`; enum-option parser.
- **Native**: per-sensor registration JSON — immutable, built under the collector lock before the sensor is published (lock order stays one-way); recorded on every `Start` for all sensors and immediately for created-while-running. C ABI grows `hsm_collector_create_int_sensor_with_options` / `create_enum_sensor_with_options` (`hsm_enum_option_t`) + `registration_count` / `get_registration_json`.

## Verification

- .NET driver (net48): conformance corpus 165/165.
- Native MSVC: ctest 55/55 (incl. meta-suite lane).
- Native gcc 11 (WSL Ubuntu 22.04): fixture green, warning-free build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)