### PR TITLE
Native core foundation: C ABI, lifecycle, scheduler, logging (#1095)

### DIFF
--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -1,9 +1,15 @@
 name: Native collector conformance
 
-# Builds the native C++ collector spike and runs the shared conformance corpus
+# Builds the native C++ collector core and runs the shared conformance corpus
 # (tests/conformance/collector/*.hsmtest) against it via ctest, on Windows and
 # Linux. The same corpus runs against the .NET collector in collector-unit-tests
 # (CollectorConformanceTests) — together they form the parity gate of epic #1093.
+#
+# Lanes (#1095 toolchain hardening):
+# - format-check : clang-format (pinned) must report no diff.
+# - native-conformance : MSVC + gcc, warnings-as-errors, the corpus via ctest.
+# - native-conformance-clang : the same on Linux clang (toolchain matrix).
+# - sanitizers : the suite under clang ASan+UBSan and TSan on Linux.
 
 on:
   push:
@@ -21,6 +27,25 @@ on:
   workflow_dispatch:
 
 jobs:
+  format-check:
+    # clang-format is pinned to the exact version the .clang-format config was
+    # authored against — minor versions disagree on formatting, so an unpinned
+    # runner clang-format would flag false diffs.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install clang-format
+        run: pip install clang-format==19.1.1
+      - name: Check formatting
+        run: |
+          clang-format --version
+          files=$(find src/native/collector \( -name '*.cpp' -o -name '*.h' -o -name '*.hpp' \))
+          echo "$files"
+          clang-format --dry-run --Werror $files
+
   native-conformance:
     # Skip on draft PRs only. Non-PR events (push/workflow_dispatch) have no
     # pull_request payload, so they must still run — hence the event_name guard.
@@ -34,7 +59,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Configure
-        run: cmake -S src/native/collector -B build/native-collector
+        run: cmake -S src/native/collector -B build/native-collector -DHSM_COLLECTOR_WERROR=ON
 
       - name: Build
         run: cmake --build build/native-collector --config Release --parallel
@@ -44,3 +69,40 @@ jobs:
       # - conformance_* fixtures — the shared .hsmtest corpus
       - name: Test
         run: ctest --test-dir build/native-collector -C Release --output-on-failure
+
+  native-conformance-clang:
+    # The toolchain matrix's clang leg (the default ubuntu lane above uses gcc).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    env:
+      CC: clang
+      CXX: clang++
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake -S src/native/collector -B build/native-clang -DHSM_COLLECTOR_WERROR=ON
+      - name: Build
+        run: cmake --build build/native-clang --parallel
+      - name: Test
+        run: ctest --test-dir build/native-clang --output-on-failure
+
+  sanitizers:
+    # ASan+UBSan and TSan on Linux clang. These exercise the multi-threaded
+    # scheduler/worker that the single-threaded corpus run cannot stress.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        preset: [asan, tsan]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure
+        run: cmake --preset ${{ matrix.preset }}
+        working-directory: src/native/collector
+      - name: Build
+        run: cmake --build --preset ${{ matrix.preset }}
+        working-directory: src/native/collector
+      - name: Test
+        run: ctest --preset ${{ matrix.preset }}
+        working-directory: src/native/collector

--- a/aicontext/features/collector/error-handling/feature.md
+++ b/aicontext/features/collector/error-handling/feature.md
@@ -58,6 +58,19 @@ DataCollector must never crash the host application. All exceptions from sensor 
 
 ---
 
+## Native port (C++)
+
+The native core (`src/native/collector`, #1095) mirrors the isolation + dedup contract:
+a swallow-all `InvokeIsolated` wrapper guards every host callback (lifecycle listeners,
+the pluggable log sink, function-sensor callbacks, the scheduler action) so a throwing
+one neither crosses the C ABI boundary nor breaks the collector; a `MessageDeduplicator`
+collapses repeated error messages within `exception_deduplicator_window_ms`
+(count-suffix flush, capacity + oldest-expiry eviction), and **zero window logs
+immediately** (the same regression-guarded contract). Error routing funnels validation
+drops and shutdown discards through the deduplicator to the C-ABI log sink. Verified by
+`native_logger_*` and `native_lifecycle_listener_exception_is_isolated` unit tests. C ABI:
+[`docs/native-collector-c-abi.md`](../../../../docs/native-collector-c-abi.md).
+
 ## Known Issues / Limitations
 
 - Deduplication is exact-string; messages differing only by timestamp/address are not grouped.

--- a/aicontext/features/collector/public-api/feature.md
+++ b/aicontext/features/collector/public-api/feature.md
@@ -36,6 +36,8 @@ Everything a host application touches: `DataCollector` construction, `CollectorO
 | `MaxDeduplicatedMessages` | int | `1000` | > 0 |
 | `MaxSensors` | int | `100000` | > 0 |
 
+**Native port (C++)**: `hsm_collector_options_t` (`src/native/collector`, #1095) mirrors this table field-for-field (`0` = managed default per field; the dedup window's `0` = log immediately). The C ABI also mirrors the lifecycle surface — status state machine, `dispose`, `TestConnection`, lifecycle listeners, `MaxSensors` cap — and a pluggable log sink. The `DataSender` seam is not exposed until the HTTP transport (#1096). Contract: [`docs/native-collector-c-abi.md`](../../../../docs/native-collector-c-abi.md).
+
 ## Lifecycle API
 
 Lifecycle state machine, gates, registration phases, event ordering, and the dispose-vs-stop race are documented in [`../overview.md`](../overview.md) (sections "Lifecycle", "Sensor registration", "Data gating", "Dispose racing Stop"). Public surface:

--- a/aicontext/features/collector/scheduling/feature.md
+++ b/aicontext/features/collector/scheduling/feature.md
@@ -47,6 +47,19 @@
 
 `CollectorSchedulerTests.cs`, `ScheduledTaskHandleTests.cs`, `CollectorTimerStressTests.cs` in `src/collector/HSMDataCollector.Tests/`.
 
+## Native port (C++)
+
+The native core (`src/native/collector`, #1095) mirrors this contract with a single
+per-collector `ScheduledTask` worker (the portable `ScheduledTaskHandle`): idempotent
+`Start`/`Stop`, bounded wait-for-current-run, a monotonic clock through an **injectable
+clock seam** (`Clock`/`RealClock`/`ManualClock`), event-driven sleep until the earliest
+periodic due-time (not a busy poll), no overlapping runs, whole-period catch-up, and
+`onError` isolation (a throwing function callback can neither kill the worker nor starve
+the other sensors). The seam routes the scheduler wait and the sensors' periodic
+due-check / rate elapsed; payload and bar timestamps keep the real wall clock (there are
+no conformance time-control verbs, by design). Verified by `native_scheduler_*` unit
+tests + the shared periodic conformance fixtures. C ABI: [`docs/native-collector-c-abi.md`](../../../../docs/native-collector-c-abi.md).
+
 ## Known Issues / Limitations
 
 - Linear scan within due buckets; fine for typical sensor counts (<1000 tasks).

--- a/docs/initiatives/cpp-collector-port-spike.md
+++ b/docs/initiatives/cpp-collector-port-spike.md
@@ -787,6 +787,47 @@ cost/benefit intact while satisfying the issue's structural ask); min standard
 stays **C++17**; sanitizer CI is **Linux clang ASan + TSan** required, Windows
 ASan nightly/opt-in.
 
+### 2026-06-15: #1095 native core foundation (one PR)
+
+Per user direction the whole of #1095 lands in one PR (toolchain + semantics),
+built on `codex/native-collector-infra` over several commits:
+
+- **Toolchain**: `.clang-format` (Microsoft/Allman, `ColumnLimit: 0` to preserve
+  the hand-wrapped C ABI), `HSM_COLLECTOR_WERROR`, `HSM_COLLECTOR_SANITIZER`
+  (ASan/TSan) + `CMakePresets.json`; CI lanes format-check (pinned clang-format
+  19.1.1), MSVC+gcc -Werror, Linux clang, and clang ASan/TSan.
+- **C ABI**: version macros + `hsm_collector_version()`; `hsm_collector_status_t`
+  + getter; the full 16-field `hsm_collector_options_t` mirror with validation
+  (Port 1..65535, non-negative numerics; `0` = managed default, dedup window `0`
+  = log-immediately); `dispose`, `test_connection`; lifecycle listeners; log sink.
+  Defaults now match managed CollectorOptions (1000/15000 ms) — the conformance
+  driver's `TestOptions` sets the small 50/20 ms test values explicitly.
+- **Lifecycle**: full state machine Stopped/Starting/Running/Stopping/Disposed +
+  the three gates; `op_mutex_` serializes Start/Stop/Dispose; `StopCore` shared
+  by Stop and Dispose so a dispose racing an in-flight stop joins it (exactly one
+  Stopped notification, terminal wins); exception-isolated lifecycle listeners;
+  MaxSensors cap + reject-during-Stopping/Disposed without crashing.
+- **Scheduler** (event-driven, the chosen shape over a full per-task wheel): a
+  single `ScheduledTask` worker sleeping until the earliest periodic due-time
+  through an injectable `Clock` seam (Real/Manual), no-overlap, whole-period
+  catch-up, onError isolation; `ScheduledTaskHandle`-equivalent idempotent
+  Start/Stop + bounded wait. The clock routes scheduling + rate elapsed; payload
+  and bar timestamps stay on the real clock (the #1094 clock-seam deferral's
+  cost/benefit is preserved — no new wall-clock fixtures).
+- **Logging**: pluggable C-ABI log sink (swallow-all), `MessageDeduplicator`
+  (window/capacity/oldest-expiry/count-suffix/zero-window), error routing
+  (shutdown discard → dedup → sink).
+- **Docs**: `docs/native-collector-c-abi.md` (the reviewed C ABI contract +
+  versioning/ABI-stability policy); aicontext scheduling/error-handling/public-api
+  carry native-port notes.
+
+New behaviors are proven by `native_*` unit tests (16 added: version/status/
+dispose/listeners/TestConnection/MaxSensors/options-validation/clock-seam/
+onError/dedup) — the cross-language corpus stays the regression net (69/69,
+warning-clean `/WX`; rate/function/bar_rollover + clock-seam flake-screened 30×).
+Test-only `hsm_collector_test_*` symbols are defined in the .cpp and
+forward-declared by the test TU, never in the public header.
+
 ## Cross-Cutting Port Invariants
 
 Behavioral invariants every port must uphold that are NOT expressible as

--- a/docs/native-collector-c-abi.md
+++ b/docs/native-collector-c-abi.md
@@ -1,0 +1,149 @@
+# Native collector C ABI
+
+The permanent interop boundary of the native collector (`src/native/collector`,
+epic #1093 / workstream #1095). Every non-C++ consumer — and the C++ wrapper
+itself — goes through the C header `include/hsm_collector/hsm_collector.h`. This
+document is the contract that header implements; it is the "C ABI doc" the #1095
+*Done-when* requires.
+
+## Design rules
+
+- **C linkage only.** Every entry point is `extern "C"`; no C++ types cross the
+  boundary. The implementation is C++ but compiles into one library that exports
+  only the `hsm_*` symbols.
+- **No exceptions cross the boundary.** Internally the core may use exceptions,
+  but every entry point catches and converts them to a result code. A C consumer
+  never sees a C++ exception. Host-supplied callbacks that throw are caught and
+  swallowed (see *Callback isolation*).
+- **Opaque handles.** `hsm_collector_t` and `hsm_sensor_t` are forward-declared
+  structs; their layout is private. Consumers hold pointers only.
+
+## Handles & ownership
+
+| Handle | Created by | Freed by | Notes |
+|---|---|---|---|
+| `hsm_collector_t*` | `hsm_collector_create` | `hsm_collector_destroy` | `hsm_collector_dispose` is the *graceful terminal transition*; `destroy` frees the handle. Call dispose then destroy, or just destroy. |
+| `hsm_sensor_t*` | `hsm_collector_create_*_sensor` | `hsm_sensor_release` | Releasing a sensor handle frees only the handle — the collector keeps the sensor registered and the scheduler keeps driving it until the collector is destroyed. |
+
+Out-parameters (`hsm_*_t** out_*`) are set to `NULL` on any failure, so a
+consumer can check the return code or the null handle interchangeably.
+
+## String ownership
+
+- **Inbound** strings (`const char*` arguments: paths, comments, options) are
+  borrowed for the duration of the call and copied internally as needed. The
+  caller keeps ownership and may free them after the call returns.
+- **Outbound** strings (`const char**` out-params from
+  `hsm_collector_get_sent_json` / `get_registration_json`, and
+  `hsm_collector_last_error`) point to storage **owned by the collector**. They
+  are valid until the next call that mutates the same collection (or until
+  destroy). The consumer must copy if it needs to retain them; it must not free
+  them.
+- `user_data` pointers passed to callbacks are stored verbatim and must
+  **outlive the collector** (not merely the sensor handle).
+
+## Error model
+
+`hsm_result_t`: `OK(0)`, `INVALID_ARGUMENT(1)`, `INVALID_STATE(2)`,
+`NOT_FOUND(3)`, `LIMIT_EXCEEDED(4)`, `INTERNAL_ERROR(255)`. On a non-OK result,
+`hsm_collector_last_error(collector)` returns a human-readable message for the
+most recent failed call on that collector (empty after a success).
+
+## Options & validation
+
+`hsm_collector_options_t` mirrors the managed `CollectorOptions`
+(`aicontext/features/collector/public-api/feature.md`). Each numeric field uses
+`0` to select the managed default; the dedup window's `0` is meaningful (log
+immediately). `hsm_collector_create` validates:
+
+- `access_key` / `server_address` required, non-blank → else `INVALID_ARGUMENT`.
+- `port` in `1..65535` → else `INVALID_ARGUMENT`.
+- every numeric field `>= 0` (negative → `INVALID_ARGUMENT`).
+
+The `DataSender` transport seam is **not** exposed here — it arrives with the
+HTTP transport (#1096). Until then the collector records sent payloads in memory.
+
+## Lifecycle
+
+State machine (mirrors the managed `CollectorStatus`):
+
+```
+Stopped --start--> Starting --(init)--> Running --stop--> Stopping --> Stopped
+Any-except-Disposed --dispose--> Disposed (terminal)
+```
+
+- `hsm_collector_start` / `_stop` are idempotent; both return `OK` when already
+  in the target state. Start/stop on a `Disposed` collector → `INVALID_STATE`.
+- `hsm_collector_dispose` is terminal, idempotent and never fails. From an active
+  state it performs the stop (firing the `Stopping`/`Stopped` notifications), then
+  moves to `Disposed`. A dispose racing an in-flight stop joins that stop rather
+  than duplicating it — exactly one `Stopped` notification fires, and the terminal
+  mode wins.
+- `hsm_collector_status` reports the current state from any thread.
+- `hsm_collector_test_connection` is callable in any state; OK when the sender is
+  reachable (always, for the in-memory sender), `INVALID_STATE` once disposed.
+
+**Gates** (same phase table as the managed collector): data is accepted while
+`Starting`/`Running`/`Stopping` and dropped otherwise; new sensors start (and
+register) immediately only while `Starting`/`Running`; registration is rejected
+(without crashing, returning a null handle) while `Stopping`/`Disposed`.
+
+**Registration** is idempotent by path (a duplicate returns the existing handle),
+rejects a type conflict (`INVALID_ARGUMENT`), and is capped at `max_sensors`
+(`LIMIT_EXCEEDED`).
+
+## Lifecycle listeners
+
+`hsm_collector_add_lifecycle_listener` registers a
+`hsm_lifecycle_callback_t(status, user_data)` invoked after each transition
+(`Starting`/`Running`/`Stopping`/`Stopped`; never `Disposed`). Only transitions
+after registration are delivered. The portable equivalent of the managed
+`ILifecycleListener`.
+
+## Logging & deduplication
+
+`hsm_collector_set_logger` installs a `hsm_log_callback_t(level, message,
+user_data)` sink (`DEBUG`/`INFO`/`ERROR`). Error messages pass through the
+`MessageDeduplicator` first: within `exception_deduplicator_window_ms`, repeats
+of the same message are collapsed and re-emitted with an `(N suppressed)` suffix;
+a window of `0` logs every message immediately. The cache is bounded by
+`max_deduplicated_messages` (oldest-expiry eviction). Passing a `NULL` callback
+clears the sink.
+
+## Callback isolation (host-crash safety)
+
+Every host-supplied callback — lifecycle listeners, the log sink, function-sensor
+callbacks, the scheduler's per-task action — is invoked through a swallow-all
+wrapper: a throwing or crashing callback can neither cross the C ABI boundary nor
+break the collector (other listeners still fire, the scheduler loop keeps
+running). This is the C-ABI face of the cross-cutting invariant tracked in
+`docs/initiatives/cpp-collector-port-spike.md`.
+
+## Threading
+
+- Sensor value methods (`hsm_sensor_add_*`) are safe to call from any thread.
+- Lifecycle calls (`start`/`stop`/`dispose`) should be driven from one thread or
+  serialized; they serialize internally so a dispose racing a stop is safe.
+- The collector owns one scheduler worker (a single `ScheduledTask`) that sleeps
+  until the earliest periodic due-time, read through an injectable monotonic clock
+  (the clock seam). Periodic posts have no overlapping runs and catch up by whole
+  periods.
+
+## Versioning & ABI stability
+
+`hsm_collector_version()` returns the packed `HSM_COLLECTOR_VERSION`
+(`MAJOR*10000 + MINOR*100 + PATCH`), letting a consumer built against one header
+check the linked library at runtime.
+
+Policy:
+
+- **MINOR** — additive, backward-compatible growth: new functions, or new fields
+  **appended** to the end of `hsm_collector_options_t` (zero-initialized struct
+  stays valid because `0` means "managed default").
+- **MAJOR** — any breaking change: reordering/removing a field, changing a
+  result-code meaning, or changing a documented behavior.
+- **PATCH** — implementation-only fixes with no surface change.
+
+Test-only symbols prefixed `hsm_collector_test_*` are **not** part of the ABI;
+they are intentionally omitted from the public header and are linked only by the
+native test binary.

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestFeature"
+  }
+}

--- a/src/native/collector/.clang-format
+++ b/src/native/collector/.clang-format
@@ -1,0 +1,23 @@
+# Formatting for the native collector core (epic #1093 / #1095).
+# Matches the existing hand-written style: Allman braces, 4-space indent,
+# indented namespace bodies, left-aligned pointers, braced-init with inner
+# spaces. Enforced in CI by `clang-format --dry-run --Werror`.
+Language: Cpp
+BasedOnStyle: Microsoft
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+# 0 disables column-based reflow: the hand-written one-argument-per-line
+# wrapping (especially in the C ABI header) is clearer than clang-format's
+# column packing, so we only normalize braces / indentation / spacing.
+ColumnLimit: 0
+NamespaceIndentation: All
+IndentExternBlock: NoIndent
+PointerAlignment: Left
+Cpp11BracedListStyle: false
+IndentCaseLabels: false
+AccessModifierOffset: -4
+AllowShortLambdasOnASingleLine: All
+AllowShortFunctionsOnASingleLine: Inline
+FixNamespaceComments: true
+SortIncludes: false

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -25,12 +25,52 @@ project(HsmCollectorNative LANGUAGES CXX)
 # toolchains (gcc without -pthread links but may crash at runtime).
 find_package(Threads REQUIRED)
 
+# Treat warnings as errors (off by default so local dev is not blocked; CI
+# turns it on). The corpus + unit tests must build warning-clean under it.
+option(HSM_COLLECTOR_WERROR "Treat compiler warnings as errors" OFF)
+
+# Build with a sanitizer: "address" (ASan+UBSan) or "thread" (TSan). Empty =
+# none. Driven by the CMakePresets asan/tsan presets and the sanitized CI lane.
+# MSVC supports only address; clang/gcc support both.
+set(HSM_COLLECTOR_SANITIZER "" CACHE STRING "Sanitizer: address, thread, or empty")
+set_property(CACHE HSM_COLLECTOR_SANITIZER PROPERTY STRINGS "" "address" "thread")
+
 # Warning flags shared by every first-party target we compile.
 function(hsm_collector_set_warnings target)
     if(MSVC)
         target_compile_options(${target} PRIVATE /W4 /permissive-)
+        if(HSM_COLLECTOR_WERROR)
+            target_compile_options(${target} PRIVATE /WX)
+        endif()
     else()
         target_compile_options(${target} PRIVATE -Wall -Wextra -Wpedantic)
+        if(HSM_COLLECTOR_WERROR)
+            target_compile_options(${target} PRIVATE -Werror)
+        endif()
+    endif()
+endfunction()
+
+# Apply the selected sanitizer to a first-party target (compile + link).
+function(hsm_collector_apply_sanitizer target)
+    if(HSM_COLLECTOR_SANITIZER STREQUAL "")
+        return()
+    endif()
+
+    if(MSVC)
+        if(NOT HSM_COLLECTOR_SANITIZER STREQUAL "address")
+            message(FATAL_ERROR "MSVC supports only the address sanitizer (got '${HSM_COLLECTOR_SANITIZER}')")
+        endif()
+        target_compile_options(${target} PRIVATE /fsanitize=address)
+    else()
+        if(HSM_COLLECTOR_SANITIZER STREQUAL "address")
+            set(flags -fsanitize=address,undefined -fno-sanitize-recover=all)
+        elseif(HSM_COLLECTOR_SANITIZER STREQUAL "thread")
+            set(flags -fsanitize=thread)
+        else()
+            message(FATAL_ERROR "Unknown HSM_COLLECTOR_SANITIZER '${HSM_COLLECTOR_SANITIZER}' (use address or thread)")
+        endif()
+        target_compile_options(${target} PRIVATE ${flags} -fno-omit-frame-pointer -g)
+        target_link_options(${target} PRIVATE ${flags})
     endif()
 endfunction()
 
@@ -48,6 +88,7 @@ target_compile_features(hsm_collector_core PUBLIC cxx_std_17)
 target_link_libraries(hsm_collector_core PUBLIC Threads::Threads)
 
 hsm_collector_set_warnings(hsm_collector_core)
+hsm_collector_apply_sanitizer(hsm_collector_core)
 
 # Header-only C++ RAII wrapper over the C ABI.
 add_library(hsm_collector_cpp INTERFACE)
@@ -68,6 +109,7 @@ add_executable(hsm_collector_tests
 target_link_libraries(hsm_collector_tests PRIVATE hsm_collector_core)
 
 hsm_collector_set_warnings(hsm_collector_tests)
+hsm_collector_apply_sanitizer(hsm_collector_tests)
 
 enable_testing()
 

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -153,6 +153,7 @@ set(NATIVE_REGRESSION_TESTS
     native_dispose_from_running_stops
     native_lifecycle_listener_receives_transitions
     native_lifecycle_listener_exception_is_isolated
+    native_lifecycle_listener_can_register_another_listener
     native_test_connection_reports_reachable
     native_max_sensors_cap_rejects_beyond_limit
     native_create_rejects_negative_option_fields

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -157,6 +157,10 @@ set(NATIVE_REGRESSION_TESTS
     native_max_sensors_cap_rejects_beyond_limit
     native_create_rejects_negative_option_fields
     native_logger_sink_can_be_set_and_cleared
+    native_scheduler_clock_seam_drives_periodic_posts
+    native_scheduler_on_error_isolates_throwing_callback
+    native_logger_deduplicates_repeated_errors_within_window
+    native_logger_zero_window_logs_every_error
 )
 
 foreach(name IN LISTS NATIVE_REGRESSION_TESTS)

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -147,6 +147,16 @@ set(NATIVE_REGRESSION_TESTS
     native_double_negative_infinity_is_rejected_and_not_sent
     native_invalid_status_on_instant_value_is_rejected_and_not_sent
     native_invalid_status_on_last_value_preserves_previous_snapshot
+    native_version_matches_macro
+    native_status_tracks_lifecycle
+    native_dispose_is_terminal_and_idempotent
+    native_dispose_from_running_stops
+    native_lifecycle_listener_receives_transitions
+    native_lifecycle_listener_exception_is_isolated
+    native_test_connection_reports_reachable
+    native_max_sensors_cap_rejects_beyond_limit
+    native_create_rejects_negative_option_fields
+    native_logger_sink_can_be_set_and_cleared
 )
 
 foreach(name IN LISTS NATIVE_REGRESSION_TESTS)

--- a/src/native/collector/CMakePresets.json
+++ b/src/native/collector/CMakePresets.json
@@ -1,0 +1,60 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": { "major": 3, "minor": 21, "patch": 0 },
+  "configurePresets": [
+    {
+      "name": "debug",
+      "displayName": "Debug (warnings as errors)",
+      "binaryDir": "${sourceDir}/build/debug",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "HSM_COLLECTOR_WERROR": "ON"
+      }
+    },
+    {
+      "name": "release",
+      "displayName": "Release (warnings as errors)",
+      "binaryDir": "${sourceDir}/build/release",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "HSM_COLLECTOR_WERROR": "ON"
+      }
+    },
+    {
+      "name": "asan",
+      "displayName": "Clang AddressSanitizer + UBSan",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/asan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "HSM_COLLECTOR_SANITIZER": "address",
+        "HSM_COLLECTOR_WERROR": "ON"
+      }
+    },
+    {
+      "name": "tsan",
+      "displayName": "Clang ThreadSanitizer",
+      "generator": "Unix Makefiles",
+      "binaryDir": "${sourceDir}/build/tsan",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "HSM_COLLECTOR_SANITIZER": "thread",
+        "HSM_COLLECTOR_WERROR": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    { "name": "debug", "configurePreset": "debug" },
+    { "name": "release", "configurePreset": "release" },
+    { "name": "asan", "configurePreset": "asan" },
+    { "name": "tsan", "configurePreset": "tsan" }
+  ],
+  "testPresets": [
+    { "name": "asan", "configurePreset": "asan", "output": { "outputOnFailure": true } },
+    { "name": "tsan", "configurePreset": "tsan", "output": { "outputOnFailure": true } }
+  ]
+}

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -67,9 +67,11 @@ typedef enum hsm_sensor_type_t
 
 /* User callbacks for function sensors. Invoked on the collector's scheduler thread OUTSIDE any
    collector/sensor lock (re-entering the same sensor from a callback is safe); they must not
-   throw across the C ABI boundary. LIFETIME: `user_data` must outlive the COLLECTOR, not just
-   the sensor handle — hsm_sensor_release frees only the handle, the collector keeps the sensor
-   registered and the scheduler keeps invoking the callback until the collector is destroyed. */
+   throw across the C ABI boundary, and must NOT call a collector lifecycle method
+   (start/stop/dispose) — doing so from the scheduler thread would join that thread on itself.
+   LIFETIME: `user_data` must outlive the COLLECTOR, not just the sensor handle —
+   hsm_sensor_release frees only the handle, the collector keeps the sensor registered and the
+   scheduler keeps invoking the callback until the collector is destroyed. */
 typedef int32_t (*hsm_int_function_t)(void* user_data);
 typedef int32_t (*hsm_int_values_function_t)(const int32_t* values, int32_t count, void* user_data);
 
@@ -145,8 +147,10 @@ hsm_result_t hsm_collector_test_connection(hsm_collector_t* collector);
    fires on the thread driving the transition, under the lifecycle lock, AFTER
    the status changes; only transitions after registration are delivered (no
    replay). A throwing/crashing callback is isolated — it can neither cross the
-   C ABI boundary nor break the collector. `user_data` must outlive the
-   collector. NULL callback unregisters nothing (returns INVALID_ARGUMENT). */
+   C ABI boundary nor break the collector. The callback may read collector state
+   and may add another listener, but must NOT call a lifecycle method
+   (start/stop/dispose) — that thread already holds the lifecycle lock.
+   `user_data` must outlive the collector. NULL callback returns INVALID_ARGUMENT. */
 typedef void (*hsm_lifecycle_callback_t)(hsm_collector_status_t status, void* user_data);
 hsm_result_t hsm_collector_add_lifecycle_listener(
     hsm_collector_t* collector,

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -82,7 +82,7 @@ typedef int32_t (*hsm_int_values_function_t)(const int32_t* values, int32_t coun
 typedef struct hsm_collector_options_t
 {
     /* Connection. */
-    const char* access_key;    /* required, non-blank */
+    const char* access_key;     /* required, non-blank */
     const char* server_address; /* required, non-blank */
     int32_t port;               /* 1..65535 */
     const char* client_name;    /* may be NULL */

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -9,6 +9,16 @@ extern "C"
 {
 #endif
 
+/* ABI version. Bumped per the policy in docs/native-collector-c-abi.md: MINOR
+   for additive, backward-compatible growth (new functions, struct fields
+   appended); MAJOR for any breaking change (field reorder/removal, semantic
+   change). hsm_collector_version() returns the packed value at runtime. */
+#define HSM_COLLECTOR_VERSION_MAJOR 0
+#define HSM_COLLECTOR_VERSION_MINOR 2
+#define HSM_COLLECTOR_VERSION_PATCH 0
+#define HSM_COLLECTOR_VERSION \
+    ((HSM_COLLECTOR_VERSION_MAJOR * 10000) + (HSM_COLLECTOR_VERSION_MINOR * 100) + HSM_COLLECTOR_VERSION_PATCH)
+
 typedef struct hsm_collector_t hsm_collector_t;
 typedef struct hsm_sensor_t hsm_sensor_t;
 
@@ -18,8 +28,21 @@ typedef enum hsm_result_t
     HSM_RESULT_INVALID_ARGUMENT = 1,
     HSM_RESULT_INVALID_STATE = 2,
     HSM_RESULT_NOT_FOUND = 3,
+    HSM_RESULT_LIMIT_EXCEEDED = 4,
     HSM_RESULT_INTERNAL_ERROR = 255
 } hsm_result_t;
+
+/* Collector lifecycle status. Mirrors the managed CollectorStatus state machine
+   (overview.md "Lifecycle"): Stopped -> Starting -> Running -> Stopping ->
+   Stopped, and Any-except-Disposed -> Disposed (terminal). */
+typedef enum hsm_collector_status_t
+{
+    HSM_COLLECTOR_STATUS_STOPPED = 0,
+    HSM_COLLECTOR_STATUS_STARTING = 1,
+    HSM_COLLECTOR_STATUS_RUNNING = 2,
+    HSM_COLLECTOR_STATUS_STOPPING = 3,
+    HSM_COLLECTOR_STATUS_DISPOSED = 4
+} hsm_collector_status_t;
 
 typedef enum hsm_sensor_status_t
 {
@@ -50,27 +73,99 @@ typedef enum hsm_sensor_type_t
 typedef int32_t (*hsm_int_function_t)(void* user_data);
 typedef int32_t (*hsm_int_values_function_t)(const int32_t* values, int32_t count, void* user_data);
 
+/* Mirrors the managed CollectorOptions (public-api/feature.md). Every numeric
+   field uses 0 to mean "take the managed default" shown in [brackets]; pass an
+   explicit value to override. Validation (hsm_collector_create) rejects a blank
+   access_key/server_address, a port outside 1..65535, and any negative numeric
+   field. The DataSender transport seam is not exposed here — it arrives with the
+   HTTP transport (#1096). */
 typedef struct hsm_collector_options_t
 {
-    const char* access_key;
-    const char* server_address;
-    int32_t port;
-    const char* module;
-    const char* computer_name;
-    /* Send-queue limits; 0 selects the default (20000 / 50 / 20ms — same as the C# collector
-       conformance defaults). The queue evicts its oldest value when max_queue_size is exceeded. */
-    int32_t max_queue_size;
-    int32_t max_values_in_package;
-    int32_t package_collect_period_ms;
+    /* Connection. */
+    const char* access_key;    /* required, non-blank */
+    const char* server_address; /* required, non-blank */
+    int32_t port;               /* 1..65535 */
+    const char* client_name;    /* may be NULL */
+    const char* module;         /* path prefix; may be NULL/blank */
+    const char* computer_name;  /* path prefix; may be NULL/blank */
+
+    /* Pipeline. The queue evicts its oldest value when max_queue_size is exceeded.
+       NOTE: the managed package/period defaults dispatch every 15 s; the
+       conformance harness sets a small package/period explicitly so the corpus
+       stays fast — the 0-default here is the production value, not the test one. */
+    int32_t max_queue_size;            /* [20000]  > 0 */
+    int32_t max_values_in_package;     /* [1000]   > 0 */
+    int32_t package_collect_period_ms; /* [15000]  > 0 */
+    int32_t request_timeout_ms;        /* [30000]  > 0 */
+    int32_t max_sensors;               /* [100000] > 0 — registration cap */
+
+    /* Transport flags (consumed once the HTTP sender lands, #1096). */
+    bool allow_untrusted_server_certificate; /* [false] */
+    bool allow_plaintext_transport;          /* [false] */
+
+    /* Error deduplication (see hsm_collector_set_logger). A window of 0 logs
+       every message immediately with no dedup. */
+    int64_t exception_deduplicator_window_ms; /* [3600000] >= 0 */
+    int32_t max_deduplicated_messages;        /* [1000]    > 0 */
 } hsm_collector_options_t;
+
+/* Packed ABI version (see HSM_COLLECTOR_VERSION). Lets a consumer built against
+   one header verify the linked library is compatible. */
+int32_t hsm_collector_version(void);
 
 hsm_result_t hsm_collector_create(const hsm_collector_options_t* options, hsm_collector_t** out_collector);
 void hsm_collector_destroy(hsm_collector_t* collector);
 
-/* Lifecycle calls are NOT safe under concurrent invocation: drive Start/Stop/destroy from one
-   thread (or serialize externally) — same assumption as the managed collector's lifecycle gate. */
+/* Start/Stop should be driven from one thread (or serialized externally), same
+   assumption as the managed collector. Both are idempotent: Start while Running
+   and Stop while Stopped are no-ops returning OK. Start/Stop on a Disposed
+   collector are rejected with HSM_RESULT_INVALID_STATE. */
 hsm_result_t hsm_collector_start(hsm_collector_t* collector);
 hsm_result_t hsm_collector_stop(hsm_collector_t* collector);
+
+/* Current lifecycle status. Safe to call from any thread/state. */
+hsm_collector_status_t hsm_collector_status(const hsm_collector_t* collector);
+
+/* Dispose: terminal and idempotent, never fails, callable from any thread/state.
+   Stops the collector if it is running — joining an in-flight Stop on another
+   thread rather than issuing a duplicate, so exactly one stopped-notification
+   fires and the terminal mode wins — then moves to Disposed. After dispose,
+   create/start/stop/registration are rejected without crashing the host.
+   destroy() still frees the handle; dispose() is the graceful terminal
+   transition and may be called before destroy(). */
+void hsm_collector_dispose(hsm_collector_t* collector);
+
+/* TestConnection: callable in any lifecycle state (mirrors the managed
+   ConnectionResult.IsOk). Returns OK when the sender reports the server
+   reachable. Until the HTTP transport lands (#1096) the in-memory sender always
+   reports reachable. */
+hsm_result_t hsm_collector_test_connection(hsm_collector_t* collector);
+
+/* Lifecycle observer (portable ILifecycleListener equivalent). The callback
+   fires on the thread driving the transition, under the lifecycle lock, AFTER
+   the status changes; only transitions after registration are delivered (no
+   replay). A throwing/crashing callback is isolated — it can neither cross the
+   C ABI boundary nor break the collector. `user_data` must outlive the
+   collector. NULL callback unregisters nothing (returns INVALID_ARGUMENT). */
+typedef void (*hsm_lifecycle_callback_t)(hsm_collector_status_t status, void* user_data);
+hsm_result_t hsm_collector_add_lifecycle_listener(
+    hsm_collector_t* collector,
+    hsm_lifecycle_callback_t callback,
+    void* user_data);
+
+/* Pluggable log sink. Levels mirror the managed ICollectorLogger (debug/info/
+   error). The callback is wrapped swallow-all: an exception escaping it is
+   caught and dropped (a broken logger must never break the collector). Error
+   messages pass through the MessageDeduplicator first (window/capacity from the
+   options). Passing a NULL callback clears the sink. */
+typedef enum hsm_log_level_t
+{
+    HSM_LOG_LEVEL_DEBUG = 0,
+    HSM_LOG_LEVEL_INFO = 1,
+    HSM_LOG_LEVEL_ERROR = 2
+} hsm_log_level_t;
+typedef void (*hsm_log_callback_t)(hsm_log_level_t level, const char* message, void* user_data);
+hsm_result_t hsm_collector_set_logger(hsm_collector_t* collector, hsm_log_callback_t callback, void* user_data);
 
 hsm_result_t hsm_collector_create_int_sensor(
     hsm_collector_t* collector,

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -22,7 +22,18 @@ extern "C"
 typedef struct hsm_collector_t hsm_collector_t;
 typedef struct hsm_sensor_t hsm_sensor_t;
 
-typedef enum hsm_result_t
+/* Fixed underlying type so ANY int value is a valid object representation. The C ABI
+   receives untrusted integers for enum-typed parameters (e.g. a caller passing a bad
+   sensor status) and validates them at runtime; without a fixed type, merely loading an
+   out-of-range value would be UB (caught by -fsanitize=enum). C++ and C23 support the
+   syntax; older C is int-compatible already, so it falls back to a plain enum. */
+#if defined(__cplusplus) || (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 202311L)
+#define HSM_ENUM_INT32 : int32_t
+#else
+#define HSM_ENUM_INT32
+#endif
+
+typedef enum hsm_result_t HSM_ENUM_INT32
 {
     HSM_RESULT_OK = 0,
     HSM_RESULT_INVALID_ARGUMENT = 1,
@@ -35,7 +46,7 @@ typedef enum hsm_result_t
 /* Collector lifecycle status. Mirrors the managed CollectorStatus state machine
    (overview.md "Lifecycle"): Stopped -> Starting -> Running -> Stopping ->
    Stopped, and Any-except-Disposed -> Disposed (terminal). */
-typedef enum hsm_collector_status_t
+typedef enum hsm_collector_status_t HSM_ENUM_INT32
 {
     HSM_COLLECTOR_STATUS_STOPPED = 0,
     HSM_COLLECTOR_STATUS_STARTING = 1,
@@ -44,7 +55,7 @@ typedef enum hsm_collector_status_t
     HSM_COLLECTOR_STATUS_DISPOSED = 4
 } hsm_collector_status_t;
 
-typedef enum hsm_sensor_status_t
+typedef enum hsm_sensor_status_t HSM_ENUM_INT32
 {
     HSM_SENSOR_STATUS_OFF_TIME = 0,
     HSM_SENSOR_STATUS_OK = 1,
@@ -52,7 +63,7 @@ typedef enum hsm_sensor_status_t
     HSM_SENSOR_STATUS_ERROR = 3
 } hsm_sensor_status_t;
 
-typedef enum hsm_sensor_type_t
+typedef enum hsm_sensor_type_t HSM_ENUM_INT32
 {
     HSM_SENSOR_TYPE_BOOLEAN = 0,
     HSM_SENSOR_TYPE_INT = 1,
@@ -162,7 +173,7 @@ hsm_result_t hsm_collector_add_lifecycle_listener(
    caught and dropped (a broken logger must never break the collector). Error
    messages pass through the MessageDeduplicator first (window/capacity from the
    options). Passing a NULL callback clears the sink. */
-typedef enum hsm_log_level_t
+typedef enum hsm_log_level_t HSM_ENUM_INT32
 {
     HSM_LOG_LEVEL_DEBUG = 0,
     HSM_LOG_LEVEL_INFO = 1,

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -5,7 +5,8 @@
 #include <stdint.h>
 
 #ifdef __cplusplus
-extern "C" {
+extern "C"
+{
 #endif
 
 typedef struct hsm_collector_t hsm_collector_t;

--- a/src/native/collector/include/hsm_collector/hsm_collector.hpp
+++ b/src/native/collector/include/hsm_collector/hsm_collector.hpp
@@ -179,4 +179,4 @@ namespace hsm::collector
 
         hsm_collector_t* handle_ = nullptr;
     };
-}
+} // namespace hsm::collector

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -331,8 +331,14 @@ namespace
                     continue;
                 }
 
-                const auto wait = std::chrono::milliseconds(std::min<int64_t>(due - now, kMaxWaitMs));
-                cv_.wait_for(lock, wait, [this] { return stop_; });
+                // due > now here. Guard the subtraction against overflow when due is the
+                // "nothing scheduled" sentinel (int64_max) or the (virtual) clock is far
+                // negative — just cap the sleep at kMaxWaitMs.
+                int64_t wait_ms = kMaxWaitMs;
+                if (due < (std::numeric_limits<int64_t>::max)())
+                    wait_ms = std::min<int64_t>(due - now, kMaxWaitMs);
+
+                cv_.wait_for(lock, std::chrono::milliseconds(wait_ms), [this] { return stop_; });
             }
         }
 
@@ -873,10 +879,14 @@ namespace
               max_deduplicated_messages_(options.max_deduplicated_messages > 0 ? options.max_deduplicated_messages : 1000)
         {
             // The scheduler reads time through clock_ (swappable before Start via SetClock) and
-            // wakes at the earliest periodic due-time. Lock order is task -> collector: the
-            // due/now callbacks lock the collector mutex, never the reverse.
+            // wakes at the earliest periodic due-time. Lock order is task -> collector: BOTH the
+            // now and due callbacks lock the collector mutex (never the reverse), so clock_ is
+            // never read unlocked even if a caller swaps it.
             scheduler_task_ = std::make_unique<ScheduledTask>(
-                [this] { return clock_->SteadyNowMs(); },
+                [this] {
+                    std::lock_guard<std::mutex> guard(mutex_);
+                    return clock_->SteadyNowMs();
+                },
                 [this] { return EarliestNextPostMs(); },
                 [this] { TickPeriodicSensors(); });
         }
@@ -936,6 +946,13 @@ namespace
         {
             std::lock_guard<std::mutex> op_guard(op_mutex_);
 
+            // The state flip to Starting AND the registration snapshot happen under one lock:
+            // otherwise a CreateSensor interleaving between them would be both in this snapshot
+            // and self-register via RegisterSensorLocked (Starting qualifies), double-counting
+            // its AddOrUpdate. Every start re-registers every sensor (mirrors C# InitAsync).
+            // RegistrationJson is immutable, so reading it under the collector lock keeps the
+            // one-way lock order. Map iteration order is unspecified — fixtures assert counts.
+            std::vector<std::shared_ptr<NativeSensor>> sensors_snapshot;
             {
                 std::lock_guard<std::mutex> guard(mutex_);
 
@@ -950,17 +967,7 @@ namespace
 
                 state_ = CollectorState::Starting;
                 ClearError();
-            }
 
-            NotifyLifecycle(CollectorState::Starting);
-
-            // Every start re-registers every sensor (mirrors C# InitAsync sending the
-            // AddOrUpdate command per start). RegistrationJson is immutable, so reading
-            // it under the collector lock keeps the one-way lock order. Map iteration
-            // order is unspecified — multi-sensor fixtures assert counts only.
-            std::vector<std::shared_ptr<NativeSensor>> sensors_snapshot;
-            {
-                std::lock_guard<std::mutex> guard(mutex_);
                 sensors_snapshot.reserve(sensors_.size());
                 for (const auto& sensor : sensors_)
                 {
@@ -968,6 +975,8 @@ namespace
                     registrations_.push_back(sensor.second->RegistrationJson());
                 }
             }
+
+            NotifyLifecycle(CollectorState::Starting);
 
             // Re-arm periodic sensors outside the collector lock (sensor locks are never taken
             // under it): the first post fires immediately, and a restarted rate sensor must not
@@ -2163,9 +2172,18 @@ namespace
             // Catch up by whole periods: if the worker (or a virtual-clock jump) skipped past
             // several periods, advance to the next future boundary and emit once — a fixed
             // cadence from the start anchor, no backlog of posts (managed fixed-rate schedule).
-            do
-                next_post_ms_ += post_period_ms_;
-            while (next_post_ms_ <= now_ms);
+            // The C ABI rejects a non-positive period at creation; the guard is defensive so a
+            // zero/negative period can never spin this loop forever under the sensor lock.
+            if (post_period_ms_ > 0)
+            {
+                do
+                    next_post_ms_ += post_period_ms_;
+                while (next_post_ms_ <= now_ms);
+            }
+            else
+            {
+                next_post_ms_ = now_ms + 1;
+            }
             next_post_hint_.store(next_post_ms_);
 
             if (type_ == HSM_SENSOR_TYPE_RATE)

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -25,10 +25,52 @@ namespace
 {
     constexpr size_t MaxCommentLength = 1024;
 
+    // Full lifecycle state machine (overview.md "Lifecycle"), mirroring the managed
+    // CollectorStatus: Stopped -> Starting -> Running -> Stopping -> Stopped, and
+    // Any-except-Disposed -> Disposed (terminal). Starting/Stopping are transient —
+    // they are only observable from another thread while Start()/Stop() runs.
     enum class CollectorState
     {
         Stopped,
+        Starting,
         Running,
+        Stopping,
+        Disposed,
+    };
+
+    hsm_collector_status_t ToPublicStatus(CollectorState state)
+    {
+        switch (state)
+        {
+        case CollectorState::Stopped:
+            return HSM_COLLECTOR_STATUS_STOPPED;
+        case CollectorState::Starting:
+            return HSM_COLLECTOR_STATUS_STARTING;
+        case CollectorState::Running:
+            return HSM_COLLECTOR_STATUS_RUNNING;
+        case CollectorState::Stopping:
+            return HSM_COLLECTOR_STATUS_STOPPING;
+        case CollectorState::Disposed:
+            return HSM_COLLECTOR_STATUS_DISPOSED;
+        }
+
+        return HSM_COLLECTOR_STATUS_STOPPED;
+    }
+
+    // A registered lifecycle observer (portable ILifecycleListener). The callback is
+    // invoked exception-isolated; user_data must outlive the collector.
+    struct LifecycleListener
+    {
+        hsm_lifecycle_callback_t callback;
+        void* user_data;
+    };
+
+    // One deduplicated error message: how many occurrences have been collapsed since
+    // the last emit, and the system-clock time of that emit (for window expiry).
+    struct DedupEntry
+    {
+        int64_t suppressed;
+        int64_t last_logged_ms;
     };
 
     std::string CopyString(const char* value)
@@ -623,51 +665,76 @@ namespace
     class NativeCollector : public std::enable_shared_from_this<NativeCollector>
     {
     public:
+        // 0 selects the managed CollectorOptions default for every numeric field
+        // EXCEPT the dedup window, where 0 is a meaningful value (log immediately,
+        // no dedup) and is passed through verbatim. Negative fields are rejected
+        // before construction (hsm_collector_create validation).
         explicit NativeCollector(const hsm_collector_options_t& options)
             : access_key_(CopyString(options.access_key)),
               server_address_(CopyString(options.server_address)),
               port_(options.port),
+              client_name_(CopyString(options.client_name)),
               module_(CopyString(options.module)),
               computer_name_(CopyString(options.computer_name)),
               max_queue_size_(options.max_queue_size > 0 ? options.max_queue_size : 20000),
-              max_values_in_package_(options.max_values_in_package > 0 ? options.max_values_in_package : 50),
-              collect_period_ms_(options.package_collect_period_ms > 0 ? options.package_collect_period_ms : 20)
+              max_values_in_package_(options.max_values_in_package > 0 ? options.max_values_in_package : 1000),
+              collect_period_ms_(options.package_collect_period_ms > 0 ? options.package_collect_period_ms : 15000),
+              request_timeout_ms_(options.request_timeout_ms > 0 ? options.request_timeout_ms : 30000),
+              max_sensors_(options.max_sensors > 0 ? options.max_sensors : 100000),
+              allow_untrusted_certificate_(options.allow_untrusted_server_certificate),
+              allow_plaintext_transport_(options.allow_plaintext_transport),
+              dedup_window_ms_(options.exception_deduplicator_window_ms),
+              max_deduplicated_messages_(options.max_deduplicated_messages > 0 ? options.max_deduplicated_messages : 1000)
         {
         }
 
         ~NativeCollector()
         {
-            // Terminal teardown (destroy without Stop): only the threads are reclaimed — there
-            // is no observable place left to drain into.
+            // Terminal teardown (destroy without an explicit dispose/stop): only the
+            // threads are reclaimed — there is no observable place left to drain into.
+            // Idempotent with Dispose() via the joinable() guards.
             StopScheduler();
             StopWorker();
         }
 
+        // Start: Stopped -> Starting -> Running. Idempotent (Running/Starting -> no-op),
+        // rejected once Disposed. The op lock serializes the whole transition against
+        // Stop/Dispose so listeners observe a consistent order.
         hsm_result_t Start()
         {
-            std::vector<std::shared_ptr<NativeSensor>> sensors_snapshot;
+            std::lock_guard<std::mutex> op_guard(op_mutex_);
+
             {
                 std::lock_guard<std::mutex> guard(mutex_);
 
-                if (state_ == CollectorState::Running)
+                if (state_ == CollectorState::Disposed)
+                    return SetError(HSM_RESULT_INVALID_STATE, "Collector is disposed.");
+
+                if (state_ == CollectorState::Running || state_ == CollectorState::Starting)
                 {
                     ClearError();
                     return HSM_RESULT_OK;
                 }
 
-                state_ = CollectorState::Running;
+                state_ = CollectorState::Starting;
+                ClearError();
+            }
+
+            NotifyLifecycle(CollectorState::Starting);
+
+            // Every start re-registers every sensor (mirrors C# InitAsync sending the
+            // AddOrUpdate command per start). RegistrationJson is immutable, so reading
+            // it under the collector lock keeps the one-way lock order. Map iteration
+            // order is unspecified — multi-sensor fixtures assert counts only.
+            std::vector<std::shared_ptr<NativeSensor>> sensors_snapshot;
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
                 sensors_snapshot.reserve(sensors_.size());
                 for (const auto& sensor : sensors_)
+                {
                     sensors_snapshot.push_back(sensor.second);
-
-                // Every start re-registers every sensor (mirrors C# InitAsync sending the
-                // AddOrUpdate command per start). RegistrationJson is immutable, so reading
-                // it under the collector lock keeps the one-way lock order. Map iteration
-                // order is unspecified — multi-sensor fixtures assert counts only.
-                for (const auto& sensor : sensors_)
                     registrations_.push_back(sensor.second->RegistrationJson());
-
-                ClearError();
+                }
             }
 
             // Re-arm periodic sensors outside the collector lock (sensor locks are never taken
@@ -678,26 +745,40 @@ namespace
 
             StartWorker();
             StartScheduler();
+
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
+                state_ = CollectorState::Running;
+            }
+
+            NotifyLifecycle(CollectorState::Running);
             return HSM_RESULT_OK;
         }
 
+        // Stop: Running -> Stopping -> Stopped. Idempotent (Stopped/Disposed -> no-op).
         hsm_result_t Stop()
         {
-            // Phase 1: flip the state so new instant values are rejected, and snapshot the
-            // sensor set. Sensor locks are taken strictly outside the collector lock (and the
-            // bar add path takes the sensor lock before calling into the collector), so the
-            // flush below must run unlocked to keep the lock order one-way.
+            std::lock_guard<std::mutex> op_guard(op_mutex_);
+            return StopCore();
+        }
+
+        // Caller holds op_mutex_. Drives the stop transition exactly once (Stopped/Disposed
+        // are no-ops), firing the Stopping/Stopped notifications around the flush+drain.
+        // Dispose reuses this so a dispose racing an in-flight Stop joins on op_mutex_ and
+        // sees Stopped here — exactly one stopped-notification, no duplicate flush.
+        hsm_result_t StopCore()
+        {
             std::vector<std::shared_ptr<NativeSensor>> sensors_snapshot;
             {
                 std::lock_guard<std::mutex> guard(mutex_);
 
-                if (state_ == CollectorState::Stopped)
+                if (state_ == CollectorState::Stopped || state_ == CollectorState::Disposed)
                 {
                     ClearError();
                     return HSM_RESULT_OK;
                 }
 
-                state_ = CollectorState::Stopped;
+                state_ = CollectorState::Stopping;
                 sensors_snapshot.reserve(sensors_.size());
                 for (const auto& sensor : sensors_)
                     sensors_snapshot.push_back(sensor.second);
@@ -705,13 +786,15 @@ namespace
                 ClearError();
             }
 
-            // Phase 1.5: stop the periodic scheduler. Posts racing the state flip are dropped by
-            // the EnqueueIfRunning gate; rate sums / function posts are deliberately NOT flushed
+            NotifyLifecycle(CollectorState::Stopping);
+
+            // Phase 1: stop the periodic scheduler. Posts racing the state flip are dropped by
+            // the CanAcceptData gate; rate sums / function posts are deliberately NOT flushed
             // (a partial-window rate is alert-noise risk — only bars preserve data at stop).
             StopScheduler();
 
             // Phase 2: flush sensors — last-value snapshots and non-empty partial bars — into
-            // the queue, bypassing the Running gate (this is the explicit stop-flush path).
+            // the queue, bypassing the data gate (this is the explicit stop-flush path).
             std::vector<std::string> flushed;
             for (const auto& sensor : sensors_snapshot)
             {
@@ -733,7 +816,71 @@ namespace
             StopWorker();
             DrainQueueOnStop();
 
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
+                state_ = CollectorState::Stopped;
+            }
+
+            NotifyLifecycle(CollectorState::Stopped);
             return HSM_RESULT_OK;
+        }
+
+        // Dispose: terminal, idempotent, never throws. Stops first if active (firing
+        // Stopping/Stopped, like the managed Dispose-from-active path), then Disposed.
+        void Dispose()
+        {
+            std::lock_guard<std::mutex> op_guard(op_mutex_);
+
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
+                if (state_ == CollectorState::Disposed)
+                    return;
+            }
+
+            StopCore();
+
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
+                state_ = CollectorState::Disposed;
+            }
+            // No listener notification for Disposed — mirrors the managed collector, which
+            // fires only ToStopping/ToStopped on dispose-from-active and nothing once stopped.
+        }
+
+        hsm_collector_status_t Status() const
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            return ToPublicStatus(state_);
+        }
+
+        // TestConnection is callable in any state (mirrors ConnectionResult). The in-memory
+        // sender is always reachable until the HTTP transport lands (#1096); a disposed
+        // collector reports invalid state instead of a phantom healthy connection.
+        hsm_result_t TestConnection()
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            if (state_ == CollectorState::Disposed)
+                return SetError(HSM_RESULT_INVALID_STATE, "Collector is disposed.");
+
+            ClearError();
+            return HSM_RESULT_OK;
+        }
+
+        hsm_result_t AddLifecycleListener(hsm_lifecycle_callback_t callback, void* user_data)
+        {
+            if (callback == nullptr)
+                return HSM_RESULT_INVALID_ARGUMENT;
+
+            std::lock_guard<std::mutex> op_guard(op_mutex_);
+            lifecycle_listeners_.push_back(LifecycleListener{ callback, user_data });
+            return HSM_RESULT_OK;
+        }
+
+        void SetLogger(hsm_log_callback_t callback, void* user_data)
+        {
+            std::lock_guard<std::mutex> guard(logger_mutex_);
+            log_callback_ = callback;
+            log_user_data_ = user_data;
         }
 
         hsm_result_t CreateSensor(
@@ -750,6 +897,14 @@ namespace
             std::lock_guard<std::mutex> guard(mutex_);
             const auto sensor_path = BuildSensorPath(path);
 
+            // Registration is closed while Stopping/Disposed: reject without crashing the host
+            // (returns an inert null handle), mirroring the managed CanRegisterSensors gate.
+            if (!CanRegisterSensorsLocked())
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_INVALID_STATE, "Collector is not accepting sensor registrations.");
+            }
+
             const auto existing = sensors_.find(sensor_path);
             if (existing != sensors_.end())
             {
@@ -765,6 +920,14 @@ namespace
                 out_sensor = existing->second;
                 ClearError();
                 return HSM_RESULT_OK;
+            }
+
+            // A registered path returns its existing handle above (idempotent, not counted);
+            // a genuinely new sensor is capped at MaxSensors (managed registration cap).
+            if (sensors_.size() >= static_cast<size_t>(max_sensors_))
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_LIMIT_EXCEEDED, "MaxSensors limit reached.");
             }
 
             auto sensor = std::make_shared<NativeSensor>(weak_from_this(), sensor_path, type, is_last_value, default_value_json);
@@ -789,6 +952,14 @@ namespace
             std::lock_guard<std::mutex> guard(mutex_);
             const auto sensor_path = BuildSensorPath(path);
 
+            // Registration is closed while Stopping/Disposed: reject without crashing the host
+            // (returns an inert null handle), mirroring the managed CanRegisterSensors gate.
+            if (!CanRegisterSensorsLocked())
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_INVALID_STATE, "Collector is not accepting sensor registrations.");
+            }
+
             const auto existing = sensors_.find(sensor_path);
             if (existing != sensors_.end())
             {
@@ -801,6 +972,14 @@ namespace
                 out_sensor = existing->second;
                 ClearError();
                 return HSM_RESULT_OK;
+            }
+
+            // A registered path returns its existing handle above (idempotent, not counted);
+            // a genuinely new sensor is capped at MaxSensors (managed registration cap).
+            if (sensors_.size() >= static_cast<size_t>(max_sensors_))
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_LIMIT_EXCEEDED, "MaxSensors limit reached.");
             }
 
             auto sensor = std::make_shared<NativeSensor>(weak_from_this(), sensor_path, type, bar_period_ms, precision);
@@ -828,6 +1007,14 @@ namespace
             std::lock_guard<std::mutex> guard(mutex_);
             const auto sensor_path = BuildSensorPath(path);
 
+            // Registration is closed while Stopping/Disposed: reject without crashing the host
+            // (returns an inert null handle), mirroring the managed CanRegisterSensors gate.
+            if (!CanRegisterSensorsLocked())
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_INVALID_STATE, "Collector is not accepting sensor registrations.");
+            }
+
             const auto existing = sensors_.find(sensor_path);
             if (existing != sensors_.end())
             {
@@ -845,6 +1032,14 @@ namespace
                 out_sensor = existing->second;
                 ClearError();
                 return HSM_RESULT_OK;
+            }
+
+            // A registered path returns its existing handle above (idempotent, not counted);
+            // a genuinely new sensor is capped at MaxSensors (managed registration cap).
+            if (sensors_.size() >= static_cast<size_t>(max_sensors_))
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_LIMIT_EXCEEDED, "MaxSensors limit reached.");
             }
 
             auto sensor = std::make_shared<NativeSensor>(
@@ -870,6 +1065,14 @@ namespace
             std::lock_guard<std::mutex> guard(mutex_);
             const auto sensor_path = BuildSensorPath(path);
 
+            // Registration is closed while Stopping/Disposed: reject without crashing the host
+            // (returns an inert null handle), mirroring the managed CanRegisterSensors gate.
+            if (!CanRegisterSensorsLocked())
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_INVALID_STATE, "Collector is not accepting sensor registrations.");
+            }
+
             const auto existing = sensors_.find(sensor_path);
             if (existing != sensors_.end())
             {
@@ -882,6 +1085,14 @@ namespace
                 out_sensor = existing->second;
                 ClearError();
                 return HSM_RESULT_OK;
+            }
+
+            // A registered path returns its existing handle above (idempotent, not counted);
+            // a genuinely new sensor is capped at MaxSensors (managed registration cap).
+            if (sensors_.size() >= static_cast<size_t>(max_sensors_))
+            {
+                out_sensor.reset();
+                return SetError(HSM_RESULT_LIMIT_EXCEEDED, "MaxSensors limit reached.");
             }
 
             auto sensor = std::make_shared<NativeSensor>(
@@ -906,7 +1117,7 @@ namespace
 
                 ClearError();
 
-                if (state_ != CollectorState::Running)
+                if (!CanAcceptDataLocked())
                     return HSM_RESULT_OK;
             }
 
@@ -914,14 +1125,14 @@ namespace
             return HSM_RESULT_OK;
         }
 
-        // Bar publish path (roll-on-add): gated on Running exactly like an instant value —
+        // Bar publish path (roll-on-add): gated on CanAcceptData exactly like an instant value —
         // a bar that closes while the collector is stopped is dropped, not queued.
         void EnqueueIfRunning(std::string json)
         {
             {
                 std::lock_guard<std::mutex> guard(mutex_);
 
-                if (state_ != CollectorState::Running)
+                if (!CanAcceptDataLocked())
                     return;
             }
 
@@ -935,7 +1146,7 @@ namespace
             {
                 std::lock_guard<std::mutex> guard(mutex_);
 
-                if (state_ != CollectorState::Running)
+                if (!CanAcceptDataLocked())
                     return;
             }
 
@@ -1051,14 +1262,141 @@ namespace
             last_error_.clear();
         }
 
+        // --- Lifecycle gates (caller holds mutex_). Same phase table as the managed
+        // collector (overview.md "Data gating" / "Sensor registration"). ---
+
+        // Data may be queued while Starting/Running/Stopping (so sensors flush at stop);
+        // dropped while Stopped or Disposed.
+        bool CanAcceptDataLocked() const
+        {
+            return state_ == CollectorState::Starting || state_ == CollectorState::Running
+                || state_ == CollectorState::Stopping;
+        }
+
+        // A new sensor starts (and registers) immediately only while Starting/Running.
+        bool CanStartNewSensorsLocked() const
+        {
+            return state_ == CollectorState::Starting || state_ == CollectorState::Running;
+        }
+
+        // Registration is accepted unless shutting down or terminal (Stopping/Disposed):
+        // the union of the configuration (Stopped) and operational (Starting/Running) phases.
+        bool CanRegisterSensorsLocked() const
+        {
+            return state_ != CollectorState::Stopping && state_ != CollectorState::Disposed;
+        }
+
+        // Run a host-supplied callback so a throwing/crashing one can neither cross the C ABI
+        // boundary nor break the collector (lifecycle listeners, log sinks, scheduler onError).
+        template <typename Fn>
+        static void InvokeIsolated(Fn&& fn) noexcept
+        {
+            try
+            {
+                fn();
+            }
+            catch (...)
+            {
+                // Swallowed by contract — see overview.md "Callback exception isolation".
+            }
+        }
+
+        // Fire a lifecycle transition to every listener, exception-isolated. Caller holds
+        // op_mutex_ (never mutex_), so callbacks observe transitions in order and a listener
+        // may safely read collector state — but must not re-enter Start/Stop/Dispose.
+        void NotifyLifecycle(CollectorState state)
+        {
+            const auto status = ToPublicStatus(state);
+            for (const auto& listener : lifecycle_listeners_)
+                InvokeIsolated([&] { listener.callback(status, listener.user_data); });
+        }
+
+        void LogMessage(hsm_log_level_t level, const std::string& message)
+        {
+            hsm_log_callback_t callback = nullptr;
+            void* user_data = nullptr;
+            {
+                std::lock_guard<std::mutex> guard(logger_mutex_);
+                callback = log_callback_;
+                user_data = log_user_data_;
+            }
+
+            if (callback == nullptr)
+                return;
+
+            InvokeIsolated([&] { callback(level, message.c_str(), user_data); });
+        }
+
+        // Error routing entry point: validation drops, loop errors and shutdown discards all
+        // funnel here. Errors pass through the deduplicator (window/capacity from the options)
+        // so a storm of identical messages collapses to one log line plus a periodic
+        // "(N suppressed)" flush. A zero window logs immediately and returns (no dedup) — the
+        // managed MessageDeduplicator's zero-window contract (and the double-log bug guard).
+        void LogError(const std::string& message)
+        {
+            if (dedup_window_ms_ <= 0)
+            {
+                LogMessage(HSM_LOG_LEVEL_ERROR, message);
+                return;
+            }
+
+            const auto now_ms = UnixTimeMilliseconds();
+            bool emit = false;
+            int64_t suppressed = 0;
+            {
+                std::lock_guard<std::mutex> guard(logger_mutex_);
+
+                auto it = dedup_.find(message);
+                if (it == dedup_.end())
+                {
+                    EvictDedupIfFullLocked(now_ms);
+                    dedup_.emplace(message, DedupEntry{ 0, now_ms });
+                    emit = true;
+                }
+                else if (now_ms - it->second.last_logged_ms >= dedup_window_ms_)
+                {
+                    suppressed = it->second.suppressed;
+                    it->second.suppressed = 0;
+                    it->second.last_logged_ms = now_ms;
+                    emit = true;
+                }
+                else
+                {
+                    ++it->second.suppressed;
+                }
+            }
+
+            if (emit)
+                LogMessage(HSM_LOG_LEVEL_ERROR, suppressed > 0
+                        ? message + " (" + std::to_string(suppressed) + " suppressed)"
+                        : message);
+        }
+
+        // Caller holds logger_mutex_. Bounds the dedup map to max_deduplicated_messages_ by
+        // evicting the oldest entry (smallest last_logged_ms) — same capacity+oldest-expiry
+        // policy as the managed MessageDeduplicator.
+        void EvictDedupIfFullLocked(int64_t /*now_ms*/)
+        {
+            if (dedup_.size() < static_cast<size_t>(max_deduplicated_messages_))
+                return;
+
+            auto oldest = dedup_.begin();
+            for (auto it = dedup_.begin(); it != dedup_.end(); ++it)
+                if (it->second.last_logged_ms < oldest->second.last_logged_ms)
+                    oldest = it;
+
+            if (oldest != dedup_.end())
+                dedup_.erase(oldest);
+        }
+
         std::string BuildSensorPath(const std::string& path) const
         {
             return JoinPathParts({ computer_name_, module_, path });
         }
 
-        // Caller holds mutex_. New sensors register immediately when the collector is
-        // already running (mirrors C# InitAsync on dynamic creation); sensors created
-        // before Start are registered by the Start loop.
+        // Caller holds mutex_. New sensors register immediately when the collector can start
+        // new sensors (Starting/Running — mirrors C# InitAsync on dynamic creation); sensors
+        // created before Start are registered by the Start loop.
         void RegisterSensorLocked(
             const std::shared_ptr<NativeSensor>& sensor,
             hsm_sensor_type_t type,
@@ -1067,7 +1405,7 @@ namespace
         {
             sensor->SetRegistrationJson(BuildRegistrationJson(sensor_path, type, registration));
 
-            if (state_ == CollectorState::Running)
+            if (CanStartNewSensorsLocked())
                 registrations_.push_back(sensor->RegistrationJson());
         }
 
@@ -1318,14 +1656,33 @@ namespace
         bool scheduler_stop_ = false;
         std::thread scheduler_;
 
+        // Lifecycle operations (Start/Stop/Dispose) serialize on this coarse lock so a
+        // dispose racing a stop joins the in-flight transition rather than duplicating
+        // it. Listeners are invoked under it (after state_ flips) for consistent order.
+        std::mutex op_mutex_;
+        std::vector<LifecycleListener> lifecycle_listeners_;
+
+        // Pluggable log sink + error deduplicator (overview.md "error-handling").
+        std::mutex logger_mutex_;
+        hsm_log_callback_t log_callback_ = nullptr;
+        void* log_user_data_ = nullptr;
+        std::unordered_map<std::string, DedupEntry> dedup_;
+
         std::string access_key_;
         std::string server_address_;
         int32_t port_;
+        std::string client_name_;
         std::string module_;
         std::string computer_name_;
         int32_t max_queue_size_;
         int32_t max_values_in_package_;
         int32_t collect_period_ms_;
+        int32_t request_timeout_ms_;
+        int32_t max_sensors_;
+        bool allow_untrusted_certificate_;
+        bool allow_plaintext_transport_;
+        int64_t dedup_window_ms_;
+        int32_t max_deduplicated_messages_;
     };
 
     hsm_result_t NativeSensor::AddInt(int32_t value, hsm_sensor_status_t status, const char* comment)
@@ -1713,6 +2070,11 @@ static hsm_result_t CreateSensor(
     hsm_sensor_t** out_sensor,
     const RegistrationOptions& registration = InstantRegistrationDefaults());
 
+int32_t hsm_collector_version(void)
+{
+    return HSM_COLLECTOR_VERSION;
+}
+
 hsm_result_t hsm_collector_create(const hsm_collector_options_t* options, hsm_collector_t** out_collector)
 {
     if (out_collector != nullptr)
@@ -1728,6 +2090,14 @@ hsm_result_t hsm_collector_create(const hsm_collector_options_t* options, hsm_co
         return HSM_RESULT_INVALID_ARGUMENT;
 
     if (options->port <= 0 || options->port > 65535)
+        return HSM_RESULT_INVALID_ARGUMENT;
+
+    // 0 means "managed default" for every numeric field (the dedup window's 0 means
+    // log-immediately); a negative value is always invalid.
+    if (options->max_queue_size < 0 || options->max_values_in_package < 0
+        || options->package_collect_period_ms < 0 || options->request_timeout_ms < 0
+        || options->max_sensors < 0 || options->exception_deduplicator_window_ms < 0
+        || options->max_deduplicated_messages < 0)
         return HSM_RESULT_INVALID_ARGUMENT;
 
     try
@@ -1763,6 +2133,50 @@ hsm_result_t hsm_collector_stop(hsm_collector_t* collector)
         return HSM_RESULT_INVALID_ARGUMENT;
 
     return collector->impl->Stop();
+}
+
+hsm_collector_status_t hsm_collector_status(const hsm_collector_t* collector)
+{
+    if (collector == nullptr)
+        return HSM_COLLECTOR_STATUS_DISPOSED;
+
+    return collector->impl->Status();
+}
+
+void hsm_collector_dispose(hsm_collector_t* collector)
+{
+    if (collector == nullptr)
+        return;
+
+    collector->impl->Dispose();
+}
+
+hsm_result_t hsm_collector_test_connection(hsm_collector_t* collector)
+{
+    if (collector == nullptr)
+        return HSM_RESULT_INVALID_ARGUMENT;
+
+    return collector->impl->TestConnection();
+}
+
+hsm_result_t hsm_collector_add_lifecycle_listener(
+    hsm_collector_t* collector,
+    hsm_lifecycle_callback_t callback,
+    void* user_data)
+{
+    if (collector == nullptr)
+        return HSM_RESULT_INVALID_ARGUMENT;
+
+    return collector->impl->AddLifecycleListener(callback, user_data);
+}
+
+hsm_result_t hsm_collector_set_logger(hsm_collector_t* collector, hsm_log_callback_t callback, void* user_data)
+{
+    if (collector == nullptr)
+        return HSM_RESULT_INVALID_ARGUMENT;
+
+    collector->impl->SetLogger(callback, user_data);
+    return HSM_RESULT_OK;
 }
 
 hsm_result_t hsm_collector_create_int_sensor(

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -1269,8 +1269,7 @@ namespace
         // dropped while Stopped or Disposed.
         bool CanAcceptDataLocked() const
         {
-            return state_ == CollectorState::Starting || state_ == CollectorState::Running
-                || state_ == CollectorState::Stopping;
+            return state_ == CollectorState::Starting || state_ == CollectorState::Running || state_ == CollectorState::Stopping;
         }
 
         // A new sensor starts (and registers) immediately only while Starting/Running.
@@ -1368,8 +1367,8 @@ namespace
 
             if (emit)
                 LogMessage(HSM_LOG_LEVEL_ERROR, suppressed > 0
-                        ? message + " (" + std::to_string(suppressed) + " suppressed)"
-                        : message);
+                                                    ? message + " (" + std::to_string(suppressed) + " suppressed)"
+                                                    : message);
         }
 
         // Caller holds logger_mutex_. Bounds the dedup map to max_deduplicated_messages_ by
@@ -2094,10 +2093,7 @@ hsm_result_t hsm_collector_create(const hsm_collector_options_t* options, hsm_co
 
     // 0 means "managed default" for every numeric field (the dedup window's 0 means
     // log-immediately); a negative value is always invalid.
-    if (options->max_queue_size < 0 || options->max_values_in_package < 0
-        || options->package_collect_period_ms < 0 || options->request_timeout_ms < 0
-        || options->max_sensors < 0 || options->exception_deduplicator_window_ms < 0
-        || options->max_deduplicated_messages < 0)
+    if (options->max_queue_size < 0 || options->max_values_in_package < 0 || options->package_collect_period_ms < 0 || options->request_timeout_ms < 0 || options->max_sensors < 0 || options->exception_deduplicator_window_ms < 0 || options->max_deduplicated_messages < 0)
         return HSM_RESULT_INVALID_ARGUMENT;
 
     try

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -1423,8 +1423,7 @@ namespace
         if (!IsValidIntPartial(min, max, mean, first, last, count))
             return HSM_RESULT_OK;
 
-        return AccumulateBar([=](MonitoringBar& bar)
-        {
+        return AccumulateBar([=](MonitoringBar& bar) {
             bar.AddPartial(
                 static_cast<double>(min),
                 static_cast<double>(max),
@@ -1693,7 +1692,7 @@ namespace
     {
         return is_last_value_;
     }
-}
+} // namespace
 
 struct hsm_collector_t
 {

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -11,7 +11,9 @@
 #include <deque>
 #include <exception>
 #include <iomanip>
+#include <functional>
 #include <initializer_list>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <sstream>
@@ -180,6 +182,170 @@ namespace
         const auto now = std::chrono::steady_clock::now().time_since_epoch();
         return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
     }
+
+    // Injectable clock seam (issue #1095 §13). The collector reads time for periodic
+    // scheduling through this so a test can drive virtual time; the default RealClock
+    // leaves production behavior unchanged. Only the scheduler / periodic-due path is
+    // routed through it — payload timestamps and bar alignment keep the real wall clock
+    // (there are no conformance time-control verbs, by design — see the spike journal).
+    class Clock
+    {
+    public:
+        virtual ~Clock() = default;
+        virtual int64_t SteadyNowMs() const = 0;
+        virtual int64_t SystemNowMs() const = 0;
+    };
+
+    class RealClock : public Clock
+    {
+    public:
+        int64_t SteadyNowMs() const override
+        {
+            return SteadyMilliseconds();
+        }
+        int64_t SystemNowMs() const override
+        {
+            return UnixTimeMilliseconds();
+        }
+    };
+
+    class ManualClock : public Clock
+    {
+    public:
+        explicit ManualClock(int64_t steady = 0, int64_t system = 0)
+            : steady_(steady), system_(system)
+        {
+        }
+        int64_t SteadyNowMs() const override
+        {
+            return steady_.load();
+        }
+        int64_t SystemNowMs() const override
+        {
+            return system_.load();
+        }
+        void AdvanceMs(int64_t delta)
+        {
+            steady_ += delta;
+            system_ += delta;
+        }
+
+    private:
+        std::atomic<int64_t> steady_;
+        std::atomic<int64_t> system_;
+    };
+
+    // Host-callback isolation: a throwing callback may neither cross the C ABI boundary nor
+    // break the component that invoked it — lifecycle listeners, log sinks, scheduler actions
+    // and onError. overview.md "Callback exception isolation".
+    template <typename Fn>
+    void InvokeIsolated(Fn&& fn) noexcept
+    {
+        try
+        {
+            fn();
+        }
+        catch (...)
+        {
+            // Swallowed by contract.
+        }
+    }
+
+    // Single-worker periodic task — the portable ScheduledTaskHandle (issue #1095 §13).
+    // Idempotent Start/Stop; the worker sleeps until the next due time reported by the
+    // injected clock (event-driven, not a busy poll — bounded by kMaxWaitMs so a dynamic
+    // schedule change or virtual-clock jump is still picked up), runs the action with no
+    // overlap (one worker, sequential) and exception isolation, and Stop joins after at
+    // most one in-flight action (bounded wait-for-current-run).
+    class ScheduledTask
+    {
+    public:
+        // now_ms reports the current monotonic time through the collector's (swappable) clock;
+        // next_due_ms reports the next absolute due time; action is the work to run when due.
+        ScheduledTask(std::function<int64_t()> now_ms, std::function<int64_t()> next_due_ms, std::function<void()> action)
+            : now_ms_(std::move(now_ms)), next_due_ms_(std::move(next_due_ms)), action_(std::move(action))
+        {
+        }
+
+        ScheduledTask(const ScheduledTask&) = delete;
+        ScheduledTask& operator=(const ScheduledTask&) = delete;
+
+        ~ScheduledTask()
+        {
+            Stop();
+        }
+
+        void Start()
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            if (running_)
+                return;
+
+            stop_ = false;
+            running_ = true;
+            worker_ = std::thread([this] { Loop(); });
+        }
+
+        void Stop()
+        {
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
+                if (!running_)
+                    return;
+
+                stop_ = true;
+            }
+
+            cv_.notify_all();
+            if (worker_.joinable())
+                worker_.join();
+
+            std::lock_guard<std::mutex> guard(mutex_);
+            running_ = false;
+        }
+
+        // Re-evaluate the schedule now (e.g. a periodic sensor was added, or virtual time
+        // advanced). Cheap and lock-free against the worker — just nudges the wait.
+        void Wake()
+        {
+            cv_.notify_all();
+        }
+
+    private:
+        static constexpr int64_t kMaxWaitMs = 1000;
+
+        void Loop()
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+
+            while (!stop_)
+            {
+                const int64_t now = now_ms_();
+                const int64_t due = next_due_ms_();
+
+                if (now >= due)
+                {
+                    lock.unlock();
+                    InvokeIsolated(action_);
+                    lock.lock();
+                    continue;
+                }
+
+                const auto wait = std::chrono::milliseconds(std::min<int64_t>(due - now, kMaxWaitMs));
+                cv_.wait_for(lock, wait, [this] { return stop_; });
+            }
+        }
+
+        std::function<int64_t()> now_ms_;
+        std::function<int64_t()> next_due_ms_;
+        std::function<void()> action_;
+
+        std::mutex mutex_;
+        std::condition_variable cv_;
+        std::thread worker_;
+        bool running_ = false;
+        bool stop_ = false;
+    };
 
     // .NET shortest round-trip ("R") double text — the canonical payload contract
     // (tests/conformance/README.md). std::to_chars produces the shortest digits, but its
@@ -579,6 +745,10 @@ namespace
               function_user_data_(function_user_data),
               function_max_cache_(max_cache_size)
         {
+            // Seed the scheduler hint so a sensor created while the collector is already
+            // running is due immediately (managed: dynamic create posts at once); pre-start
+            // sensors are re-anchored by ResetPeriodicBaseline on Start.
+            next_post_hint_.store(next_post_ms_);
         }
 
         // File sensor constructor (string-content publishing only).
@@ -623,8 +793,19 @@ namespace
         void SetRegistrationJson(std::string json) { registration_json_ = std::move(json); }
         const std::string& RegistrationJson() const { return registration_json_; }
 
+        // Periodic scheduling clock (issue #1095 §13). Set under the collector lock at
+        // registration; the periodic due-time and rate elapsed read through it so a test
+        // clock can drive cadence. Null falls back to the real monotonic clock.
+        void SetClock(std::shared_ptr<Clock> clock) { clock_ = std::move(clock); }
+
+        // Lock-free hint of the next periodic due time (steady ms) for the scheduler's wait
+        // computation; std::numeric_limits<int64_t>::max() for a non-periodic sensor.
+        int64_t NextPostHint() const { return next_post_hint_.load(); }
+
     private:
         hsm_result_t AddValueJson(std::string value_json, hsm_sensor_status_t status, const char* comment);
+
+        int64_t SteadyNowMs() const { return clock_ ? clock_->SteadyNowMs() : SteadyMilliseconds(); }
 
         template <typename Accumulate>
         hsm_result_t AccumulateBar(Accumulate&& accumulate);
@@ -640,6 +821,11 @@ namespace
         std::string last_comment_;
         MonitoringBar bar_;
 
+        // Periodic scheduling clock (real by default) + lock-free next-due hint read by the
+        // scheduler without taking the sensor lock.
+        std::shared_ptr<Clock> clock_;
+        std::atomic<int64_t> next_post_hint_{ (std::numeric_limits<int64_t>::max)() };
+
         // Periodic (rate / function) state, guarded by mutex_.
         bool is_periodic_ = false;
         int64_t post_period_ms_ = 0;
@@ -647,7 +833,7 @@ namespace
         double rate_sum_ = 0.0;
         hsm_sensor_status_t rate_status_ = HSM_SENSOR_STATUS_OK;
         std::string rate_comment_;
-        std::chrono::steady_clock::time_point rate_prev_{};
+        int64_t rate_prev_ms_ = 0;
         bool rate_has_prev_ = false;
         hsm_int_function_t int_function_ = nullptr;
         hsm_int_values_function_t int_values_function_ = nullptr;
@@ -686,6 +872,52 @@ namespace
               dedup_window_ms_(options.exception_deduplicator_window_ms),
               max_deduplicated_messages_(options.max_deduplicated_messages > 0 ? options.max_deduplicated_messages : 1000)
         {
+            // The scheduler reads time through clock_ (swappable before Start via SetClock) and
+            // wakes at the earliest periodic due-time. Lock order is task -> collector: the
+            // due/now callbacks lock the collector mutex, never the reverse.
+            scheduler_task_ = std::make_unique<ScheduledTask>(
+                [this] { return clock_->SteadyNowMs(); },
+                [this] { return EarliestNextPostMs(); },
+                [this] { TickPeriodicSensors(); });
+        }
+
+        // Test-only seam (no public C ABI surface): swap the scheduling clock before Start.
+        // Existing sensors are re-pointed at it too, so a manual clock drives both the
+        // scheduler wait and the sensors' due-checks.
+        void SetClock(std::shared_ptr<Clock> clock)
+        {
+            std::lock_guard<std::mutex> guard(mutex_);
+            clock_ = std::move(clock);
+            for (const auto& sensor : sensors_)
+                sensor.second->SetClock(clock_);
+        }
+
+        void TestInstallManualClock(int64_t base_ms)
+        {
+            SetClock(std::make_shared<ManualClock>(base_ms, base_ms));
+        }
+
+        // Advance the installed manual clock and wake the scheduler so it re-evaluates the
+        // virtual due-time at once (no real-time wait).
+        void TestAdvanceClock(int64_t delta_ms)
+        {
+            std::shared_ptr<Clock> clock;
+            {
+                std::lock_guard<std::mutex> guard(mutex_);
+                clock = clock_;
+            }
+
+            if (auto* manual = dynamic_cast<ManualClock*>(clock.get()))
+                manual->AdvanceMs(delta_ms);
+
+            scheduler_task_->Wake();
+        }
+
+        // Drive the error-routing/dedup path directly (the production routes — validation
+        // drops, shutdown discards — are hard to fire deterministically from a unit test).
+        void TestLogError(const std::string& message)
+        {
+            LogError(message);
         }
 
         ~NativeCollector()
@@ -1285,21 +1517,6 @@ namespace
             return state_ != CollectorState::Stopping && state_ != CollectorState::Disposed;
         }
 
-        // Run a host-supplied callback so a throwing/crashing one can neither cross the C ABI
-        // boundary nor break the collector (lifecycle listeners, log sinks, scheduler onError).
-        template <typename Fn>
-        static void InvokeIsolated(Fn&& fn) noexcept
-        {
-            try
-            {
-                fn();
-            }
-            catch (...)
-            {
-                // Swallowed by contract — see overview.md "Callback exception isolation".
-            }
-        }
-
         // Fire a lifecycle transition to every listener, exception-isolated. Caller holds
         // op_mutex_ (never mutex_), so callbacks observe transitions in order and a listener
         // may safely read collector state — but must not re-enter Start/Stop/Dispose.
@@ -1402,10 +1619,18 @@ namespace
             const std::string& sensor_path,
             const RegistrationOptions& registration)
         {
+            sensor->SetClock(clock_);
             sensor->SetRegistrationJson(BuildRegistrationJson(sensor_path, type, registration));
 
             if (CanStartNewSensorsLocked())
+            {
                 registrations_.push_back(sensor->RegistrationJson());
+
+                // A periodic sensor created while running must post immediately: nudge the
+                // scheduler so it re-reads the due-time instead of waiting out its current sleep.
+                if (sensor->IsPeriodic())
+                    scheduler_task_->Wake();
+            }
         }
 
         // FIFO send queue. Lock discipline: `queue_mutex_` and `mutex_` are never held together —
@@ -1440,47 +1665,32 @@ namespace
 
         void StartScheduler()
         {
-            {
-                std::lock_guard<std::mutex> guard(scheduler_mutex_);
-                scheduler_stop_ = false;
-            }
-
-            scheduler_ = std::thread([this] { SchedulerLoop(); });
+            scheduler_task_->Start();
         }
 
         void StopScheduler()
         {
-            {
-                std::lock_guard<std::mutex> guard(scheduler_mutex_);
-                scheduler_stop_ = true;
-            }
-
-            scheduler_cv_.notify_all();
-
-            if (scheduler_.joinable())
-                scheduler_.join();
+            scheduler_task_->Stop();
         }
 
-        // ~10ms tick granularity; each due periodic sensor builds its post under its own lock
-        // and publishes through the Running gate. Sensor locks are taken strictly outside the
-        // collector lock (snapshot first), same one-way order as everywhere else.
-        void SchedulerLoop()
+        // Earliest next periodic due time (steady ms) across all periodic sensors; the
+        // scheduler sleeps until then instead of polling. Reads each sensor's lock-free hint,
+        // so no sensor lock is taken under the collector lock. Far future when nothing periodic.
+        int64_t EarliestNextPostMs()
         {
-            std::unique_lock<std::mutex> lock(scheduler_mutex_);
+            int64_t earliest = (std::numeric_limits<int64_t>::max)();
+            std::lock_guard<std::mutex> guard(mutex_);
+            for (const auto& sensor : sensors_)
+                if (sensor.second->IsPeriodic())
+                    earliest = std::min(earliest, sensor.second->NextPostHint());
 
-            while (!scheduler_stop_)
-            {
-                scheduler_cv_.wait_for(lock, std::chrono::milliseconds(10), [this] { return scheduler_stop_; });
-
-                if (scheduler_stop_)
-                    break;
-
-                lock.unlock();
-                TickPeriodicSensors();
-                lock.lock();
-            }
+            return earliest;
         }
 
+        // Each due periodic sensor builds its post under its own lock and publishes through the
+        // data gate. Sensor locks are taken strictly outside the collector lock (snapshot
+        // first), same one-way order as everywhere else. A throwing user function callback is
+        // isolated so it cannot kill the scheduler loop or starve the other sensors (onError).
         void TickPeriodicSensors()
         {
             std::vector<std::shared_ptr<NativeSensor>> periodic;
@@ -1494,9 +1704,11 @@ namespace
 
             for (const auto& sensor : periodic)
             {
-                std::string json;
-                if (sensor->TryBuildPeriodicJson(json))
-                    EnqueueIfRunning(std::move(json));
+                InvokeIsolated([&] {
+                    std::string json;
+                    if (sensor->TryBuildPeriodicJson(json))
+                        EnqueueIfRunning(std::move(json));
+                });
             }
         }
 
@@ -1543,16 +1755,26 @@ namespace
 
         void DrainQueueOnStop()
         {
-            std::unique_lock<std::mutex> lock(queue_mutex_);
-            DispatchQueuedLocked(lock, /*clear_remainder_on_failure=*/true);
+            size_t dropped = 0;
+            {
+                std::unique_lock<std::mutex> lock(queue_mutex_);
+                dropped = DispatchQueuedLocked(lock, /*clear_remainder_on_failure=*/true);
+            }
+
+            // Error routing — shutdown discard: a bounded stop that drops pending values on a
+            // dead/failing transport reports it (logged outside the queue lock so a slow log
+            // sink cannot stall shutdown). Deduplicated like any other error.
+            if (dropped > 0)
+                LogError("Collector stop dropped " + std::to_string(dropped) + " pending value(s): transport unavailable.");
         }
 
         // Pops and sends batches of up to max_values_in_package_ until the queue is empty or a
         // send fails. The lock is dropped around the send so enqueues never wait on dispatch.
         // On failure the batch is re-enqueued at the TAIL (the C# re-enqueue contract: a retried
         // package rotates behind later packages) — or, during the stop flush, everything left is
-        // dropped so shutdown cannot hang on a failing transport.
-        void DispatchQueuedLocked(std::unique_lock<std::mutex>& lock, bool clear_remainder_on_failure)
+        // dropped so shutdown cannot hang on a failing transport. Returns the number of values
+        // dropped (only non-zero on the clear-on-failure stop path).
+        size_t DispatchQueuedLocked(std::unique_lock<std::mutex>& lock, bool clear_remainder_on_failure)
         {
             while (!queue_.empty())
             {
@@ -1574,17 +1796,19 @@ namespace
                 {
                     if (clear_remainder_on_failure)
                     {
+                        const size_t dropped = batch.size() + queue_.size();
                         queue_.clear();
-                    }
-                    else
-                    {
-                        for (auto& json : batch)
-                            queue_.push_back(std::move(json));
+                        return dropped;
                     }
 
-                    return;
+                    for (auto& json : batch)
+                        queue_.push_back(std::move(json));
+
+                    return 0;
                 }
             }
+
+            return 0;
         }
 
         bool TrySendBatch(std::vector<std::string>& batch)
@@ -1650,10 +1874,12 @@ namespace
         bool send_hang_ = false;
         bool send_cancelled_ = false;
 
-        std::mutex scheduler_mutex_;
-        std::condition_variable scheduler_cv_;
-        bool scheduler_stop_ = false;
-        std::thread scheduler_;
+        // Periodic scheduler (issue #1095 §13): a single ScheduledTask worker that sleeps
+        // until the earliest sensor due-time, read through the swappable clock seam. The
+        // clock is shared with each periodic sensor (via SetClock at registration) so a test
+        // clock drives both the wait and the sensors' due-checks.
+        std::shared_ptr<Clock> clock_ = std::make_shared<RealClock>();
+        std::unique_ptr<ScheduledTask> scheduler_task_;
 
         // Lifecycle operations (Start/Stop/Dispose) serialize on this coarse lock so a
         // dispose racing a stop joins the in-flight transition rather than duplicating
@@ -1910,7 +2136,8 @@ namespace
 
         // Immediate first post on (re)start; the rate baseline resets so the first sample of a
         // new run does not divide by the stopped gap (mirrors C# MonitoringRateSensor.InitAsync).
-        next_post_ms_ = SteadyMilliseconds();
+        next_post_ms_ = SteadyNowMs();
+        next_post_hint_.store(next_post_ms_);
         rate_has_prev_ = false;
     }
 
@@ -1929,32 +2156,32 @@ namespace
         {
             std::lock_guard<std::mutex> guard(mutex_);
 
-            const auto now_ms = SteadyMilliseconds();
+            const auto now_ms = SteadyNowMs();
             if (now_ms < next_post_ms_)
                 return false;
 
-            // Re-anchoring to the actual tick time lets the cadence drift by up to the
-            // scheduler granularity (~10ms) per post, unlike the managed fixed-rate schedule.
-            // Benign for the rate VALUE (it divides by measured elapsed, not the period); a
-            // real port that wants to match managed post timestamps should anchor to the
-            // previous due time instead.
-            next_post_ms_ = now_ms + post_period_ms_;
+            // Catch up by whole periods: if the worker (or a virtual-clock jump) skipped past
+            // several periods, advance to the next future boundary and emit once — a fixed
+            // cadence from the start anchor, no backlog of posts (managed fixed-rate schedule).
+            do
+                next_post_ms_ += post_period_ms_;
+            while (next_post_ms_ <= now_ms);
+            next_post_hint_.store(next_post_ms_);
 
             if (type_ == HSM_SENSOR_TYPE_RATE)
             {
-                const auto now = std::chrono::steady_clock::now();
-
                 // Divide by the measured elapsed time since the previous post; the first sample
-                // falls back to the configured period (C# #1102-E2 contract).
+                // falls back to the configured period (C# #1102-E2 contract). Elapsed is read
+                // through the clock seam (ms granularity).
                 double seconds = post_period_ms_ / 1000.0;
                 if (rate_has_prev_)
                 {
-                    const auto elapsed = std::chrono::duration<double>(now - rate_prev_).count();
+                    const double elapsed = (now_ms - rate_prev_ms_) / 1000.0;
                     if (elapsed > 0)
                         seconds = elapsed;
                 }
 
-                rate_prev_ = now;
+                rate_prev_ms_ = now_ms;
                 rate_has_prev_ = true;
 
                 const double rate = seconds > 0 ? rate_sum_ / seconds : 0.0;
@@ -2173,6 +2400,27 @@ hsm_result_t hsm_collector_set_logger(hsm_collector_t* collector, hsm_log_callba
 
     collector->impl->SetLogger(callback, user_data);
     return HSM_RESULT_OK;
+}
+
+// Test-only seam — deliberately NOT declared in the public header. The native unit tests
+// forward-declare these to drive the scheduler's clock without real-time sleeps (the
+// injectable clock seam, issue #1095 §13). Install before Start; advance while running.
+extern "C" void hsm_collector_test_install_manual_clock(hsm_collector_t* collector, int64_t base_ms)
+{
+    if (collector != nullptr)
+        collector->impl->TestInstallManualClock(base_ms);
+}
+
+extern "C" void hsm_collector_test_advance_clock_ms(hsm_collector_t* collector, int64_t delta_ms)
+{
+    if (collector != nullptr)
+        collector->impl->TestAdvanceClock(delta_ms);
+}
+
+extern "C" void hsm_collector_test_log_error(hsm_collector_t* collector, const char* message)
+{
+    if (collector != nullptr && message != nullptr)
+        collector->impl->TestLogError(message);
 }
 
 hsm_result_t hsm_collector_create_int_sensor(

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -1921,19 +1921,23 @@ namespace
         void* log_user_data_ = nullptr;
         std::unordered_map<std::string, DedupEntry> dedup_;
 
+        // [[maybe_unused]] marks options stored to mirror CollectorOptions but consumed only by
+        // the HTTP transport (#1096), which has not landed yet — this keeps the clang
+        // -Wunused-private-field lane (under -Werror) green without reordering the members
+        // (which would trip -Wreorder against the constructor initializer list).
         std::string access_key_;
         std::string server_address_;
-        int32_t port_;
+        [[maybe_unused]] int32_t port_;
         std::string client_name_;
         std::string module_;
         std::string computer_name_;
         int32_t max_queue_size_;
         int32_t max_values_in_package_;
         int32_t collect_period_ms_;
-        int32_t request_timeout_ms_;
+        [[maybe_unused]] int32_t request_timeout_ms_;
         int32_t max_sensors_;
-        bool allow_untrusted_certificate_;
-        bool allow_plaintext_transport_;
+        [[maybe_unused]] bool allow_untrusted_certificate_;
+        [[maybe_unused]] bool allow_plaintext_transport_;
         int64_t dedup_window_ms_;
         int32_t max_deduplicated_messages_;
     };

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -1112,7 +1112,10 @@ namespace
             if (callback == nullptr)
                 return HSM_RESULT_INVALID_ARGUMENT;
 
-            std::lock_guard<std::mutex> op_guard(op_mutex_);
+            // Guarded by its own mutex (not op_mutex_): NotifyLifecycle snapshots under this
+            // lock and invokes OUTSIDE it, so a callback that registers another listener does
+            // not deadlock on a held lock, and the listener vector is never mutated mid-iteration.
+            std::lock_guard<std::mutex> guard(listeners_mutex_);
             lifecycle_listeners_.push_back(LifecycleListener{ callback, user_data });
             return HSM_RESULT_OK;
         }
@@ -1527,12 +1530,22 @@ namespace
         }
 
         // Fire a lifecycle transition to every listener, exception-isolated. Caller holds
-        // op_mutex_ (never mutex_), so callbacks observe transitions in order and a listener
-        // may safely read collector state — but must not re-enter Start/Stop/Dispose.
+        // op_mutex_ (never mutex_), so transitions are serialized and callbacks observe them in
+        // order. The listener set is snapshotted under listeners_mutex_ and the callbacks run
+        // OUTSIDE that lock, so a callback may register another listener (no self-deadlock, no
+        // mid-iteration mutation). A listener may read collector state but must not re-enter
+        // Start/Stop/Dispose (those hold op_mutex_, which this thread already holds).
         void NotifyLifecycle(CollectorState state)
         {
             const auto status = ToPublicStatus(state);
-            for (const auto& listener : lifecycle_listeners_)
+
+            std::vector<LifecycleListener> listeners;
+            {
+                std::lock_guard<std::mutex> guard(listeners_mutex_);
+                listeners = lifecycle_listeners_;
+            }
+
+            for (const auto& listener : listeners)
                 InvokeIsolated([&] { listener.callback(status, listener.user_data); });
         }
 
@@ -1554,9 +1567,11 @@ namespace
 
         // Error routing entry point: validation drops, loop errors and shutdown discards all
         // funnel here. Errors pass through the deduplicator (window/capacity from the options)
-        // so a storm of identical messages collapses to one log line plus a periodic
-        // "(N suppressed)" flush. A zero window logs immediately and returns (no dedup) — the
-        // managed MessageDeduplicator's zero-window contract (and the double-log bug guard).
+        // so a storm of identical messages collapses to one log line; the suppressed count is
+        // flushed as a "(N suppressed)" suffix on the FIRST recurrence after the window elapses
+        // (recurrence-driven, not timer-driven — a storm that simply stops leaves its trailing
+        // count unemitted; memory is still bounded by capacity eviction). A zero window logs
+        // immediately and returns (no dedup) — the managed zero-window contract / double-log guard.
         void LogError(const std::string& message)
         {
             if (dedup_window_ms_ <= 0)
@@ -1894,6 +1909,10 @@ namespace
         // dispose racing a stop joins the in-flight transition rather than duplicating
         // it. Listeners are invoked under it (after state_ flips) for consistent order.
         std::mutex op_mutex_;
+
+        // Lifecycle listeners have their own lock: NotifyLifecycle snapshots under it and
+        // invokes callbacks outside it, so a callback may add a listener without deadlocking.
+        std::mutex listeners_mutex_;
         std::vector<LifecycleListener> lifecycle_listeners_;
 
         // Pluggable log sink + error deduplicator (overview.md "error-handling").

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -437,7 +437,6 @@ namespace
 
     struct ConformanceState
     {
-        CollectorHandle collector;
         std::vector<SensorHandle> sensors;
 
         struct MixedInstantSet
@@ -452,8 +451,14 @@ namespace
         std::vector<MixedInstantSet> mixed_sets;
 
         // Keeps function-sensor constants alive for the lifetime of the case (the C API stores
-        // the raw user_data pointer).
+        // the raw user_data pointer). MUST be destroyed AFTER the collector: the scheduler keeps
+        // invoking the function callback (which reads this user_data) until the collector is
+        // destroyed, so the collector is declared LAST here — members destruct in reverse
+        // declaration order, so the collector (and its scheduler-worker join) tears down first,
+        // before these constants are freed. (TSan caught the reverse order as a use-after-free.)
         std::vector<std::unique_ptr<int32_t>> function_constants;
+
+        CollectorHandle collector;
     };
 
     int32_t ConstantIntFunction(void* user_data)

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -1036,8 +1036,7 @@ namespace
 
             for (int worker = 0; worker < worker_count; ++worker)
             {
-                workers.emplace_back([&, worker]()
-                {
+                workers.emplace_back([&, worker]() {
                     try
                     {
                         for (int value_index = 0; value_index < values_per_worker; ++value_index)
@@ -1067,8 +1066,7 @@ namespace
             return;
         }
 
-        const auto add_mixed_instant_value = [&](size_t set_index, int value, hsm_sensor_status_t status, const std::string& comment)
-        {
+        const auto add_mixed_instant_value = [&](size_t set_index, int value, hsm_sensor_status_t status, const std::string& comment) {
             Require(set_index < state.mixed_sets.size(), "mixed set index out of range");
             const auto& set = state.mixed_sets[set_index];
             const auto string_value = "value-" + std::to_string(value);
@@ -1130,8 +1128,7 @@ namespace
 
             for (int worker = 0; worker < worker_count; ++worker)
             {
-                workers.emplace_back([&, worker]()
-                {
+                workers.emplace_back([&, worker]() {
                     try
                     {
                         for (int value_index = 0; value_index < values_per_worker; ++value_index)
@@ -1169,8 +1166,7 @@ namespace
             const auto path_count = ToInt(step[2]);
             const auto path_prefix = step[3];
 
-            const auto expect_rejected = [](hsm_result_t result, hsm_sensor_t* sensor)
-            {
+            const auto expect_rejected = [](hsm_result_t result, hsm_sensor_t* sensor) {
                 if (result == HSM_RESULT_OK)
                 {
                     hsm_sensor_release(sensor);
@@ -1186,8 +1182,7 @@ namespace
 
             for (int worker = 0; worker < worker_count; ++worker)
             {
-                workers.emplace_back([&, worker]()
-                {
+                workers.emplace_back([&, worker]() {
                     try
                     {
                         for (int path_index = worker; path_index < path_count; path_index += worker_count)
@@ -1267,7 +1262,8 @@ namespace
             Require(
                 WaitForSentCountEquals(state.collector.value, expected, timeout_ms),
                 ("sent count did not match: expected " + step[1] +
-                 ", got " + std::to_string(hsm_collector_sent_count(state.collector.value))).c_str());
+                 ", got " + std::to_string(hsm_collector_sent_count(state.collector.value)))
+                    .c_str());
             return;
         }
 
@@ -1325,7 +1321,8 @@ namespace
             Require(
                 WaitForRegistrationCountEquals(state.collector.value, expected, timeout_ms),
                 ("registration count did not match: expected " + step[1] +
-                 ", got " + std::to_string(hsm_collector_registration_count(state.collector.value))).c_str());
+                 ", got " + std::to_string(hsm_collector_registration_count(state.collector.value)))
+                    .c_str());
             return;
         }
 
@@ -1392,8 +1389,7 @@ namespace
         {
             Require(step.size() >= 6, "expect_payload_type_counts requires bool, int, double, string, and enum counts");
 
-            const auto count_type = [&](const std::string& type)
-            {
+            const auto count_type = [&](const std::string& type) {
                 auto actual = 0;
                 const auto sent_count = hsm_collector_sent_count(state.collector.value);
 
@@ -1505,8 +1501,7 @@ namespace
 
             for (int worker = 0; worker < worker_count; ++worker)
             {
-                workers.emplace_back([&, worker]()
-                {
+                workers.emplace_back([&, worker]() {
                     try
                     {
                         for (int value_index = 0; value_index < values_per_worker; ++value_index)
@@ -1588,7 +1583,8 @@ namespace
             const auto started = std::chrono::steady_clock::now();
             Require(hsm_collector_stop(state.collector.value) == HSM_RESULT_OK, "collector stop failed");
             const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                std::chrono::steady_clock::now() - started).count();
+                                        std::chrono::steady_clock::now() - started)
+                                        .count();
 
             Require(
                 elapsed_ms < ToInt(step[1]),
@@ -1617,8 +1613,14 @@ namespace
             const auto& field = step[2];
 
             static const std::map<std::string, std::string> field_keys = {
-                { "type", "Type" }, { "min", "Min" }, { "max", "Max" }, { "mean", "Mean" },
-                { "first", "First" }, { "last", "Last" }, { "count", "Count" }, { "status", "Status" },
+                { "type", "Type" },
+                { "min", "Min" },
+                { "max", "Max" },
+                { "mean", "Mean" },
+                { "first", "First" },
+                { "last", "Last" },
+                { "count", "Count" },
+                { "status", "Status" },
             };
 
             const auto key = field_keys.find(field);
@@ -2373,7 +2375,7 @@ namespace
 
         return tests;
     }
-}
+} // namespace
 
 int main(int argc, char** argv)
 {
@@ -2399,6 +2401,4 @@ int main(int argc, char** argv)
         std::cerr << ex.what() << '\n';
         return 1;
     }
-
-    return 0;
 }

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -2326,9 +2326,181 @@ namespace
         NotContains(payload, "\"Value\":999");
     }
 
+    // --- #1095 native core: ABI version, lifecycle state machine, dispose, listeners,
+    // TestConnection, MaxSensors cap, options validation, log sink. ---
+
+    void NativeVersionMatchesMacro()
+    {
+        Require(hsm_collector_version() == HSM_COLLECTOR_VERSION, "version() must match the header macro");
+        Require(HSM_COLLECTOR_VERSION_MAJOR == 0 && HSM_COLLECTOR_VERSION_MINOR >= 2, "unexpected ABI version");
+    }
+
+    void NativeStatusTracksLifecycle()
+    {
+        auto collector = CreateCollector();
+        Require(hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_STOPPED, "fresh collector should be Stopped");
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+        Require(hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_RUNNING, "started collector should be Running");
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop failed");
+        Require(hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_STOPPED, "stopped collector should be Stopped");
+    }
+
+    void NativeDisposeIsTerminalAndIdempotent()
+    {
+        auto collector = CreateCollector();
+        hsm_collector_dispose(collector.value);
+        Require(hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_DISPOSED, "disposed collector should be Disposed");
+        hsm_collector_dispose(collector.value);
+        Require(hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_DISPOSED, "second dispose should be a no-op");
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_INVALID_STATE, "start after dispose must be rejected");
+
+        hsm_sensor_t* sensor = nullptr;
+        Require(
+            hsm_collector_create_int_sensor(collector.value, "after/dispose", &sensor) == HSM_RESULT_INVALID_STATE,
+            "registration after dispose must be rejected");
+        Require(sensor == nullptr, "rejected registration must return a null handle");
+    }
+
+    void NativeDisposeFromRunningStops()
+    {
+        auto collector = CreateCollector();
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+        hsm_collector_dispose(collector.value);
+        Require(
+            hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_DISPOSED,
+            "dispose from running should reach Disposed");
+    }
+
+    void NativeLifecycleListenerReceivesTransitions()
+    {
+        std::vector<hsm_collector_status_t> seen;
+        auto collector = CreateCollector();
+        Require(
+            hsm_collector_add_lifecycle_listener(
+                collector.value,
+                [](hsm_collector_status_t status, void* user_data) {
+                    static_cast<std::vector<hsm_collector_status_t>*>(user_data)->push_back(status);
+                },
+                &seen) == HSM_RESULT_OK,
+            "add listener failed");
+
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop failed");
+
+        const std::vector<hsm_collector_status_t> expected = {
+            HSM_COLLECTOR_STATUS_STARTING,
+            HSM_COLLECTOR_STATUS_RUNNING,
+            HSM_COLLECTOR_STATUS_STOPPING,
+            HSM_COLLECTOR_STATUS_STOPPED
+        };
+        Require(seen == expected, "listener should observe Starting,Running,Stopping,Stopped in order");
+    }
+
+    void NativeLifecycleListenerExceptionIsIsolated()
+    {
+        auto collector = CreateCollector();
+        Require(
+            hsm_collector_add_lifecycle_listener(
+                collector.value,
+                [](hsm_collector_status_t, void*) { throw std::runtime_error("listener boom"); },
+                nullptr) == HSM_RESULT_OK,
+            "add listener failed");
+
+        // A throwing listener must neither break the transition nor escape the ABI.
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start must survive a throwing listener");
+        Require(
+            hsm_collector_status(collector.value) == HSM_COLLECTOR_STATUS_RUNNING,
+            "collector must still be Running after a throwing listener");
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop must survive a throwing listener");
+    }
+
+    void NativeTestConnectionReportsReachable()
+    {
+        auto collector = CreateCollector();
+        Require(hsm_collector_test_connection(collector.value) == HSM_RESULT_OK, "test connection should be OK when stopped");
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+        Require(hsm_collector_test_connection(collector.value) == HSM_RESULT_OK, "test connection should be OK while running");
+        hsm_collector_dispose(collector.value);
+        Require(
+            hsm_collector_test_connection(collector.value) == HSM_RESULT_INVALID_STATE,
+            "test connection on a disposed collector should report invalid state");
+    }
+
+    void NativeMaxSensorsCapRejectsBeyondLimit()
+    {
+        auto options = TestOptions();
+        options.max_sensors = 2;
+        auto collector = CreateCollector(options);
+
+        hsm_sensor_t* a = nullptr;
+        hsm_sensor_t* b = nullptr;
+        hsm_sensor_t* c = nullptr;
+        Require(hsm_collector_create_int_sensor(collector.value, "cap/a", &a) == HSM_RESULT_OK, "first sensor should be accepted");
+        Require(hsm_collector_create_int_sensor(collector.value, "cap/b", &b) == HSM_RESULT_OK, "second sensor should be accepted");
+        Require(
+            hsm_collector_create_int_sensor(collector.value, "cap/c", &c) == HSM_RESULT_LIMIT_EXCEEDED,
+            "third sensor should hit the MaxSensors cap");
+        Require(c == nullptr, "rejected sensor must return a null handle");
+
+        // A duplicate path returns the existing handle and does not count against the cap.
+        hsm_sensor_t* a_again = nullptr;
+        Require(
+            hsm_collector_create_int_sensor(collector.value, "cap/a", &a_again) == HSM_RESULT_OK,
+            "duplicate path must stay idempotent under the cap");
+
+        hsm_sensor_release(a);
+        hsm_sensor_release(b);
+        hsm_sensor_release(a_again);
+    }
+
+    void NativeCreateRejectsNegativeOptionFields()
+    {
+        {
+            auto options = TestOptions();
+            options.max_queue_size = -1;
+            ExpectCollectorCreateRejected(options);
+        }
+        {
+            auto options = TestOptions();
+            options.exception_deduplicator_window_ms = -5;
+            ExpectCollectorCreateRejected(options);
+        }
+        {
+            auto options = TestOptions();
+            options.max_sensors = -10;
+            ExpectCollectorCreateRejected(options);
+        }
+    }
+
+    void NativeLoggerSinkCanBeSetAndCleared()
+    {
+        int calls = 0;
+        auto collector = CreateCollector();
+        Require(
+            hsm_collector_set_logger(
+                collector.value,
+                [](hsm_log_level_t, const char*, void* user_data) { ++*static_cast<int*>(user_data); },
+                &calls) == HSM_RESULT_OK,
+            "set logger failed");
+        Require(hsm_collector_set_logger(collector.value, nullptr, nullptr) == HSM_RESULT_OK, "clearing logger failed");
+        // Lifecycle still works with a logger attached and then detached.
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop failed");
+    }
+
     const std::map<std::string, std::function<void(const std::string&)>>& Tests()
     {
         static const std::map<std::string, std::function<void(const std::string&)>> tests = {
+            { "native_version_matches_macro", [](const std::string&) { NativeVersionMatchesMacro(); } },
+            { "native_status_tracks_lifecycle", [](const std::string&) { NativeStatusTracksLifecycle(); } },
+            { "native_dispose_is_terminal_and_idempotent", [](const std::string&) { NativeDisposeIsTerminalAndIdempotent(); } },
+            { "native_dispose_from_running_stops", [](const std::string&) { NativeDisposeFromRunningStops(); } },
+            { "native_lifecycle_listener_receives_transitions", [](const std::string&) { NativeLifecycleListenerReceivesTransitions(); } },
+            { "native_lifecycle_listener_exception_is_isolated", [](const std::string&) { NativeLifecycleListenerExceptionIsIsolated(); } },
+            { "native_test_connection_reports_reachable", [](const std::string&) { NativeTestConnectionReportsReachable(); } },
+            { "native_max_sensors_cap_rejects_beyond_limit", [](const std::string&) { NativeMaxSensorsCapRejectsBeyondLimit(); } },
+            { "native_create_rejects_negative_option_fields", [](const std::string&) { NativeCreateRejectsNegativeOptionFields(); } },
+            { "native_logger_sink_can_be_set_and_cleared", [](const std::string&) { NativeLoggerSinkCanBeSetAndCleared(); } },
             { "native_invalid_argument_clears_out_params", [](const std::string&) { NativeInvalidArgumentClearsOutParams(); } },
             { "native_add_after_collector_destroy_is_rejected", [](const std::string&) { NativeAddAfterCollectorDestroyIsRejected(); } },
             { "native_sent_json_failure_reports_fresh_error", [](const std::string&) { NativeSentJsonFailureReportsFreshError(); } },

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -2591,9 +2591,27 @@ namespace
         Require(logs.size() == 3, "a zero window logs every error immediately with no deduplication");
     }
 
+    void NativeLifecycleListenerCanRegisterAnotherListener()
+    {
+        auto collector = CreateCollector();
+        // A listener that registers another listener from within its callback must not deadlock
+        // on the lifecycle lock, nor corrupt the listener vector mid-iteration (snapshot-then-invoke).
+        hsm_collector_add_lifecycle_listener(
+            collector.value,
+            [](hsm_collector_status_t, void* ud) {
+                hsm_collector_add_lifecycle_listener(
+                    static_cast<hsm_collector_t*>(ud), [](hsm_collector_status_t, void*) {}, nullptr);
+            },
+            collector.value);
+
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start must not deadlock when a listener adds a listener");
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop must not deadlock when a listener adds a listener");
+    }
+
     const std::map<std::string, std::function<void(const std::string&)>>& Tests()
     {
         static const std::map<std::string, std::function<void(const std::string&)>> tests = {
+            { "native_lifecycle_listener_can_register_another_listener", [](const std::string&) { NativeLifecycleListenerCanRegisterAnotherListener(); } },
             { "native_logger_deduplicates_repeated_errors_within_window", [](const std::string&) { NativeLoggerDeduplicatesRepeatedErrorsWithinWindow(); } },
             { "native_logger_zero_window_logs_every_error", [](const std::string&) { NativeLoggerZeroWindowLogsEveryError(); } },
             { "native_scheduler_clock_seam_drives_periodic_posts", [](const std::string&) { NativeSchedulerClockSeamDrivesPeriodicPosts(); } },

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -46,6 +46,11 @@ namespace
         options.port = 443;
         options.module = "conformance-module";
         options.computer_name = "conformance-host";
+        // The managed package/period defaults dispatch every 15 s; the corpus needs fast
+        // dispatch, so the harness sets the small test values explicitly (matching the C#
+        // CollectorConformanceTests harness). create_collector_with_limits overrides these.
+        options.max_values_in_package = 50;
+        options.package_collect_period_ms = 20;
         return options;
     }
 

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -18,6 +18,12 @@
 #include <utility>
 #include <vector>
 
+// Test-only seam (defined in hsm_collector.cpp, deliberately not in the public header): drive
+// the scheduler's injectable clock from the native unit tests (issue #1095 §13).
+extern "C" void hsm_collector_test_install_manual_clock(hsm_collector_t* collector, int64_t base_ms);
+extern "C" void hsm_collector_test_advance_clock_ms(hsm_collector_t* collector, int64_t delta_ms);
+extern "C" void hsm_collector_test_log_error(hsm_collector_t* collector, const char* message);
+
 namespace
 {
     void Require(bool condition, const char* message)
@@ -2488,9 +2494,110 @@ namespace
         Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop failed");
     }
 
+    void NativeSchedulerClockSeamDrivesPeriodicPosts()
+    {
+        auto collector = CreateCollector();
+        // Install a virtual clock BEFORE start so both the scheduler wait and the sensor
+        // due-checks read it (issue #1095 §13 injectable clock seam).
+        hsm_collector_test_install_manual_clock(collector.value, 1000000);
+
+        hsm_sensor_t* sensor = nullptr;
+        Require(
+            hsm_collector_create_function_int_sensor(
+                collector.value, "seam/func", 100, [](void*) -> int32_t { return 7; }, nullptr, &sensor) == HSM_RESULT_OK,
+            "create function sensor failed");
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+
+        // The first post fires immediately on start (next_post == clock base).
+        Require(WaitForSentCountAtLeast(collector.value, 1, 2000), "first periodic post should fire immediately on start");
+        const auto first = hsm_collector_sent_count(collector.value);
+
+        // Real time passing must NOT advance the virtual clock: no further posts appear.
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        Require(hsm_collector_sent_count(collector.value) == first, "frozen virtual clock: real time must not drive posts");
+
+        // Advancing virtual time past one period makes exactly one more post due.
+        hsm_collector_test_advance_clock_ms(collector.value, 150);
+        Require(
+            WaitForSentCountAtLeast(collector.value, first + 1, 2000),
+            "advancing the virtual clock should drive the next post");
+
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop failed");
+        hsm_sensor_release(sensor);
+    }
+
+    void NativeSchedulerOnErrorIsolatesThrowingCallback()
+    {
+        auto collector = CreateCollector();
+        // A function sensor whose callback throws must not kill the scheduler loop; a second
+        // healthy function sensor must keep posting (onError contract, issue #1095 §13).
+        hsm_sensor_t* boom = nullptr;
+        hsm_sensor_t* ok = nullptr;
+        Require(
+            hsm_collector_create_function_int_sensor(
+                collector.value, "sched/boom", 20, [](void*) -> int32_t { throw std::runtime_error("boom"); }, nullptr,
+                &boom) == HSM_RESULT_OK,
+            "create throwing sensor failed");
+        Require(
+            hsm_collector_create_function_int_sensor(
+                collector.value, "sched/ok", 20, [](void*) -> int32_t { return 1; }, nullptr, &ok) == HSM_RESULT_OK,
+            "create healthy sensor failed");
+
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "start failed");
+        Require(
+            WaitForSentCountAtLeast(collector.value, 3, 3000),
+            "healthy sensor must keep posting despite a throwing callback on every tick");
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "stop failed");
+        hsm_sensor_release(boom);
+        hsm_sensor_release(ok);
+    }
+
+    void NativeLoggerDeduplicatesRepeatedErrorsWithinWindow()
+    {
+        std::vector<std::string> logs;
+        auto options = TestOptions();
+        options.exception_deduplicator_window_ms = 3600000; // 1 h: nothing expires during the test
+        auto collector = CreateCollector(options);
+        hsm_collector_set_logger(
+            collector.value,
+            [](hsm_log_level_t, const char* message, void* ud) {
+                static_cast<std::vector<std::string>*>(ud)->emplace_back(message);
+            },
+            &logs);
+
+        for (int i = 0; i < 5; ++i)
+            hsm_collector_test_log_error(collector.value, "disk full");
+
+        Require(logs.size() == 1, "repeated errors within the window must collapse to a single log line");
+        Require(logs[0] == "disk full", "the first occurrence is logged verbatim");
+    }
+
+    void NativeLoggerZeroWindowLogsEveryError()
+    {
+        std::vector<std::string> logs;
+        auto options = TestOptions();
+        options.exception_deduplicator_window_ms = 0; // log immediately, no dedup (managed zero-window contract)
+        auto collector = CreateCollector(options);
+        hsm_collector_set_logger(
+            collector.value,
+            [](hsm_log_level_t, const char* message, void* ud) {
+                static_cast<std::vector<std::string>*>(ud)->emplace_back(message);
+            },
+            &logs);
+
+        for (int i = 0; i < 3; ++i)
+            hsm_collector_test_log_error(collector.value, "blip");
+
+        Require(logs.size() == 3, "a zero window logs every error immediately with no deduplication");
+    }
+
     const std::map<std::string, std::function<void(const std::string&)>>& Tests()
     {
         static const std::map<std::string, std::function<void(const std::string&)>> tests = {
+            { "native_logger_deduplicates_repeated_errors_within_window", [](const std::string&) { NativeLoggerDeduplicatesRepeatedErrorsWithinWindow(); } },
+            { "native_logger_zero_window_logs_every_error", [](const std::string&) { NativeLoggerZeroWindowLogsEveryError(); } },
+            { "native_scheduler_clock_seam_drives_periodic_posts", [](const std::string&) { NativeSchedulerClockSeamDrivesPeriodicPosts(); } },
+            { "native_scheduler_on_error_isolates_throwing_callback", [](const std::string&) { NativeSchedulerOnErrorIsolatesThrowingCallback(); } },
             { "native_version_matches_macro", [](const std::string&) { NativeVersionMatchesMacro(); } },
             { "native_status_tracks_lifecycle", [](const std::string&) { NativeStatusTracksLifecycle(); } },
             { "native_dispose_is_terminal_and_idempotent", [](const std::string&) { NativeDisposeIsTerminalAndIdempotent(); } },


### PR DESCRIPTION
Closes #1095 (epic #1093). The native collector graduates from spike to the real core: the cross-cutting infrastructure every later workstream builds on. Per request this lands as **one PR** covering the whole issue checklist (toolchain + C ABI + lifecycle + scheduler + logging + docs). The shared #1094 conformance corpus stays the regression net — **69/69 native, warning-clean under `/WX`**, timing fixtures flake-screened 30×.

## Project & toolchain
- Multi-target CMake (core / C++ wrapper / tests) from PR1; `.clang-format` (Microsoft/Allman, `ColumnLimit: 0`), `HSM_COLLECTOR_WERROR`, `HSM_COLLECTOR_SANITIZER` (ASan/TSan) + `CMakePresets.json`.
- CI lanes: `format-check` (clang-format pinned 19.1.1), MSVC + gcc `-Werror`, Linux clang, **clang ASan+UBSan and TSan** (first race-detector run of the scheduler/worker).

## C ABI
- Opaque handles + explicit string-ownership rules (documented); error codes + last-error; `HSM_RESULT_LIMIT_EXCEEDED`.
- `hsm_collector_options_t` — full **16-field** `CollectorOptions` mirror + validation (Port 1..65535, non-negative numerics; `0` = managed default, dedup window `0` = log-immediately).
- `hsm_collector_status` / `dispose` / `test_connection`; lifecycle listeners; pluggable log sink; `hsm_collector_version()` + ABI macros.
- Versioning/ABI-stability policy + the full contract: **[`docs/native-collector-c-abi.md`](../blob/codex/native-collector-infra/docs/native-collector-c-abi.md)**.

## Lifecycle semantics
- State machine Stopped→Starting→Running→Stopping→Stopped (+ Disposed terminal) with the three gates (CanAcceptData / CanRegisterSensors / CanStartNewSensors) — same phase table as .NET.
- Dispose-vs-stop race: `StopCore` shared by Stop and Dispose under a coarse op-lock → a dispose joins an in-flight stop, **exactly one stopped-notification**, terminal wins.
- Exception-isolated lifecycle listeners; registration path-dedup / type-conflict / **MaxSensors cap** / reject-during-Stopping-or-Disposed without crashing.

## Scheduler (event-driven + clock seam)
- Single `ScheduledTask` worker (the portable `ScheduledTaskHandle`): idempotent Start/Stop, bounded wait-for-current-run, **sleeps until the earliest due-time** (no busy poll), no overlapping runs, whole-period catch-up, `onError` isolation.
- **Injectable clock seam** (`Clock`/`RealClock`/`ManualClock`) routes the scheduler wait + sensors' periodic due-check + rate elapsed; payload/bar timestamps keep the real clock (no new wall-clock fixtures — preserves the #1094 deferral's cost/benefit).

## Error handling & logging
- Swallow-all isolation on every host callback; `MessageDeduplicator` (window/capacity/oldest-expiry/count-suffix, zero-window=log-immediately); error routing (shutdown discard → dedup → sink).

## Verification
69/69 native (53 corpus/meta + 16 new `native_*` unit tests: version/status/dispose/listeners/TestConnection/MaxSensors/options-validation/clock-seam/onError/dedup). Windows MSVC `/WX` clean; clang + ASan/TSan via CI. Flake screen rate/function/bar_rollover + clock-seam 30× green. Test-only `hsm_collector_test_*` symbols are forward-declared by the test TU, never in the public header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)