### PR TITLE
Fake-server E2E smoke lane (.NET leg) (#1094)

### DIFF
--- a/docs/initiatives/cpp-collector-port-spike.md
+++ b/docs/initiatives/cpp-collector-port-spike.md
@@ -696,6 +696,58 @@ second of scheduler stall to fake a pass (screened 20× both legs).
 Verification: managed meta 10/10 + full suite 464/464 green (9 skips
 pre-existing); MSVC ctest 53/53; gcc (WSL) meta 10/10.
 
+### 2026-06-12: #1094 wrap-up — DSL spec, parity matrix, fuzzer, mapping, E2E
+
+Closed out the remaining #1094 workstream items across six PRs (#1110 native
+CI lane, #1111 meta-suite, #1112 DSL spec + AGENTS policy, #1113
+number-format matrix, #1114 registration, #1115/#1117 differential fuzzer,
+#1116 inventory mapping + coverage script):
+
+- **DSL formalized** (`tests/conformance/README.md`): file format, text tokens,
+  canonical payload shapes, the full ~70-verb catalog, determinism/authoring
+  rules, versioning policy, driver contract, unsupported-marker mechanism.
+  AGENTS.md rule #9 makes conformance coverage a review gate.
+- **Number-format matrix**: the native serializer printed `setprecision(17)`
+  (0.1 → 0.10000000000000001) — invisible under tolerant compares. Rewrote
+  `DoubleJson` to .NET shortest-round-trip (`R`) semantics; pinned by an
+  exact-text matrix.
+- **Registration corpus**: AddOrUpdate (TTL ticks / unit / description /
+  EnumOptions, re-register on restart, immediate-while-running).
+- **Differential fuzzer**: seeded generator → both drivers → byte-compare
+  canonical dumps. Its first real run did its job — surfaced a false-positive
+  ordering divergence (bar stop-flush iterates a hash map; C# `Dictionary` vs
+  C++ `std::unordered_map`), triaged to the non-contractual inter-sensor flush
+  order and fixed the oracle (stable-sort by Path), not the collectors.
+  windows-only lane (managed driver is net48 → needs mono on Linux).
+- **Coverage mapping**: 49/261 inventory lines annotated with their owning
+  `fixture:case`, plus `scripts/conformance-coverage.ps1` that validates every
+  annotation against the corpus so the mapping can't rot.
+
+**Fake-server E2E smoke lane (#1094, .NET leg).** New
+`HSMDataCollector.IntegrationTests/.../FakeHsmServer.cs` +
+`FakeServerE2ETests.cs`: an in-process `HttpListener` Sensor API over real
+plaintext HTTP (no Docker, no TLS — `AllowPlaintextTransport`). Proves the
+real `HttpClient` stack end-to-end: the `Key`/`ClientName` auth headers and
+the serialized value reach the wire; a sensor registration arrives batched to
+`/commands`; `TestConnection` hits `/testConnection`; and an injected
+transient 503 is survived by the queue's **re-enqueue-on-non-success** path
+(the default Polly pipeline retries only exceptions, not 5xx — #1096 — but the
+package is re-enqueued and lands on a later collect cycle). 4 tests, ~3 s, no
+container. The **native leg is blocked on #1096** (the spike has no HTTP
+transport yet) — it joins this lane when the transport lands.
+
+**Clock seam (`advance_clock`) — deliberately deferred (`[decide]`).** The
+issue lists an injectable clock seam so TTL/bar-alignment scenarios avoid
+wall-clock sleeps. Assessed and deferred: it is a *production* change spanning
+`CollectorScheduler` (`Stopwatch.GetTimestamp`), `BarTimeHelper`
+(`DateTime.UtcNow`), the bar/rate sensors and the dedup window — the same
+scheduler that hosted the critical TickCount-wraparound silent-death bug —
+for **low marginal coverage**: the corpus is already deterministic without it
+(inert periods + flush-on-stop + immediate-first-post), bar alignment is
+already pinned, and the collector has no local TTL expiry (TTL is server-side,
+already pinned in `registration_contract`). Revisit when a scenario genuinely
+needs controllable time (e.g. server-side TTL expiry in the E2E lane).
+
 ## Cross-Cutting Port Invariants
 
 Behavioral invariants every port must uphold that are NOT expressible as

--- a/src/collector/HSMDataCollector.IntegrationTests/Helpers/FakeHsmServer.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Helpers/FakeHsmServer.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HSMDataCollector.IntegrationTests.Helpers
+{
+    /// <summary>
+    /// In-process fake HSM Sensor API over real plaintext HTTP (no Docker, no TLS): captures every
+    /// request the collector makes (path, method, headers, body) and can inject transient failures.
+    /// The collector talks to it through its normal HttpClient stack, so this exercises the real
+    /// serializer, headers, batching and retry/re-enqueue path end-to-end — the smoke layer of the
+    /// conformance strategy (epic #1093 / #1094), complementing the in-proc corpus and the
+    /// Dockerized real-server integration tests.
+    /// </summary>
+    public sealed class FakeHsmServer : IDisposable
+    {
+        private readonly HttpListener _listener = new HttpListener();
+        private readonly CancellationTokenSource _cts = new CancellationTokenSource();
+        private readonly ConcurrentQueue<CapturedRequest> _requests = new ConcurrentQueue<CapturedRequest>();
+        private readonly Task _loop;
+
+        // Data POSTs to fail with 503 before the first success (decremented per data request).
+        private int _failDataRequests;
+
+        public FakeHsmServer()
+        {
+            Port = GetFreeTcpPort();
+            // The collector posts to {address}:{port}/api/sensors/{endpoint}; a root prefix
+            // captures every endpoint (data, addOrUpdate, commands, testConnection, file).
+            _listener.Prefixes.Add($"http://localhost:{Port}/");
+            _listener.Start();
+            _loop = Task.Run(AcceptLoopAsync);
+        }
+
+        public int Port { get; }
+
+        public string ServerAddress => "http://localhost";
+
+        public IReadOnlyList<CapturedRequest> Requests => _requests.ToArray();
+
+        /// <summary>The next <paramref name="count"/> data POSTs answer 503; the collector must
+        /// re-enqueue and retry until they stop failing.</summary>
+        public void FailNextDataRequests(int count) => Interlocked.Exchange(ref _failDataRequests, count);
+
+        public IEnumerable<CapturedRequest> DataRequests =>
+            Requests.Where(r => r.Method == "POST"
+                                && !r.Path.EndsWith("/addOrUpdate", StringComparison.Ordinal)
+                                && !r.Path.EndsWith("/commands", StringComparison.Ordinal)
+                                && !r.Path.EndsWith("/testConnection", StringComparison.Ordinal));
+
+        private async Task AcceptLoopAsync()
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                HttpListenerContext context;
+                try
+                {
+                    context = await _listener.GetContextAsync().ConfigureAwait(false);
+                }
+                catch (Exception) when (_cts.IsCancellationRequested)
+                {
+                    return;
+                }
+                catch (HttpListenerException)
+                {
+                    return;
+                }
+
+                _ = Task.Run(() => Handle(context));
+            }
+        }
+
+        private void Handle(HttpListenerContext context)
+        {
+            var request = context.Request;
+            string body;
+            using (var reader = new StreamReader(request.InputStream, request.ContentEncoding))
+                body = reader.ReadToEnd();
+
+            var path = request.Url?.AbsolutePath ?? string.Empty;
+            var isData = request.HttpMethod == "POST"
+                         && !path.EndsWith("/addOrUpdate", StringComparison.Ordinal)
+                         && !path.EndsWith("/commands", StringComparison.Ordinal)
+                         && !path.EndsWith("/testConnection", StringComparison.Ordinal);
+
+            _requests.Enqueue(new CapturedRequest(
+                request.HttpMethod,
+                path,
+                request.Headers["Key"],
+                request.Headers["ClientName"],
+                body));
+
+            var statusCode = HttpStatusCode.OK;
+            if (isData && Interlocked.Decrement(ref _failDataRequests) >= 0)
+                statusCode = HttpStatusCode.ServiceUnavailable;
+            else if (isData)
+                Interlocked.Increment(ref _failDataRequests); // floor the counter at 0
+
+            try
+            {
+                context.Response.StatusCode = (int)statusCode;
+                context.Response.Close();
+            }
+            catch (HttpListenerException)
+            {
+                // client went away mid-response — irrelevant to the assertions
+            }
+        }
+
+        private static int GetFreeTcpPort()
+        {
+            var probe = new TcpListener(IPAddress.Loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+            return port;
+        }
+
+        public void Dispose()
+        {
+            _cts.Cancel();
+            try { _listener.Stop(); } catch { /* already stopped */ }
+            try { _loop.Wait(TimeSpan.FromSeconds(2)); } catch { /* loop already unwound */ }
+            _listener.Close();
+            _cts.Dispose();
+        }
+
+        public sealed class CapturedRequest
+        {
+            public CapturedRequest(string method, string path, string key, string clientName, string body)
+            {
+                Method = method;
+                Path = path;
+                Key = key;
+                ClientName = clientName;
+                Body = body;
+            }
+
+            public string Method { get; }
+            public string Path { get; }
+            public string Key { get; }
+            public string ClientName { get; }
+            public string Body { get; }
+        }
+    }
+}

