### PR TITLE
Fix differential fuzzer: stable-sort by path + windows-only lane

### DIFF
--- a/.github/workflows/conformance-fuzzer.yml
+++ b/.github/workflows/conformance-fuzzer.yml
@@ -20,11 +20,10 @@ on:
 
 jobs:
   fuzz:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    # windows-latest only: the differential fuzzer needs BOTH drivers, and the
+    # managed driver test project targets net48 — running it on Linux would need
+    # mono. The value is two DRIVERS, not two OSes, and both run on Windows.
+    runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
 
@@ -44,13 +43,12 @@ jobs:
           if (-not $seed) { $seed = '${{ github.run_number }}' }
           $iterations = '${{ github.event.inputs.iterations }}'
           if (-not $iterations) { $iterations = '40' }
-          $binary = if ($IsWindows) { 'build/native-spike/Release/hsm_collector_spike_tests.exe' } else { 'build/native-spike/hsm_collector_spike_tests' }
-          ./scripts/fuzz-conformance.ps1 -Seed ([int]$seed) -Iterations ([int]$iterations) -NativeTestBinary $binary
+          ./scripts/fuzz-conformance.ps1 -Seed ([int]$seed) -Iterations ([int]$iterations) -NativeTestBinary 'build/native-spike/Release/hsm_collector_spike_tests.exe'
 
       - name: Upload divergence repros
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: fuzz-repros-${{ matrix.os }}
+          name: fuzz-repros
           path: tests/conformance/fuzz-repros/
           if-no-files-found: ignore

--- a/scripts/fuzz-conformance.ps1
+++ b/scripts/fuzz-conformance.ps1
@@ -161,11 +161,24 @@ function Get-DumpLines {
     return $text -split "`n"
 }
 
+# Order WITHIN one sensor path is contractual (FIFO); order ACROSS paths is
+# explicitly unspecified (tests/conformance/README.md — "Inter-sensor flush
+# order is unspecified"). The bar stop-flush iterates a hash map whose order
+# differs between the C# Dictionary and the C++ std::unordered_map, so normalize
+# by a STABLE sort on Path (preserves each path's own subsequence) before the
+# positional compare — this still catches value/aggregation/formatting drift and
+# per-sensor ordering bugs, just not the non-contractual cross-sensor order.
+function Get-PathFromPayload {
+    param([string]$Line)
+    if ($Line -match '"Path":"([^"]*)"') { return $Matches[1] }
+    return ""
+}
+
 function Compare-Dumps {
     param([string]$ManagedDump, [string]$NativeDump)
 
-    $managed = Get-DumpLines $ManagedDump
-    $native = Get-DumpLines $NativeDump
+    $managed = @(Get-DumpLines $ManagedDump | Sort-Object -Stable { Get-PathFromPayload $_ })
+    $native = @(Get-DumpLines $NativeDump | Sort-Object -Stable { Get-PathFromPayload $_ })
 
     if ($managed.Count -ne $native.Count) {
         return "payload count: managed=$($managed.Count) native=$($native.Count)"
@@ -173,7 +186,7 @@ function Compare-Dumps {
 
     for ($i = 0; $i -lt $managed.Count; $i++) {
         if ($managed[$i] -cne $native[$i]) {
-            return "payload ${i}:`n  managed: $($managed[$i])`n  native:  $($native[$i])"
+            return "payload ${i} (after stable sort by path):`n  managed: $($managed[$i])`n  native:  $($native[$i])"
         }
     }
 

--- a/tests/conformance/README.md
+++ b/tests/conformance/README.md
@@ -139,7 +139,7 @@ into the per-case creation order of that sensor kind (0-based).
 
 | Verb | Semantics |
 |---|---|
-| `dump_payloads_to\|file` | writes every captured payload's canonical text, one per line (LF, UTF-8, no BOM) — the differential fuzzer's byte-comparison channel (`scripts/fuzz-conformance.ps1`); the native driver strips its spike-internal `UnixTimeMs` field |
+| `dump_payloads_to\|file` | writes every captured payload's canonical text, one per line (LF, UTF-8, no BOM) — the differential fuzzer's byte-comparison channel (`scripts/fuzz-conformance.ps1`); the native driver strips its spike-internal `UnixTimeMs` field. The fuzzer compares dumps after a **stable sort by `Path`** — order within one sensor is contractual (FIFO), order across sensors at a stop-flush is not (hash-map iteration). |
 
 ### Assertions
 


### PR DESCRIPTION
Follow-up to #1115. The first real fuzzer run (manual dispatch on master) did exactly its job and surfaced two harness issues — **neither is a collector bug**:

1. **Linux leg failed**: the managed driver test project targets net48 → needs mono on Linux. The fuzzer's value is two **drivers**, not two OSes, and both run on Windows. Lane restricted to `windows-latest`.
2. **Windows leg reported 5 'divergences' — all false positives**: the bar stop-flush iterates a hash map (C# `Dictionary` vs C++ `std::unordered_map`), so multi-sensor flushes emit in different orders. Inter-sensor flush order is **explicitly not contractual** (`tests/conformance/README.md`). The positional comparison was too strict; it now compares after a **stable sort by `Path`** — order within one sensor stays verified (FIFO is contractual), cross-sensor order is normalized away.

Verified: all 5 reported repros are byte-identical under the new comparison (multiset confirmed equal; stable-sort-by-path confirmed equal). README documents the normalization.

This is the parity-policy flow working as designed — the fuzzer found a divergence, I triaged it to a non-contractual ordering and fixed the oracle rather than the collectors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)