### PR TITLE
Differential conformance fuzzer: seeded generator + dump-compare + nightly lane (#1094)

### DIFF
--- a/.github/workflows/conformance-fuzzer.yml
+++ b/.github/workflows/conformance-fuzzer.yml
@@ -1,0 +1,56 @@
+name: Conformance differential fuzzer
+
+# Nightly differential fuzzing of the two collector drivers (#1094, epic #1093):
+# seeded random .hsmtest fixtures run through BOTH collectors; canonical payload
+# dumps must agree byte-for-byte. Scheduled lane, not a per-PR check — divergences
+# produce a minimized repro artifact to turn into a permanent corpus fixture.
+
+on:
+  schedule:
+    - cron: '17 4 * * 1-5'
+  workflow_dispatch:
+    inputs:
+      seed:
+        description: 'Generator seed (default: the run number)'
+        required: false
+      iterations:
+        description: 'Fixtures per run'
+        required: false
+        default: '40'
+
+jobs:
+  fuzz:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - name: Build native driver
+        run: |
+          cmake -S src/native/collector_spike -B build/native-spike
+          cmake --build build/native-spike --config Release --parallel
+
+      - name: Run differential fuzzer
+        shell: pwsh
+        run: |
+          $seed = '${{ github.event.inputs.seed }}'
+          if (-not $seed) { $seed = '${{ github.run_number }}' }
+          $iterations = '${{ github.event.inputs.iterations }}'
+          if (-not $iterations) { $iterations = '40' }
+          $binary = if ($IsWindows) { 'build/native-spike/Release/hsm_collector_spike_tests.exe' } else { 'build/native-spike/hsm_collector_spike_tests' }
+          ./scripts/fuzz-conformance.ps1 -Seed ([int]$seed) -Iterations ([int]$iterations) -NativeTestBinary $binary
+
+      - name: Upload divergence repros
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: fuzz-repros-${{ matrix.os }}
+          path: tests/conformance/fuzz-repros/
+          if-no-files-found: ignore

--- a/scripts/fuzz-conformance.ps1
+++ b/scripts/fuzz-conformance.ps1
@@ -1,0 +1,291 @@
+# Differential conformance fuzzer (#1094, epic #1093).
+#
+# Generates seeded random .hsmtest action sequences from the DETERMINISTIC verb
+# subset, runs each fixture through BOTH collector drivers (the .NET driver via
+# the Fuzz_fixture_executes theory + HSM_CONFORMANCE_FUZZ_DIR, the native driver
+# via the conformance_fuzz entry point), and byte-compares the canonical payload
+# dumps (dump_payloads_to). On divergence the failing fixture is minimized by
+# whole-line removal and saved together with both dumps.
+#
+# Determinism constraints baked into the generator (do not widen casually):
+# - inert dispatcher (collect period 60s) — everything materializes on stop-flush;
+# - doubles limited to <= 7 significant digits (n/100), where net48 "R", .NET Core
+#   and the native shortest-round-trip formatter all agree byte-for-byte;
+# - NaN/Infinity only fed to bars (silently skipped) — instant double adds throw;
+# - no rate/function sensors (wall-clock-dependent values);
+# - bar periods 3600000 ms (inert) — bars publish only via flush-on-stop.
+
+param(
+    [int]$Seed = 0,
+    [int]$Iterations = 25,
+    [string]$Configuration = "Debug",
+    [string]$NativeTestBinary = "",
+    [switch]$SkipManagedBuild
+)
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$collectorTests = Join-Path $repoRoot "src/collector/HSMDataCollector.Tests/HSMDataCollector.Tests.csproj"
+$reproRoot = Join-Path $repoRoot "tests/conformance/fuzz-repros"
+
+function Resolve-NativeBinary {
+    if ($NativeTestBinary -and (Test-Path $NativeTestBinary)) {
+        return (Resolve-Path $NativeTestBinary).Path
+    }
+
+    $candidates = @(
+        (Join-Path $repoRoot "src/native/collector_spike/build/$Configuration/hsm_collector_spike_tests.exe"),
+        (Join-Path $repoRoot "src/native/collector_spike/build/hsm_collector_spike_tests")
+    )
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path $candidate) {
+            return (Resolve-Path $candidate).Path
+        }
+    }
+
+    throw "Native test binary not found (looked at: $($candidates -join '; ')). Build the spike or pass -NativeTestBinary."
+}
+
+# One fixture = one case = one op sequence. Returns the fixture text with the
+# literal token OUTFILE as the dump target (substituted per driver run).
+#
+# Each case uses ONE sensor population of ONE kind: per the DSL spec sensor
+# indexes are kind-relative, but the native driver currently indexes the flat
+# creation order — identical only when every sensor in a case has the same
+# kind. (Aligning the native driver and pinning mixed-kind indexing is a
+# separate corpus item.)
+function New-FuzzFixture {
+    param([int]$CaseSeed, [string]$CaseName)
+
+    $rng = [System.Random]::new($CaseSeed)
+    $lines = [System.Collections.Generic.List[string]]::new()
+    $lines.Add("# seed: $CaseSeed (regenerate: scripts/fuzz-conformance.ps1)")
+
+    $maxQueue = 5 + $rng.Next(46)          # 5..50
+    $package = 1 + $rng.Next(10)           # 1..10
+    $lines.Add("$CaseName|create_collector_with_limits|$maxQueue|$package|60000")
+
+    $mode = @("int", "bool", "double", "string", "int_bar", "double_bar")[$rng.Next(6)]
+    $sensorCount = 1 + $rng.Next(4)        # 1..4 sensors of the chosen kind
+
+    for ($s = 0; $s -lt $sensorCount; $s++) {
+        switch ($mode) {
+            "int_bar"    { $lines.Add("$CaseName|create_int_bar_sensor|fuzz/bar/$s|3600000|0") }
+            "double_bar" { $lines.Add("$CaseName|create_double_bar_sensor|fuzz/bar/$s|3600000|0|$($rng.Next(4))") }
+            default      { $lines.Add("$CaseName|create_${mode}_sensor|fuzz/$mode/$s") }
+        }
+    }
+
+    $lines.Add("$CaseName|start")
+
+    $running = $true
+    $ops = 10 + $rng.Next(71)              # 10..80 ops
+    for ($i = 0; $i -lt $ops; $i++) {
+        if ($rng.Next(100) -lt 6) {
+            # Lifecycle cycling: instant values added while stopped are dropped, bar values
+            # keep accumulating — both deterministic.
+            if ($running) { $lines.Add("$CaseName|stop") } else { $lines.Add("$CaseName|start") }
+            $running = -not $running
+            continue
+        }
+
+        $idx = $rng.Next($sensorCount)
+        $status = @("Ok", "Warning", "Error")[$rng.Next(3)]
+        switch ($mode) {
+            "int"    { $lines.Add("$CaseName|add_int|$idx|$($rng.Next(-100000, 100000))|$status|fuzz-$i") }
+            "bool"   { $lines.Add("$CaseName|add_bool|$idx|$(@('true','false')[$rng.Next(2)])|$status|fuzz-$i") }
+            "double" { $lines.Add("$CaseName|add_double|$idx|$(($rng.Next(-10000000, 10000000)) / 100.0)|$status|fuzz-$i") }
+            "string" { $lines.Add("$CaseName|add_string|$idx|value-$($rng.Next(1000))|$status|fuzz-$i") }
+            "int_bar" { $lines.Add("$CaseName|add_bar_int|$idx|$($rng.Next(-100000, 100000))") }
+            "double_bar" {
+                # Bars silently skip non-finite values — exercise that path occasionally.
+                if ($rng.Next(10) -eq 0) {
+                    $value = @("NaN", "Infinity", "-Infinity")[$rng.Next(3)]
+                } else {
+                    $value = ($rng.Next(-10000000, 10000000)) / 100.0
+                }
+                $lines.Add("$CaseName|add_bar_double|$idx|$value")
+            }
+        }
+    }
+
+    if (-not $running) { $lines.Add("$CaseName|start") }
+    $lines.Add("$CaseName|stop")
+    $lines.Add("$CaseName|dump_payloads_to|OUTFILE")
+
+    return ($lines -join "`n") + "`n"
+}
+
+function Write-DriverFixture {
+    param([string]$FixtureText, [string]$TargetPath, [string]$DumpPath)
+
+    $text = $FixtureText.Replace("OUTFILE", ($DumpPath -replace '\\', '/'))
+    [System.IO.File]::WriteAllText($TargetPath, $text, [System.Text.UTF8Encoding]::new($false))
+}
+
+function Invoke-ManagedRun {
+    param([string]$FuzzDir)
+
+    $env:HSM_CONFORMANCE_FUZZ_DIR = $FuzzDir
+    try {
+        & dotnet test $collectorTests --filter "FullyQualifiedName~Fuzz_fixture_executes" --logger "console;verbosity=minimal" | Out-Host
+        if ($LASTEXITCODE -ne 0) {
+            throw "Managed fuzz run failed (driver-level failure, not a divergence) — inspect the dotnet test output."
+        }
+    }
+    finally {
+        Remove-Item Env:HSM_CONFORMANCE_FUZZ_DIR -ErrorAction SilentlyContinue
+    }
+}
+
+function Invoke-NativeRun {
+    param([string]$Binary, [string]$FixturePath)
+
+    & $Binary conformance_fuzz $FixturePath | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "Native fuzz run failed (driver-level failure, not a divergence): $FixturePath"
+    }
+}
+
+function Get-DumpLines {
+    param([string]$Path)
+
+    if (!(Test-Path $Path)) { throw "Dump file was not produced: $Path" }
+    $text = [System.IO.File]::ReadAllText($Path).Replace("`r", "").TrimEnd("`n")
+    # Bar open/close are wall-clock-derived (aligned to the bar period) — the two driver
+    # runs happen at different instants, so neutralize them; values, counts and ordering
+    # are what the fuzzer compares.
+    $text = $text -replace '"(OpenTimeMs|CloseTimeMs)":-?\d+', '"$1":T'
+    return $text -split "`n"
+}
+
+function Compare-Dumps {
+    param([string]$ManagedDump, [string]$NativeDump)
+
+    $managed = Get-DumpLines $ManagedDump
+    $native = Get-DumpLines $NativeDump
+
+    if ($managed.Count -ne $native.Count) {
+        return "payload count: managed=$($managed.Count) native=$($native.Count)"
+    }
+
+    for ($i = 0; $i -lt $managed.Count; $i++) {
+        if ($managed[$i] -cne $native[$i]) {
+            return "payload ${i}:`n  managed: $($managed[$i])`n  native:  $($native[$i])"
+        }
+    }
+
+    return $null
+}
+
+# Runs one fixture text through both drivers; returns $null on agreement or a
+# human-readable divergence description.
+function Test-FixtureAgreement {
+    param([string]$FixtureText, [string]$WorkDir, [string]$Binary, [string]$Name)
+
+    $fuzzDir = Join-Path $WorkDir "managed-$Name"
+    New-Item -ItemType Directory -Force -Path $fuzzDir | Out-Null
+
+    $managedDump = Join-Path $WorkDir "$Name.managed.txt"
+    $nativeDump = Join-Path $WorkDir "$Name.native.txt"
+    $managedFixture = Join-Path $fuzzDir "$Name.hsmtest"
+    $nativeFixture = Join-Path $WorkDir "$Name.native.hsmtest"
+
+    Write-DriverFixture $FixtureText $managedFixture $managedDump
+    Write-DriverFixture $FixtureText $nativeFixture $nativeDump
+
+    Invoke-ManagedRun $fuzzDir
+    Invoke-NativeRun $Binary $nativeFixture
+
+    return Compare-Dumps $managedDump $nativeDump
+}
+
+# Whole-line minimization: repeatedly try dropping each op line (never the
+# create/start/stop/dump skeleton); keep the drop when the divergence persists.
+# Every probe costs a full managed run — cap the budget.
+function Get-MinimizedFixture {
+    param([string]$FixtureText, [string]$WorkDir, [string]$Binary)
+
+    $lines = [System.Collections.Generic.List[string]]($FixtureText.TrimEnd("`n") -split "`n")
+    $probes = 0
+    $maxProbes = 12
+
+    for ($i = $lines.Count - 1; $i -ge 0 -and $probes -lt $maxProbes; $i--) {
+        $line = $lines[$i]
+        if ($line -match '\|(create_|start$|stop$|dump_payloads_to\|)' -or $line.StartsWith("#")) { continue }
+
+        $candidate = [System.Collections.Generic.List[string]]::new($lines)
+        $candidate.RemoveAt($i)
+        $candidateText = ($candidate -join "`n") + "`n"
+
+        $probes++
+        if (Test-FixtureAgreement $candidateText $WorkDir $Binary "min$probes") {
+            $lines = $candidate
+        }
+    }
+
+    return ($lines -join "`n") + "`n"
+}
+
+$binary = Resolve-NativeBinary
+$workRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("hsm-fuzz-" + [System.Guid]::NewGuid().ToString("N").Substring(0, 8))
+New-Item -ItemType Directory -Force -Path $workRoot | Out-Null
+
+if (-not $SkipManagedBuild) {
+    & dotnet build $collectorTests --nologo -v q | Out-Host
+    if ($LASTEXITCODE -ne 0) { throw "Managed test project build failed." }
+}
+
+Write-Host "Differential fuzzer: seed=$Seed iterations=$Iterations work=$workRoot"
+Write-Host "Native binary: $binary"
+
+# Generate all fixtures up front; ONE managed run executes them all (dotnet test
+# startup dominates), then the native binary replays each fixture individually.
+$fixtures = @{}
+$fuzzDir = Join-Path $workRoot "managed"
+New-Item -ItemType Directory -Force -Path $fuzzDir | Out-Null
+
+for ($it = 0; $it -lt $Iterations; $it++) {
+    $caseSeed = $Seed * 100000 + $it
+    $name = "fuzz_seed_$caseSeed"
+    $text = New-FuzzFixture -CaseSeed $caseSeed -CaseName $name
+    $fixtures[$name] = $text
+
+    Write-DriverFixture $text (Join-Path $fuzzDir "$name.hsmtest") (Join-Path $workRoot "$name.managed.txt")
+    Write-DriverFixture $text (Join-Path $workRoot "$name.native.hsmtest") (Join-Path $workRoot "$name.native.txt")
+}
+
+Invoke-ManagedRun $fuzzDir
+foreach ($name in $fixtures.Keys) {
+    Invoke-NativeRun $binary (Join-Path $workRoot "$name.native.hsmtest")
+}
+
+$divergences = @()
+foreach ($name in ($fixtures.Keys | Sort-Object)) {
+    $difference = Compare-Dumps (Join-Path $workRoot "$name.managed.txt") (Join-Path $workRoot "$name.native.txt")
+    if ($null -eq $difference) { continue }
+
+    Write-Host "DIVERGENCE in ${name}: $difference" -ForegroundColor Red
+    Write-Host "Minimizing $name..."
+    $minimized = Get-MinimizedFixture $fixtures[$name] $workRoot $binary
+
+    New-Item -ItemType Directory -Force -Path $reproRoot | Out-Null
+    $reproPath = Join-Path $reproRoot "$name.hsmtest"
+    [System.IO.File]::WriteAllText($reproPath, $minimized, [System.Text.UTF8Encoding]::new($false))
+    Copy-Item (Join-Path $workRoot "$name.managed.txt") (Join-Path $reproRoot "$name.managed.txt")
+    Copy-Item (Join-Path $workRoot "$name.native.txt") (Join-Path $reproRoot "$name.native.txt")
+
+    $divergences += "${name}: $difference (repro: $reproPath)"
+}
+
+if ($divergences.Count -gt 0) {
+    Write-Host ""
+    Write-Host "=== $($divergences.Count) divergence(s) found ===" -ForegroundColor Red
+    $divergences | ForEach-Object { Write-Host $_ }
+    exit 1
+}
+
+Write-Host "All $Iterations fuzz fixtures agree across drivers." -ForegroundColor Green
+exit 0