--- a/src/collector/HSMDataCollector.IntegrationTests/Tests/FakeServerE2ETests.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Tests/FakeServerE2ETests.cs
@@ -1,0 +1,140 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using HSMDataCollector.Core;
+using HSMDataCollector.IntegrationTests.Helpers;
+using HSMDataCollector.Options;
+using Xunit;
+
+namespace HSMDataCollector.IntegrationTests.Tests
+{
+    /// <summary>
+    /// Fake-server E2E smoke lane (#1094): the collector runs as itself against an in-process
+    /// HTTP server over a real socket — no Docker, no TLS. Asserts on what actually reaches the
+    /// wire (auth headers, the serialized value) and the retry/re-enqueue path under injected
+    /// failures. These are deliberately few; the in-proc conformance corpus owns the broad
+    /// behavior matrix, this layer proves the real HttpClient stack is wired correctly.
+    /// The native collector joins this lane once it grows an HTTP transport (#1096).
+    /// </summary>
+    [Trait("Category", "Integration")]
+    [Trait("Category", "FakeServerE2E")]
+    public sealed class FakeServerE2ETests
+    {
+        private const string AccessKey = "fake-server-access-key";
+        private const string ClientName = "fake-server-client";
+
+        private static readonly TimeSpan Timeout = TimeSpan.FromSeconds(15);
+
+        private static CollectorOptions OptionsFor(FakeHsmServer server) => new CollectorOptions
+        {
+            ServerAddress = server.ServerAddress,
+            Port = server.Port,
+            AccessKey = AccessKey,
+            ClientName = ClientName,
+            AllowPlaintextTransport = true,
+            PackageCollectPeriod = TimeSpan.FromMilliseconds(500),
+        };
+
+        [Fact]
+        public async Task SentValue_ReachesServer_WithAuthHeadersAndPayload()
+        {
+            using var server = new FakeHsmServer();
+            using var collector = new DataCollector(OptionsFor(server));
+
+            await collector.Start();
+            var sensor = collector.CreateIntSensor("e2e/headers/int");
+            sensor.AddValue(31337);
+
+            var dataRequest = await WaitForAsync(
+                () => server.DataRequests.FirstOrDefault(r => r.Body.Contains("31337")),
+                r => r != null);
+
+            await collector.Stop();
+
+            Assert.Equal(AccessKey, dataRequest.Key);
+            Assert.Equal(ClientName, dataRequest.ClientName);
+            Assert.StartsWith("/api/sensors/", dataRequest.Path);
+            Assert.Contains("31337", dataRequest.Body);
+        }
+
+        [Fact]
+        public async Task SensorRegistration_ReachesServer_AsCommandWithPath()
+        {
+            using var server = new FakeHsmServer();
+            using var collector = new DataCollector(OptionsFor(server));
+
+            await collector.Start();
+            collector.CreateIntSensor("e2e/registration/int");
+
+            // A registration is an AddOrUpdateSensorRequest; the command queue batches commands
+            // and posts them to /commands (the single-item /addOrUpdate route is only used when a
+            // lone request is sent, not the batched queue path).
+            var registration = await WaitForAsync(
+                () => server.Requests.FirstOrDefault(r =>
+                    r.Path.EndsWith("/commands", StringComparison.Ordinal) && r.Body.Contains("e2e/registration/int")),
+                r => r != null);
+
+            await collector.Stop();
+
+            Assert.True(registration != null,
+                "No /commands request carried the registration. Paths seen: " + string.Join(", ", server.Requests.Select(r => r.Method + " " + r.Path)));
+            Assert.Equal(AccessKey, registration.Key);
+            Assert.Equal(ClientName, registration.ClientName);
+        }
+
+        [Fact]
+        public async Task TransientServerFailure_ValueEventuallyLands_ViaReEnqueue()
+        {
+            using var server = new FakeHsmServer();
+            // The default Polly pipeline retries only exceptions, not 5xx — but the queue
+            // re-enqueues a package whose send returned a non-success status, so the value
+            // survives a transient 503 and lands on a later collect cycle.
+            server.FailNextDataRequests(2);
+
+            using var collector = new DataCollector(OptionsFor(server));
+
+            await collector.Start();
+            var sensor = collector.CreateIntSensor("e2e/retry/int");
+            sensor.AddValue(4242);
+
+            // Eventually a data request with the value is answered 200 (the run records both the
+            // failed and the successful attempts; we only need the value to have reached the wire
+            // after the injected failures were consumed).
+            var landed = await WaitForAsync(
+                () => server.DataRequests.Count(r => r.Body.Contains("4242")),
+                count => count >= 3); // 2 failed attempts + at least one more
+
+            await collector.Stop();
+
+            Assert.True(landed >= 3, $"Expected the value to be retried past 2 injected failures, saw {landed} attempts.");
+        }
+
+        [Fact]
+        public async Task TestConnection_AgainstReachableServer_ReturnsOk()
+        {
+            using var server = new FakeHsmServer();
+            using var collector = new DataCollector(OptionsFor(server));
+
+            var result = await collector.TestConnection();
+
+            Assert.True(result.IsOk, $"Expected OK, got {result.Code}: {result.Error}");
+            Assert.Contains(server.Requests, r => r.Path.EndsWith("/testConnection", StringComparison.Ordinal));
+        }
+
+        // Polls a producer until the predicate holds or the timeout elapses, then returns the last
+        // value (so the caller's assertions produce a meaningful message on timeout).
+        private static async Task<T> WaitForAsync<T>(Func<T> produce, Func<T, bool> done)
+        {
+            var deadline = DateTime.UtcNow + Timeout;
+            var value = produce();
+
+            while (!done(value) && DateTime.UtcNow < deadline)
+            {
+                await Task.Delay(50).ConfigureAwait(false);
+                value = produce();
+            }
+
+            return value;
+        }
+    }
+}