--- a/src/collector/HSMDataCollector.Tests/CollectorConformanceTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorConformanceTests.cs
@@ -86,6 +86,33 @@ namespace HSMDataCollector.Tests
             Assert.True(detected != null, $"Must-fail fixture '{caseName}' passed — the driver is not detecting wrong expectations.");
         }
 
+        // Differential-fuzzer entry point: executes generator-produced fixtures from the
+        // directory named by HSM_CONFORMANCE_FUZZ_DIR (scripts/fuzz-conformance.ps1). When the
+        // variable is unset (normal CI/dev runs), a single empty sentinel case keeps xUnit happy.
+        [Theory]
+        [MemberData(nameof(CollectorFuzzCases))]
+        public Task Fuzz_fixture_executes(string caseName, IReadOnlyList<ContractStep> steps) =>
+            Collector_contract_matches_shared_fixture(caseName, steps);
+
+        public static IEnumerable<object[]> CollectorFuzzCases()
+        {
+            var directory = Environment.GetEnvironmentVariable("HSM_CONFORMANCE_FUZZ_DIR");
+
+            if (string.IsNullOrEmpty(directory) || !Directory.Exists(directory))
+            {
+                yield return new object[] { "fuzz-disabled", (IReadOnlyList<ContractStep>)new List<ContractStep>() };
+                yield break;
+            }
+
+            foreach (var contractFile in Directory.GetFiles(directory, "*.hsmtest").OrderBy(x => x, StringComparer.Ordinal))
+            {
+                var contractName = Path.GetFileNameWithoutExtension(contractFile);
+
+                foreach (var testCase in ReadContractCases(contractFile))
+                    yield return new object[] { contractName + ":" + testCase.Key, testCase.Value };
+            }
+        }
+
         public static IEnumerable<object[]> CollectorMetaMustFailCases()
         {
             foreach (var contractFile in FindMetaContractFiles())
@@ -357,6 +384,16 @@ namespace HSMDataCollector.Tests
 
                 case "expect_payload_contains":
                     Assert.Contains(step.Arg(1), PayloadText(state.Sender.Values[int.Parse(step.Arg(0))]));
+                    break;
+
+                // Differential-fuzzer support: write every captured payload's canonical text,
+                // one per line (LF, UTF-8 no BOM) — byte-comparable with the native driver dump.
+                case "dump_payloads_to":
+                    var dumpLines = state.Sender.Values.Select(PayloadText).ToList();
+                    File.WriteAllText(
+                        ExpandTextToken(step.Arg(0)),
+                        dumpLines.Count == 0 ? string.Empty : string.Join("\n", dumpLines) + "\n",
+                        new UTF8Encoding(false));
                     break;
 
                 case "expect_registration_count":

--- a/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
+++ b/src/native/collector_spike/tests/hsm_collector_spike_tests.cpp
@@ -1286,6 +1286,36 @@ namespace
             return;
         }
 