### PR DESCRIPTION
Part of #1094 / epic #1093 — the **fake-server E2E smoke lane**, .NET leg.

## What

A lightweight in-process **`HttpListener` Sensor API over real plaintext HTTP** — no Docker, no TLS (uses the collector's `AllowPlaintextTransport` option). It captures every request the collector makes (path, method, `Key`/`ClientName` headers, body) and can inject transient failures. The collector talks to it through its normal `HttpClient` stack, so this exercises the real serializer, headers, batching and retry/re-enqueue **end-to-end** — the smoke layer that the in-proc conformance corpus and the Dockerized real-server integration tests don't cover (raw request inspection + fault injection).

**`FakeServerE2ETests`** (4 tests, ~3 s, no container):
- a sent value reaches the wire with the `Key`/`ClientName` auth headers and the serialized payload;
- a sensor registration arrives (batched to `/commands` — the queued command path, not the single-item `/addOrUpdate` route);
- `TestConnection` hits `/testConnection` and returns `Ok`;
- an **injected transient 503 is survived**: the default Polly pipeline retries only exceptions, not 5xx (#1096), but the queue re-enqueues a package whose send returned non-success, so the value lands on a later collect cycle.

## Scope notes

- **Native leg blocked on #1096**: the spike has no HTTP transport yet — it joins this lane when the transport lands (recorded in the spike journal).
- This is the **last in-scope #1094 item** I'm landing now. The **clock seam (`advance_clock`) is deliberately deferred** (`[decide]`, rationale in the journal): it's a production change to the scheduler/bar/rate/dedup time sources — the scheduler that hosted the TickCount-wraparound bug — for low marginal coverage, since the corpus is already deterministic without it and the collector has no local TTL expiry.

## Verification

4/4 green, flake-screened 3× (~3 s each, no Docker). Lands in the existing `HSMDataCollector.IntegrationTests` project; runs under the `collector-integration-tests` lane (the new tests need no container, so they also run fine standalone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)