+        if (action == "dump_payloads_to")
+        {
+            // Differential-fuzzer support: canonical payload texts, one per line, LF endings
+            // (binary mode defeats Windows CRLF translation) — byte-comparable with the C# dump.
+            Require(step.size() >= 2, "dump_payloads_to requires a file path");
+
+            std::ofstream output(step[1], std::ios::binary | std::ios::trunc);
+            Require(static_cast<bool>(output), "cannot open payload dump file");
+
+            const auto count = hsm_collector_sent_count(state.collector.value);
+            for (size_t i = 0; i < count; ++i)
+            {
+                // The spike's instant wire json carries a UnixTimeMs field the canonical C#
+                // text does not have — strip it so the dumps are byte-comparable.
+                auto line = SentJson(state.collector.value, i);
+                const std::string time_key = ",\"UnixTimeMs\":";
+                const auto time_field = line.find(time_key);
+                if (time_field != std::string::npos)
+                {
+                    auto end = time_field + time_key.size();
+                    while (end < line.size() && (line[end] == '-' || (line[end] >= '0' && line[end] <= '9')))
+                        ++end;
+                    line.erase(time_field, end - time_field);
+                }
+
+                output << line << '\n';
+            }
+            return;
+        }
+
         if (action == "expect_registration_count")
         {
             Require(step.size() >= 2, "expect_registration_count requires count");
@@ -2338,6 +2368,7 @@ namespace
             { "conformance_number_format_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "conformance_registration_contract", [](const std::string& path) { RunConformanceContract(path); } },
             { "meta_must_fail", [](const std::string& path) { RunConformanceContractExpectFailure(path); } },
+            { "conformance_fuzz", [](const std::string& path) { RunConformanceContract(path); } },
         };
 
         return tests;

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -135,6 +135,12 @@ into the per-case creation order of that sensor kind (0-based).
 | `set_sender_fail_next\|count` | next `count` data sends fail before recording; queue must re-enqueue |
 | `set_sender_hang` | every data send blocks until the stop path cancels it (dead transport) |
 
+### Tooling
+
+| Verb | Semantics |
+|---|---|
+| `dump_payloads_to\|file` | writes every captured payload's canonical text, one per line (LF, UTF-8, no BOM) — the differential fuzzer's byte-comparison channel (`scripts/fuzz-conformance.ps1`); the native driver strips its spike-internal `UnixTimeMs` field |
+
 ### Assertions
 
 `expect_*` verbs throw/assert on mismatch — a failing step fails the case.


### PR DESCRIPTION
Part of #1094 / epic #1093 — the **differential fuzzer** item.

## How it works

A seeded generator produces random operation sequences **as ordinary `.hsmtest` files** (reusing the whole harness, per the issue design), both drivers execute them, and the canonical payload dumps must agree **byte-for-byte**. On divergence the fixture is minimized by whole-line removal and saved to `tests/conformance/fuzz-repros/` together with both dumps — ready to become a permanent corpus fixture (parity-bug flow).

- **New verb `dump_payloads_to|file`** — canonical payload texts, one per line (LF/UTF-8/no-BOM). The native driver strips its spike-internal `UnixTimeMs`; bar `Open/CloseTimeMs` are neutralized by the comparator (wall-clock, not contract).
- **C# entry**: `Fuzz_fixture_executes` theory over `HSM_CONFORMANCE_FUZZ_DIR` (no-op sentinel when unset — zero impact on normal runs). **Native entry**: `conformance_fuzz`.
- **`scripts/fuzz-conformance.ps1`**: one managed run executes all generated fixtures (dotnet startup dominates), native replays each individually; minimization budget-capped.
- **Nightly lane** `conformance-fuzzer.yml`: cron + `workflow_dispatch` (seed defaults to the run number → fresh sequences every night), windows+ubuntu, repro artifacts on failure. Scheduled, not per-PR.

## Determinism constraints (baked into the generator)

Inert 60 s dispatcher (everything materializes on stop-flush); doubles ≤ 7 significant digits (where net48 `R`, .NET Core and the native shortest-round-trip formatter agree byte-for-byte); NaN/±Infinity only fed to bars (silently skipped — instant double adds throw); no rate/function sensors (wall-clock values); random stop/start cycling (instant drops while stopped, bars keep accumulating — both deterministic).

**Single-kind sensor population per case**: the DSL spec says sensor indexes are kind-relative, but the native driver currently indexes the flat creation order — mixed-kind cases are impossible until that's aligned (verified both directions locally; follow-up item).

## Verification

- Cross-driver dump protocol proven **byte-identical** on hand-written instant and bar smokes (incl. NaN-skip and `AwayFromZero` precision rounding) — both drivers run locally against the same fixtures.
- Full native ctest 55/55; C# conformance 176/176; gcc 11 build warning-free.
- The PowerShell runner is exercised via `workflow_dispatch` (PowerShell execution is denied in this dev session) — I'll trigger a manual run right after merge and watch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)