### PR TITLE
Native HTTP transport: libcurl + retry + 4xx/5xx fix + E2E (#1096 PR2)

### DIFF
--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -86,6 +86,47 @@ jobs:
       - name: Test
         run: ctest --test-dir build/native-clang --output-on-failure
 
+  http-transport:
+    # Builds the optional libcurl HTTP transport (HSM_COLLECTOR_HTTP=ON) and runs the
+    # transport-only tests: the in-proc capture-server E2E, the endpoint route table, and the
+    # retry policy. curl comes from vcpkg manifest mode (src/native/collector/vcpkg.json), so
+    # the baseline there must stay an upstream microsoft/vcpkg commit. ssl-only feature set →
+    # Schannel on Windows / OpenSSL on Linux, no heavyweight TLS build.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      VCPKG_DISABLE_METRICS: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Linux build deps for vcpkg curl
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y nasm
+
+      # Pinned to the vcpkg.json builtin-baseline so the manifest resolves deterministically.
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 6f29f12e82a8293156836ad81cc9bf5af41fe836
+
+      - name: Configure (HTTP transport on)
+        run: >
+          cmake -S src/native/collector -B build/native-http
+          -DHSM_COLLECTOR_WERROR=ON
+          -DHSM_COLLECTOR_HTTP=ON
+          -DCMAKE_TOOLCHAIN_FILE=${{ env.VCPKG_ROOT }}/scripts/buildsystems/vcpkg.cmake
+
+      - name: Build
+        run: cmake --build build/native-http --config Release --parallel
+
+      # Transport E2E (real libcurl against a loopback capture server), route table, retry policy.
+      - name: Test (HTTP lane)
+        run: ctest --test-dir build/native-http -C Release --output-on-failure -R "native_http"
+
   sanitizers:
     # ASan+UBSan and TSan on Linux clang. These exercise the multi-threaded
     # scheduler/worker that the single-threaded corpus run cannot stress.

--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -114,6 +114,12 @@ jobs:
           vcpkgGitCommitId: 6f29f12e82a8293156836ad81cc9bf5af41fe836
 
       - name: Configure (HTTP transport on)
+        # vcpkg manifest install runs here (cmake project() triggers it). run-vcpkg defaults
+        # VCPKG_BINARY_SOURCES to "clear;x-gha,readwrite", whose GHA backend needs
+        # ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL that aren't reliably exported — failing the
+        # install. Override to "clear" for this step so curl is built from source, no cache tokens.
+        env:
+          VCPKG_BINARY_SOURCES: clear
         run: >
           cmake -S src/native/collector -B build/native-http
           -DHSM_COLLECTOR_WERROR=ON

--- a/aicontext/features/collector/http-client/feature.md
+++ b/aicontext/features/collector/http-client/feature.md
@@ -1,6 +1,6 @@
 # Feature: HTTP Client
 
-> Owner: collector | Last reviewed: 2026-06-10 | Canonical: yes
+> Owner: collector | Last reviewed: 2026-06-16 | Canonical: yes
 > Scope: Collector - HTTPS transport with Polly retry for sending sensor data
 
 ---
@@ -20,6 +20,7 @@
 - `HttpResponseMessage` is always disposed after use (`using` blocks).
 - `HttpContent` is disposed after sending (in `ExecutePipelineAsync`).
 - Polly retry per handler: data/priority/file — 10 attempts, exponential backoff 1 s → 2 min; commands — `int.MaxValue` attempts, linear backoff.
+- `ShouldHandle` (`BaseHandlers.ShouldRetry`, #1096): transport-level exceptions are always retried; a returned **5xx** is retried too, but **only on the bounded** data/priority/file pipelines — the unbounded command pipeline stays exceptions-only so a persistent 5xx cannot hang it forever. **4xx** are permanent and never retried. A 5xx that exhausts the bounded budget still falls through to queue re-enqueue, so no data is lost.
 - `CancelPendingRequests()` (`ICancelableDataSender`, called by collector Stop) cancels the shared in-flight token and installs a fresh one. It must **NOT** dispose the HttpClient — disposal during a graceful stop converted remaining flush sends into `ObjectDisposedException` data loss (PR #1080 finding #7; regression-tested in `HsmHttpsClientCancellationTests`).
 - `PackageSendingInfo` captures content size (chars), success flag, and error string (`"Code: {status}. {content}"` or exception message) for self-diagnostics.
 - JSON: System.Text.Json, `AllowNamedFloatingPointLiterals`, runtime-polymorphic write via `JsonRequestConverter`.
@@ -35,7 +36,10 @@
 |---|---|
 | `Client/HttpsClient/HsmHttpsClient.cs` | HttpClient lifecycle, dispose, test connection |
 | `Client/HttpsClient/Endpoints.cs` | URL construction from CollectorOptions |
-| `Client/HttpsClient/RequestHandlers/BaseHandlers.cs` | Polly pipeline, send logic, error logging |
+| `Client/HttpsClient/RequestHandlers/BaseHandlers.cs` | Polly pipeline, send logic, error logging, `ShouldRetry` (4xx/5xx, #1096) |
+| `../../src/native/collector/src/hsm_http_transport.{hpp,cpp}` | Native (C++) libcurl transport — Post/Get, timeout, cert-bypass, xfer-abort cancel |
+| `../../src/native/collector/src/hsm_http_endpoints.hpp` | Native route table + scheme defaulting (mirror of `Endpoints.cs` + `*Handlers.GetUri`) |
+| `../../src/native/collector/src/hsm_http_retry.hpp` | Native retry policy (mirror of the Polly pipelines + `ShouldRetry`) |
 
 ---
 
@@ -55,7 +59,18 @@ All under `https://{server}:{port}/api/sensors/`:
 
 ---
 
+## Native port (C++) — #1096
+
+The native collector (`src/native/collector`) emits the **byte-identical** wire stream (see `../../api/wire-contract/feature.md`) and ships a real HTTP transport that mirrors this client:
+
+- `hsm_http_transport.{hpp,cpp}` — a libcurl easy-handle wrapper (`Post`/`Get`), confined to one TU so the rest of the core never sees `<curl/curl.h>` and the `-Werror`/`/WX` gate stays green. `CURLOPT_TIMEOUT_MS` ↔ `RequestTimeout`, `CURLOPT_SSL_VERIFYPEER` ↔ `AllowUntrustedServerCertificate`, `CURLOPT_XFERINFOFUNCTION`-abort ↔ `CancelPendingRequests`. Built only when `HSM_COLLECTOR_HTTP=ON` (curl via vcpkg manifest); the default build is curl-free.
+- `hsm_http_endpoints.hpp` — pure route table + scheme defaulting (bare host → https; explicit `http` kept only with `AllowPlaintextTransport`), and per-kind / batch / command routing identical to `DataHandlers`/`CommandHandler.GetUri`.
+- `hsm_http_retry.hpp` — the retry policy with the same `ShouldRetry` semantics (bounded 5xx retry, unbounded commands exceptions-only, 4xx never).
+
+Routing + retry are pure headers compiled into the always-on core, so they are unit-tested in the default `/WX` lane (`native_http_endpoint_routing_matches_net`, `native_http_retry_policy_matches_net`); the transport is exercised by an in-proc capture-server E2E (`native_http_transport_posts_to_capture_server`) in the `HSM_COLLECTOR_HTTP` CI lane. The .NET side of the 5xx fix is pinned by `Retry5xxParityTests` against the fake server.
+
+**Remaining integration step:** the native live send path still records to an in-memory sender behind the test seam (`TrySendBatch`); swapping it to dispatch wire bytes through `HttpTransport` in production requires a staged/real HSM server for true request-parity E2E and is the final wiring task of the native port.
+
 ## Known Issues / Limitations
 
-- Polly retry does not configure `ShouldHandle` for HTTP status codes. Only transport-level exceptions trigger retries. HTTP 4xx/5xx responses are accepted as "successful" by Polly and the data is silently lost.
 - No circuit breaker pattern. If the server is down for extended periods, each batch attempt will exhaust all retry attempts before failing.

--- a/src/collector/HSMDataCollector.IntegrationTests/Helpers/FakeHsmServer.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Helpers/FakeHsmServer.cs
@@ -28,6 +28,9 @@ namespace HSMDataCollector.IntegrationTests.Helpers
         // Data POSTs to fail with 503 before the first success (decremented per data request).
         private int _failDataRequests;
 
+        // Command POSTs (/commands, /addOrUpdate) to fail with 503 before the first success.
+        private int _failCommandRequests;
+
         public FakeHsmServer()
         {
             Port = GetFreeTcpPort();
@@ -47,6 +50,15 @@ namespace HSMDataCollector.IntegrationTests.Helpers
         /// <summary>The next <paramref name="count"/> data POSTs answer 503; the collector must
         /// re-enqueue and retry until they stop failing.</summary>
         public void FailNextDataRequests(int count) => Interlocked.Exchange(ref _failDataRequests, count);
+
+        /// <summary>The next <paramref name="count"/> command POSTs (/commands or /addOrUpdate)
+        /// answer 503.</summary>
+        public void FailNextCommandRequests(int count) => Interlocked.Exchange(ref _failCommandRequests, count);
+
+        public IEnumerable<CapturedRequest> CommandRequests =>
+            Requests.Where(r => r.Method == "POST"
+                                && (r.Path.EndsWith("/addOrUpdate", StringComparison.Ordinal)
+                                    || r.Path.EndsWith("/commands", StringComparison.Ordinal)));
 
         public IEnumerable<CapturedRequest> DataRequests =>
             Requests.Where(r => r.Method == "POST"
@@ -84,9 +96,11 @@ namespace HSMDataCollector.IntegrationTests.Helpers
                 body = reader.ReadToEnd();
 
             var path = request.Url?.AbsolutePath ?? string.Empty;
+            var isCommand = request.HttpMethod == "POST"
+                            && (path.EndsWith("/addOrUpdate", StringComparison.Ordinal)
+                                || path.EndsWith("/commands", StringComparison.Ordinal));
             var isData = request.HttpMethod == "POST"
-                         && !path.EndsWith("/addOrUpdate", StringComparison.Ordinal)
-                         && !path.EndsWith("/commands", StringComparison.Ordinal)
+                         && !isCommand
                          && !path.EndsWith("/testConnection", StringComparison.Ordinal);
 
             _requests.Enqueue(new CapturedRequest(
@@ -101,6 +115,10 @@ namespace HSMDataCollector.IntegrationTests.Helpers
                 statusCode = HttpStatusCode.ServiceUnavailable;
             else if (isData)
                 Interlocked.Increment(ref _failDataRequests); // floor the counter at 0
+            else if (isCommand && Interlocked.Decrement(ref _failCommandRequests) >= 0)
+                statusCode = HttpStatusCode.ServiceUnavailable;
+            else if (isCommand)
+                Interlocked.Increment(ref _failCommandRequests); // floor the counter at 0
 
             try
             {

--- a/src/collector/HSMDataCollector.IntegrationTests/Tests/FakeServerE2ETests.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Tests/FakeServerE2ETests.cs
@@ -86,9 +86,10 @@ namespace HSMDataCollector.IntegrationTests.Tests
         public async Task TransientServerFailure_ValueEventuallyLands_ViaReEnqueue()
         {
             using var server = new FakeHsmServer();
-            // The default Polly pipeline retries only exceptions, not 5xx — but the queue
-            // re-enqueues a package whose send returned a non-success status, so the value
-            // survives a transient 503 and lands on a later collect cycle.
+            // The bounded data pipeline now retries 5xx within its own budget (#1096), and the
+            // queue still re-enqueues a package whose send ultimately returned a non-success
+            // status — either way the value survives a transient 503 and lands. (The precise
+            // pipeline-vs-re-enqueue behaviour is pinned by Retry5xxParityTests.)
             server.FailNextDataRequests(2);
 
             using var collector = new DataCollector(OptionsFor(server));

--- a/src/collector/HSMDataCollector.IntegrationTests/Tests/Retry5xxParityTests.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Tests/Retry5xxParityTests.cs
@@ -1,0 +1,76 @@
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HSMDataCollector.Client;
+using HSMDataCollector.Core;
+using HSMDataCollector.IntegrationTests.Helpers;
+using HSMDataCollector.Logging;
+using HSMSensorDataObjects.SensorRequests;
+using HSMSensorDataObjects.SensorValueRequests;
+using Xunit;
+
+namespace HSMDataCollector.IntegrationTests.Tests
+{
+    /// <summary>
+    /// Reproducing scenario + regression lock for the #1096 4xx/5xx ShouldHandle fix
+    /// (BaseHandlers.ShouldRetry). Before the fix the Polly pipeline only retried on EXCEPTIONS,
+    /// so a returned 5xx was treated as a final outcome — the data path recovered only via the
+    /// slower queue re-enqueue (one attempt per collect cycle, each logged as an error). The fix
+    /// makes the BOUNDED data/priority/file pipelines retry 5xx within their own budget, while the
+    /// UNBOUNDED command pipeline deliberately stays exceptions-only so a persistent 5xx can never
+    /// hang it forever. These tests drive the real HsmHttpsClient handler stack against the
+    /// in-process fake server, so they exercise the actual Polly pipelines, not a mock.
+    /// </summary>
+    [Trait("Category", "Integration")]
+    [Trait("Category", "FakeServerE2E")]
+    public sealed class Retry5xxParityTests
+    {
+        private static CollectorOptions OptionsFor(FakeHsmServer server) => new CollectorOptions
+        {
+            ServerAddress = server.ServerAddress,
+            Port = server.Port,
+            AccessKey = "retry-parity-key",
+            ClientName = "retry-parity-client",
+            AllowPlaintextTransport = true,
+        };
+
+        [Fact]
+        public async Task DataPipeline_RetriesTransient5xx_WithinOneSend_AndSucceeds()
+        {
+            using var server = new FakeHsmServer();
+            server.FailNextDataRequests(2); // 503, 503, then 200
+
+            using var client = new HsmHttpsClient(OptionsFor(server), new LoggerManager());
+
+            var value = new IntSensorValue { Path = "retry/data/int", Value = 7 };
+            var info = await client.SendDataAsync(new[] { value }, CancellationToken.None);
+
+            // The fix: the bounded data pipeline retried the two 503s internally and landed the 200,
+            // so the single SendDataAsync reports success. Pre-fix this returned the first 503
+            // (IsSuccess == false), forcing recovery onto the queue re-enqueue path instead.
+            Assert.True(info.IsSuccess, $"Expected success after transient 5xx retries; Error = {info.Error}");
+
+            // Three HTTP attempts inside ONE SendDataAsync proves Polly retried (not queue re-enqueue,
+            // which would be one attempt per call). Pre-fix this count would be 1.
+            Assert.Equal(3, server.DataRequests.Count(r => r.Body.Contains("retry/data/int")));
+        }
+
+        [Fact]
+        public async Task CommandPipeline_5xx_IsNotResultRetried_ReturnsWithoutHanging()
+        {
+            using var server = new FakeHsmServer();
+            server.FailNextCommandRequests(1); // one 503 on /commands
+
+            using var client = new HsmHttpsClient(OptionsFor(server), new LoggerManager());
+
+            var command = new AddOrUpdateSensorRequest { Path = "retry/command/int" };
+            var info = await client.SendCommandAsync(new[] { command }, CancellationToken.None);
+
+            // The command pipeline is unbounded (int.MaxValue retries) but exceptions-only: a 5xx is
+            // a returned result, so ShouldRetry says no and the send returns the failure immediately.
+            // This is the guard that keeps a persistent server error from hanging commands forever.
+            Assert.False(info.IsSuccess);
+            Assert.Equal(1, server.CommandRequests.Count(r => r.Body.Contains("retry/command/int")));
+        }
+    }
+}

--- a/src/collector/HSMDataCollector/Client/HttpsClient/RequestHandlers/BaseHandlers.cs
+++ b/src/collector/HSMDataCollector/Client/HttpsClient/RequestHandlers/BaseHandlers.cs
@@ -40,6 +40,7 @@ namespace HSMDataCollector.Client.HttpsClient
                 MaxDelay = TimeSpan.FromMinutes(2),
                 Delay    = TimeSpan.FromSeconds(1),
 
+                ShouldHandle = ShouldRetry,
                 OnRetry  = LogException,
             };
 
@@ -58,6 +59,25 @@ namespace HSMDataCollector.Client.HttpsClient
 
         internal abstract string GetUri(object rawData);
 
+
+        // Retry predicate (#1096). The default Polly pipeline only retried on EXCEPTIONS, so a
+        // returned non-success HttpResponseMessage (4xx/5xx) was treated as success and the data
+        // was dropped (silent loss). We now also retry server-side 5xx — but ONLY on the bounded
+        // pipelines (data/priority/file, MaxRetryAttempts = 10). The command pipeline retries
+        // unboundedly (for connection failures while the server restarts); applying result-retry
+        // there would let a persistent 5xx hang a command send forever, so commands stay
+        // exceptions-only and rely on the per-sensor error dictionary in the response. Client 4xx
+        // are permanent (bad payload/auth) and are never retried.
+        private ValueTask<bool> ShouldRetry(RetryPredicateArguments<HttpResponseMessage> args)
+        {
+            if (args.Outcome.Exception != null)
+                return new ValueTask<bool>(true);
+
+            var response = args.Outcome.Result;
+            var isServerError = response != null && (int)response.StatusCode >= 500;
+
+            return new ValueTask<bool>(isServerError && MaxRequestAttempts != int.MaxValue);
+        }
 
         private ValueTask LogException(OnRetryArguments<HttpResponseMessage> args)
         {

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -184,6 +184,8 @@ set(NATIVE_REGRESSION_TESTS
     native_wire_file_json_matches_net_byte_layout
     native_wire_timespan_and_version_match_net
     native_wire_registration_json_matches_net_byte_layout
+    native_http_endpoint_routing_matches_net
+    native_http_retry_policy_matches_net
     native_lifecycle_listener_can_register_another_listener
     native_test_connection_reports_reachable
     native_max_sensors_cap_rejects_beyond_limit

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -124,7 +124,19 @@ target_link_libraries(hsm_collector_tests PRIVATE hsm_collector_core)
 hsm_collector_set_warnings(hsm_collector_tests)
 hsm_collector_apply_sanitizer(hsm_collector_tests)
 
+# The HTTP-transport E2E test compiles only in the HTTP build (it needs the transport + the
+# in-proc capture server). The define gates the #ifdef'd test code; ws2_32 auto-links on MSVC.
+if(HSM_COLLECTOR_HTTP)
+    target_compile_definitions(hsm_collector_tests PRIVATE HSM_COLLECTOR_HTTP=1)
+endif()
+
 enable_testing()
+
+if(HSM_COLLECTOR_HTTP)
+    add_test(NAME native_http_transport_posts_to_capture_server
+        COMMAND hsm_collector_tests native_http_transport_posts_to_capture_server
+    )
+endif()
 
 add_test(NAME native_invalid_argument_clears_out_params
     COMMAND hsm_collector_tests native_invalid_argument_clears_out_params

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -90,6 +90,19 @@ target_link_libraries(hsm_collector_core PUBLIC Threads::Threads)
 hsm_collector_set_warnings(hsm_collector_core)
 hsm_collector_apply_sanitizer(hsm_collector_core)
 
+# libcurl HTTP transport (#1096 §12). Opt-in so the serialization/behavior build and the existing
+# CI lanes need no curl/vcpkg; the dedicated HTTP lane sets it ON (vcpkg.json provides curl[ssl] —
+# Schannel on Windows, OpenSSL elsewhere). curl headers are SYSTEM so the -Werror gate ignores
+# them; only hsm_http_transport.cpp includes <curl/curl.h>.
+option(HSM_COLLECTOR_HTTP "Build the libcurl HTTP transport" OFF)
+if(HSM_COLLECTOR_HTTP)
+    find_package(CURL REQUIRED)
+    target_sources(hsm_collector_core PRIVATE src/hsm_http_transport.cpp)
+    target_compile_definitions(hsm_collector_core PRIVATE HSM_COLLECTOR_HTTP=1)
+    target_link_libraries(hsm_collector_core PRIVATE CURL::libcurl)
+    target_include_directories(hsm_collector_core SYSTEM PRIVATE ${CURL_INCLUDE_DIRS})
+endif()
+
 # Header-only C++ RAII wrapper over the C ABI.
 add_library(hsm_collector_cpp INTERFACE)
 

--- a/src/native/collector/src/hsm_http_endpoints.hpp
+++ b/src/native/collector/src/hsm_http_endpoints.hpp
@@ -1,0 +1,159 @@
+#pragma once
+
+#include <cctype>
+#include <string>
+
+#include "hsm_collector/hsm_collector.h"
+
+// Native mirror of the .NET collector's Endpoints + per-type routing
+// (src/collector/HSMDataCollector/Client/HttpsClient/Endpoints.cs,
+//  RequestHandlers/DataHandlers.cs, RequestHandlers/CommandHandlers.cs).
+//
+// Pure string logic, no libcurl — compiled into the always-on core so the route table and
+// the scheme-defaulting rules are unit-tested in the default /WX lane, not only the HTTP build.
+//
+// Faithful to the .NET behaviour for the inputs the collector actually feeds it (a bare host or
+// a "scheme://host" URL). The .NET side runs ServerUrl through UriBuilder{Port, Path="api/sensors"};
+// we reproduce the observable result — "<scheme>://<host>:<port>/api/sensors" with the scheme
+// defaulted to https unless an explicit http scheme is paired with AllowPlaintextTransport.
+// UriBuilder corner cases the collector never produces (userinfo, query, embedded path) are out
+// of scope; the host is taken verbatim after the scheme is stripped.
+namespace hsm::http
+{
+    struct Endpoints
+    {
+        std::string connection_address; // "<scheme>://<host>:<port>/api/sensors"
+
+        // Command routes.
+        std::string AddOrUpdateSensor() const { return connection_address + "/addOrUpdate"; }
+        std::string CommandsList() const { return connection_address + "/commands"; }
+
+        // Single-value routes (one per sensor kind), matching DataHandlers.GetUri.
+        std::string Bool() const { return connection_address + "/bool"; }
+        std::string Integer() const { return connection_address + "/int"; }
+        std::string Double() const { return connection_address + "/double"; }
+        std::string String() const { return connection_address + "/string"; }
+        std::string Timespan() const { return connection_address + "/timespan"; }
+        std::string Version() const { return connection_address + "/version"; }
+        std::string Rate() const { return connection_address + "/rate"; }
+        std::string Enum() const { return connection_address + "/enum"; }
+        std::string DoubleBar() const { return connection_address + "/doubleBar"; }
+        std::string IntBar() const { return connection_address + "/intBar"; }
+
+        // Batch / file routes.
+        std::string List() const { return connection_address + "/list"; }
+        std::string File() const { return connection_address + "/file"; }
+
+        std::string TestConnection() const { return connection_address + "/testConnection"; }
+    };
+
+    namespace detail
+    {
+        // Strip a leading "scheme://" and return (scheme, remainder). scheme is empty when absent.
+        inline void SplitScheme(const std::string& url, std::string& scheme, std::string& rest)
+        {
+            const auto sep = url.find("://");
+            if (sep == std::string::npos)
+            {
+                scheme.clear();
+                rest = url;
+                return;
+            }
+
+            scheme = url.substr(0, sep);
+            rest = url.substr(sep + 3);
+        }
+
+        // Keep only the host: drop any path, query, or :port that an explicit URL might carry
+        // (the collector passes Port separately, so an embedded port is ignored just as UriBuilder
+        // overwrites it with the explicit Port).
+        inline std::string HostOnly(const std::string& authority)
+        {
+            std::string host = authority;
+            const auto slash = host.find('/');
+            if (slash != std::string::npos)
+                host = host.substr(0, slash);
+
+            const auto colon = host.find(':');
+            if (colon != std::string::npos)
+                host = host.substr(0, colon);
+
+            return host;
+        }
+
+        inline bool EqualsIgnoreCase(const std::string& a, const char* b)
+        {
+            size_t i = 0;
+            for (; i < a.size() && b[i] != '\0'; ++i)
+            {
+                const char ca = static_cast<char>(std::tolower(static_cast<unsigned char>(a[i])));
+                const char cb = static_cast<char>(std::tolower(static_cast<unsigned char>(b[i])));
+                if (ca != cb)
+                    return false;
+            }
+            return i == a.size() && b[i] == '\0';
+        }
+    } // namespace detail
+
+    // Mirror of Endpoints(CollectorOptions): scheme defaulting + the /api/sensors base path.
+    inline Endpoints MakeEndpoints(const std::string& server_url, int32_t port, bool allow_plaintext)
+    {
+        std::string scheme;
+        std::string rest;
+        detail::SplitScheme(server_url, scheme, rest);
+
+        const bool has_explicit_scheme = !scheme.empty();
+        const std::string host = detail::HostOnly(rest);
+
+        std::string effective_scheme = "https";
+        if (has_explicit_scheme)
+        {
+            if (detail::EqualsIgnoreCase(scheme, "http") && allow_plaintext)
+                effective_scheme = "http";
+            else if (!detail::EqualsIgnoreCase(scheme, "http"))
+                effective_scheme = scheme; // preserve an explicit https (or any non-http) scheme
+        }
+
+        Endpoints endpoints;
+        endpoints.connection_address =
+            effective_scheme + "://" + host + ":" + std::to_string(port) + "/api/sensors";
+        return endpoints;
+    }
+
+    // DataHandlers.GetUri: a single value goes to its kind-specific route; a batch goes to /list.
+    inline std::string RouteForSensorValue(const Endpoints& endpoints, hsm_sensor_type_t type, bool is_batch)
+    {
+        if (is_batch)
+            return endpoints.List();
+
+        switch (type)
+        {
+        case HSM_SENSOR_TYPE_BOOLEAN:
+            return endpoints.Bool();
+        case HSM_SENSOR_TYPE_INT:
+            return endpoints.Integer();
+        case HSM_SENSOR_TYPE_DOUBLE:
+            return endpoints.Double();
+        case HSM_SENSOR_TYPE_STRING:
+            return endpoints.String();
+        case HSM_SENSOR_TYPE_INT_BAR:
+            return endpoints.IntBar();
+        case HSM_SENSOR_TYPE_DOUBLE_BAR:
+            return endpoints.DoubleBar();
+        case HSM_SENSOR_TYPE_FILE:
+            return endpoints.File();
+        case HSM_SENSOR_TYPE_RATE:
+            return endpoints.Rate();
+        case HSM_SENSOR_TYPE_ENUM:
+            return endpoints.Enum();
+        default:
+            return {}; // Unsupported kind — the .NET side throws; the caller treats empty as "no route".
+        }
+    }
+
+    // CommandHandler.GetUri: a batch of commands → /commands, a single AddOrUpdate → /addOrUpdate.
+    inline std::string RouteForCommand(const Endpoints& endpoints, bool is_batch)
+    {
+        return is_batch ? endpoints.CommandsList() : endpoints.AddOrUpdateSensor();
+    }
+} // namespace hsm::http

--- a/src/native/collector/src/hsm_http_retry.hpp
+++ b/src/native/collector/src/hsm_http_retry.hpp
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <cstdint>
+
+// Native mirror of the .NET resilience pipelines
+// (src/collector/HSMDataCollector/Client/HttpsClient/RequestHandlers/BaseHandlers.cs +
+//  DataHandlers.cs + CommandHandlers.cs). Pure arithmetic, no libcurl — compiled into the
+// always-on core so the retry decision + the backoff schedule are unit-tested in the /WX lane.
+//
+// Two pipeline shapes, exactly as Polly is configured on the managed side:
+//   * Bounded (data / priority / file):   MaxRetryAttempts = 10,           Exponential backoff.
+//   * Unbounded (commands / addOrUpdate): MaxRetryAttempts = int.MaxValue, Linear backoff.
+// Both use Delay = 1s and MaxDelay = 2min.
+//
+// ShouldRetry mirrors the #1096 BaseHandlers.ShouldRetry fix:
+//   * a transport-level failure (connect refused / timeout / cancelled == a thrown exception
+//     on the managed side) is always retried;
+//   * a non-success HTTP result is retried ONLY for 5xx AND only on the bounded pipelines —
+//     a persistent 5xx must not hang the unbounded command pipeline forever;
+//   * 4xx are permanent and never retried.
+namespace hsm::http
+{
+    enum class BackoffType
+    {
+        Exponential, // bounded data/priority/file pipelines
+        Linear,      // unbounded command pipeline
+    };
+
+    struct RetryPolicy
+    {
+        int32_t max_attempts = 10; // int.MaxValue (or <0) == unbounded
+        BackoffType backoff = BackoffType::Exponential;
+        int64_t base_delay_ms = 1000;  // Polly Delay = 1s
+        int64_t max_delay_ms = 120000; // Polly MaxDelay = 2min
+
+        bool IsBounded() const { return max_attempts >= 0 && max_attempts != INT32_MAX; }
+
+        // Bounded data/priority/file pipeline.
+        static RetryPolicy Data()
+        {
+            return RetryPolicy{ 10, BackoffType::Exponential, 1000, 120000 };
+        }
+
+        // Unbounded command/addOrUpdate pipeline.
+        static RetryPolicy Commands()
+        {
+            return RetryPolicy{ INT32_MAX, BackoffType::Linear, 1000, 120000 };
+        }
+
+        // Decide whether to retry after one attempt. transport_ok == false models a thrown
+        // exception (always retryable); otherwise the HTTP status decides.
+        bool ShouldRetry(bool transport_ok, int64_t status_code) const
+        {
+            if (!transport_ok)
+                return true;
+
+            const bool is_success = status_code >= 200 && status_code < 300;
+            if (is_success)
+                return false;
+
+            const bool is_server_error = status_code >= 500;
+            return is_server_error && IsBounded();
+        }
+
+        // Whether another attempt is allowed given how many have already run (1-based count).
+        bool HasAttemptsLeft(int32_t attempts_made) const
+        {
+            if (!IsBounded())
+                return true;
+            // MaxRetryAttempts is the number of RETRIES on top of the first try.
+            return attempts_made <= max_attempts;
+        }
+
+        // Backoff before the (retry_index)-th retry, retry_index 0-based (delay before retry #1
+        // is DelayMs(0)). Polly v8: Exponential = base * 2^n, Linear = base * (n + 1); both
+        // clamped to MaxDelay.
+        int64_t DelayMs(int32_t retry_index) const
+        {
+            int64_t delay;
+            if (backoff == BackoffType::Exponential)
+            {
+                delay = base_delay_ms;
+                for (int32_t i = 0; i < retry_index && delay < max_delay_ms; ++i)
+                    delay *= 2;
+            }
+            else
+            {
+                delay = base_delay_ms * (static_cast<int64_t>(retry_index) + 1);
+            }
+
+            return delay > max_delay_ms ? max_delay_ms : delay;
+        }
+    };
+} // namespace hsm::http

--- a/src/native/collector/src/hsm_http_transport.cpp
+++ b/src/native/collector/src/hsm_http_transport.cpp
@@ -7,13 +7,16 @@ namespace hsm::http
     namespace
     {
         // libcurl needs one process-wide init before any easy handle is used. A function-local
-        // static gives thread-safe once-only init; cleanup runs at process exit.
+        // static gives thread-safe once-only init. We deliberately DO NOT call
+        // curl_global_cleanup(): it is not thread-safe and, run from a static destructor at
+        // process exit, would race any still-live easy handles / worker threads (and TSan would
+        // flag it). Leaking the one-time global allocation is the documented, safe choice for a
+        // library that cannot prove all curl users have quiesced.
         void EnsureCurlGlobal()
         {
             struct CurlGlobal
             {
                 CurlGlobal() { curl_global_init(CURL_GLOBAL_DEFAULT); }
-                ~CurlGlobal() { curl_global_cleanup(); }
             };
             static CurlGlobal global;
             (void)global;

--- a/src/native/collector/src/hsm_http_transport.cpp
+++ b/src/native/collector/src/hsm_http_transport.cpp
@@ -1,0 +1,121 @@
+#include "hsm_http_transport.hpp"
+
+#include <curl/curl.h>
+
+namespace hsm::http
+{
+    namespace
+    {
+        // libcurl needs one process-wide init before any easy handle is used. A function-local
+        // static gives thread-safe once-only init; cleanup runs at process exit.
+        void EnsureCurlGlobal()
+        {
+            struct CurlGlobal
+            {
+                CurlGlobal() { curl_global_init(CURL_GLOBAL_DEFAULT); }
+                ~CurlGlobal() { curl_global_cleanup(); }
+            };
+            static CurlGlobal global;
+            (void)global;
+        }
+
+        size_t WriteCallback(char* ptr, size_t size, size_t nmemb, void* userdata)
+        {
+            const size_t total = size * nmemb;
+            static_cast<std::string*>(userdata)->append(ptr, total);
+            return total;
+        }
+
+        // Returning non-zero aborts the transfer — the CancelPendingRequests primitive.
+        int XferCallback(void* clientp, curl_off_t, curl_off_t, curl_off_t, curl_off_t)
+        {
+            return static_cast<std::atomic<bool>*>(clientp)->load() ? 1 : 0;
+        }
+
+        HttpResponse Perform(
+            const std::string& url,
+            const std::vector<HttpHeader>& headers,
+            int64_t timeout_ms,
+            bool verify_peer,
+            std::atomic<bool>& cancelled,
+            bool is_post,
+            const std::string& body)
+        {
+            HttpResponse response;
+
+            CURL* curl = curl_easy_init();
+            if (curl == nullptr)
+            {
+                response.error = "curl_easy_init failed";
+                return response;
+            }
+
+            curl_slist* header_list = nullptr;
+            for (const auto& header : headers)
+                header_list = curl_slist_append(header_list, (header.name + ": " + header.value).c_str());
+
+            curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
+            curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);
+            curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteCallback);
+            curl_easy_setopt(curl, CURLOPT_WRITEDATA, &response.body);
+            curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeout_ms));
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, verify_peer ? 1L : 0L);
+            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, verify_peer ? 2L : 0L);
+            curl_easy_setopt(curl, CURLOPT_NOPROGRESS, 0L);
+            curl_easy_setopt(curl, CURLOPT_XFERINFOFUNCTION, XferCallback);
+            curl_easy_setopt(curl, CURLOPT_XFERINFODATA, &cancelled);
+
+            if (is_post)
+            {
+                curl_easy_setopt(curl, CURLOPT_POST, 1L);
+                curl_easy_setopt(curl, CURLOPT_POSTFIELDS, body.c_str());
+                curl_easy_setopt(curl, CURLOPT_POSTFIELDSIZE, static_cast<long>(body.size()));
+            }
+
+            const CURLcode rc = curl_easy_perform(curl);
+            if (rc == CURLE_OK)
+            {
+                long code = 0;
+                curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &code);
+                response.transport_ok = true;
+                response.status_code = code;
+            }
+            else
+            {
+                response.error = curl_easy_strerror(rc);
+            }
+
+            curl_slist_free_all(header_list);
+            curl_easy_cleanup(curl);
+            return response;
+        }
+    } // namespace
+
+    HttpTransport::HttpTransport(int64_t timeout_ms, bool verify_peer)
+        : timeout_ms_(timeout_ms), verify_peer_(verify_peer)
+    {
+        EnsureCurlGlobal();
+    }
+
+    HttpTransport::~HttpTransport() = default;
+
+    void HttpTransport::Cancel()
+    {
+        cancelled_.store(true);
+    }
+
+    void HttpTransport::ResetCancel()
+    {
+        cancelled_.store(false);
+    }
+
+    HttpResponse HttpTransport::Post(const std::string& url, const std::string& json_body, const std::vector<HttpHeader>& headers)
+    {
+        return Perform(url, headers, timeout_ms_, verify_peer_, cancelled_, /*is_post=*/true, json_body);
+    }
+
+    HttpResponse HttpTransport::Get(const std::string& url, const std::vector<HttpHeader>& headers)
+    {
+        return Perform(url, headers, timeout_ms_, verify_peer_, cancelled_, /*is_post=*/false, std::string{});
+    }
+} // namespace hsm::http

--- a/src/native/collector/src/hsm_http_transport.hpp
+++ b/src/native/collector/src/hsm_http_transport.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+// Internal C++ HTTP transport for the native collector (#1096 §12). NOT part of the C ABI — it
+// sits behind the in-collector send path. libcurl is confined to hsm_http_transport.cpp so the
+// rest of the core never sees <curl/curl.h> (and the -Werror gate never lints curl headers).
+namespace hsm::http
+{
+    struct HttpHeader
+    {
+        std::string name;
+        std::string value;
+    };
+
+    struct HttpResponse
+    {
+        // transport_ok = a response was received (any HTTP status). On a transport-level failure
+        // (connect refused, timeout, cancelled) transport_ok is false and error carries the reason.
+        bool transport_ok = false;
+        long status_code = 0;
+        std::string body;
+        std::string error;
+
+        bool IsSuccess() const { return transport_ok && status_code >= 200 && status_code < 300; }
+    };
+
+    // One transport per collector. Each call uses its own libcurl easy handle, so concurrent calls
+    // are safe. Cancel() aborts in-flight transfers (the CancelPendingRequests primitive); a fresh
+    // ResetCancel() re-arms it for subsequent sends without tearing the transport down.
+    class HttpTransport
+    {
+    public:
+        HttpTransport(int64_t timeout_ms, bool verify_peer);
+        ~HttpTransport();
+
+        HttpTransport(const HttpTransport&) = delete;
+        HttpTransport& operator=(const HttpTransport&) = delete;
+
+        HttpResponse Post(const std::string& url, const std::string& json_body, const std::vector<HttpHeader>& headers);
+        HttpResponse Get(const std::string& url, const std::vector<HttpHeader>& headers);
+
+        void Cancel();
+        void ResetCancel();
+
+    private:
+        int64_t timeout_ms_;
+        bool verify_peer_;
+        std::atomic<bool> cancelled_{ false };
+    };
+} // namespace hsm::http

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -18,6 +18,11 @@
 #include <utility>
 #include <vector>
 
+#if defined(HSM_COLLECTOR_HTTP)
+#include "../src/hsm_http_transport.hpp"
+#include "http_capture_server.hpp"
+#endif
+
 // Test-only seam (defined in hsm_collector.cpp, deliberately not in the public header): drive
 // the scheduler's injectable clock from the native unit tests (issue #1095 §13).
 extern "C" void hsm_collector_test_install_manual_clock(hsm_collector_t* collector, int64_t base_ms);
@@ -2752,6 +2757,38 @@ namespace
             "file wire layout (List<byte> numeric array)");
     }
 
+#if defined(HSM_COLLECTOR_HTTP)
+    void NativeHttpTransportPostsToCaptureServer()
+    {
+        hsm::test::HttpCaptureServer server(200);
+        hsm::http::HttpTransport transport(5000, /*verify_peer=*/false);
+
+        const std::string url = "http://127.0.0.1:" + std::to_string(server.Port()) + "/api/sensors/list";
+        const std::string body = "[{\"Type\":1,\"Value\":42,\"Comment\":null,\"Time\":\"1970-01-01T00:00:00Z\",\"Status\":1,\"Key\":null,\"Path\":\"p/int\"}]";
+
+        const auto response = transport.Post(
+            url,
+            body,
+            { hsm::http::HttpHeader{ "Key", "test-key" },
+              hsm::http::HttpHeader{ "ClientName", "test-client" },
+              hsm::http::HttpHeader{ "Content-Type", "application/json" } });
+
+        Require(response.transport_ok, ("transport must reach the local capture server: " + response.error).c_str());
+        Require(response.IsSuccess(), "expected a 2xx from the capture server");
+
+        for (int i = 0; i < 200 && !server.Request().received.load(std::memory_order_acquire); ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        const auto& request = server.Request();
+        Require(request.received.load(std::memory_order_acquire), "the capture server must have received the request");
+        Require(request.method == "POST", "method must be POST");
+        Require(request.path == "/api/sensors/list", "path must be the list endpoint");
+        Contains(request.headers, "Key: test-key");
+        Contains(request.headers, "ClientName: test-client");
+        Require(request.body == body, "captured body must be the exact wire bytes sent");
+    }
+#endif
+
     void NativeWireTimeSpanAndVersionMatchNet()
     {
         // .NET TimeSpan "c": "1.02:03:04.0050000" (ticks for TimeSpan(1,2,3,4,5) = 937840050000);
@@ -2790,6 +2827,9 @@ namespace
     const std::map<std::string, std::function<void(const std::string&)>>& Tests()
     {
         static const std::map<std::string, std::function<void(const std::string&)>> tests = {
+#if defined(HSM_COLLECTOR_HTTP)
+            { "native_http_transport_posts_to_capture_server", [](const std::string&) { NativeHttpTransportPostsToCaptureServer(); } },
+#endif
             { "native_wire_timespan_and_version_match_net", [](const std::string&) { NativeWireTimeSpanAndVersionMatchNet(); } },
             { "native_wire_registration_json_matches_net_byte_layout", [](const std::string&) { NativeWireRegistrationJsonMatchesNetByteLayout(); } },
             { "native_wire_iso_from_unix_ms_matches_net", [](const std::string&) { NativeWireIsoFromUnixMsMatchesNet(); } },

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -1,5 +1,7 @@
 #include "hsm_collector/hsm_collector.h"
 #include "hsm_collector/hsm_collector.hpp"
+#include "../src/hsm_http_endpoints.hpp"
+#include "../src/hsm_http_retry.hpp"
 #include <iostream>
 #include <fstream>
 #include <chrono>
@@ -2824,12 +2826,101 @@ namespace
             "AddOrUpdateSensorRequest wire layout");
     }
 
+    void NativeHttpEndpointRoutingMatchesNet()
+    {
+        // Scheme defaulting mirrors Endpoints(CollectorOptions): bare host -> https; explicit
+        // http stays http ONLY with AllowPlaintextTransport, otherwise upgraded to https; the
+        // /api/sensors base path and explicit Port are always applied.
+        Require(hsm::http::MakeEndpoints("localhost", 44330, false).connection_address ==
+                    "https://localhost:44330/api/sensors",
+                "bare host defaults to https");
+        Require(hsm::http::MakeEndpoints("https://example.org", 443, false).connection_address ==
+                    "https://example.org:443/api/sensors",
+                "explicit https preserved");
+        Require(hsm::http::MakeEndpoints("http://example.org", 80, false).connection_address ==
+                    "https://example.org:80/api/sensors",
+                "explicit http upgraded to https without plaintext opt-in");
+        Require(hsm::http::MakeEndpoints("http://example.org", 8080, true).connection_address ==
+                    "http://example.org:8080/api/sensors",
+                "explicit http kept only with plaintext opt-in");
+        // An embedded :port/path on the URL is dropped — the explicit Port wins (UriBuilder parity).
+        Require(hsm::http::MakeEndpoints("https://host:1234/ignored", 44330, false).connection_address ==
+                    "https://host:44330/api/sensors",
+                "embedded port/path dropped, explicit port applied");
+
+        const auto ep = hsm::http::MakeEndpoints("localhost", 44330, false);
+
+        // Single-value routes (DataHandlers.GetUri), one per kind.
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_BOOLEAN, false) == ep.connection_address + "/bool", "bool route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_INT, false) == ep.connection_address + "/int", "int route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_DOUBLE, false) == ep.connection_address + "/double", "double route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_STRING, false) == ep.connection_address + "/string", "string route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_INT_BAR, false) == ep.connection_address + "/intBar", "intBar route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_DOUBLE_BAR, false) == ep.connection_address + "/doubleBar", "doubleBar route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_FILE, false) == ep.connection_address + "/file", "file route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_RATE, false) == ep.connection_address + "/rate", "rate route");
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_ENUM, false) == ep.connection_address + "/enum", "enum route");
+
+        // A batch of values goes to /list regardless of kind.
+        Require(hsm::http::RouteForSensorValue(ep, HSM_SENSOR_TYPE_BOOLEAN, true) == ep.connection_address + "/list", "value batch -> /list");
+
+        // Commands: batch -> /commands, single AddOrUpdate -> /addOrUpdate.
+        Require(hsm::http::RouteForCommand(ep, true) == ep.connection_address + "/commands", "command batch -> /commands");
+        Require(hsm::http::RouteForCommand(ep, false) == ep.connection_address + "/addOrUpdate", "single command -> /addOrUpdate");
+
+        Require(ep.TestConnection() == ep.connection_address + "/testConnection", "testConnection route");
+    }
+
+    void NativeHttpRetryPolicyMatchesNet()
+    {
+        const auto data = hsm::http::RetryPolicy::Data();         // bounded, exponential, 10 retries
+        const auto commands = hsm::http::RetryPolicy::Commands(); // unbounded, linear
+
+        // ShouldRetry parity with BaseHandlers.ShouldRetry (#1096 fix):
+        // transport failure (exception-equivalent) is always retried on both pipelines.
+        Require(data.ShouldRetry(/*transport_ok=*/false, 0), "data retries transport failure");
+        Require(commands.ShouldRetry(/*transport_ok=*/false, 0), "commands retry transport failure");
+
+        // 5xx is retried only on the bounded pipeline; the unbounded command pipeline must not
+        // spin forever on a persistent server error.
+        Require(data.ShouldRetry(true, 503), "data retries 5xx");
+        Require(!commands.ShouldRetry(true, 503), "commands do NOT retry 5xx (would hang unbounded)");
+
+        // 4xx is permanent on both; 2xx is success on both.
+        Require(!data.ShouldRetry(true, 400), "data does not retry 4xx");
+        Require(!data.ShouldRetry(true, 404), "data does not retry 4xx");
+        Require(!data.ShouldRetry(true, 200), "2xx is success");
+        Require(!commands.ShouldRetry(true, 400), "commands do not retry 4xx");
+
+        // Attempt budget: bounded stops after 10 retries; unbounded never exhausts.
+        Require(data.HasAttemptsLeft(10), "10th retry allowed");
+        Require(!data.HasAttemptsLeft(11), "11th retry rejected");
+        Require(commands.HasAttemptsLeft(1000000), "command retries never exhaust");
+
+        // Exponential backoff: 1s, 2s, 4s, 8s ... clamped at 2min (Polly base*2^n, MaxDelay=120s).
+        Require(data.DelayMs(0) == 1000, "exp retry#1 = 1s");
+        Require(data.DelayMs(1) == 2000, "exp retry#2 = 2s");
+        Require(data.DelayMs(2) == 4000, "exp retry#3 = 4s");
+        Require(data.DelayMs(3) == 8000, "exp retry#4 = 8s");
+        Require(data.DelayMs(7) == 120000, "exp clamps to 2min (128s -> 120s)");
+        Require(data.DelayMs(20) == 120000, "exp stays clamped at 2min");
+
+        // Linear backoff: 1s, 2s, 3s ... clamped at 2min (Polly base*(n+1)).
+        Require(commands.DelayMs(0) == 1000, "lin retry#1 = 1s");
+        Require(commands.DelayMs(1) == 2000, "lin retry#2 = 2s");
+        Require(commands.DelayMs(2) == 3000, "lin retry#3 = 3s");
+        Require(commands.DelayMs(119) == 120000, "lin retry#120 = 2min");
+        Require(commands.DelayMs(200) == 120000, "lin clamps to 2min");
+    }
+
     const std::map<std::string, std::function<void(const std::string&)>>& Tests()
     {
         static const std::map<std::string, std::function<void(const std::string&)>> tests = {
 #if defined(HSM_COLLECTOR_HTTP)
             { "native_http_transport_posts_to_capture_server", [](const std::string&) { NativeHttpTransportPostsToCaptureServer(); } },
 #endif
+            { "native_http_endpoint_routing_matches_net", [](const std::string&) { NativeHttpEndpointRoutingMatchesNet(); } },
+            { "native_http_retry_policy_matches_net", [](const std::string&) { NativeHttpRetryPolicyMatchesNet(); } },
             { "native_wire_timespan_and_version_match_net", [](const std::string&) { NativeWireTimeSpanAndVersionMatchNet(); } },
             { "native_wire_registration_json_matches_net_byte_layout", [](const std::string&) { NativeWireRegistrationJsonMatchesNetByteLayout(); } },
             { "native_wire_iso_from_unix_ms_matches_net", [](const std::string&) { NativeWireIsoFromUnixMsMatchesNet(); } },

--- a/src/native/collector/tests/http_capture_server.hpp
+++ b/src/native/collector/tests/http_capture_server.hpp
@@ -180,4 +180,4 @@ namespace hsm::test
         std::thread worker_;
         CapturedRequest request_;
     };
-}
+} // namespace hsm::test

--- a/src/native/collector/tests/http_capture_server.hpp
+++ b/src/native/collector/tests/http_capture_server.hpp
@@ -26,6 +26,7 @@ using socket_t = SOCKET;
 #else
 #include <arpa/inet.h>
 #include <netinet/in.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
 using socket_t = int;
@@ -93,9 +94,41 @@ namespace hsm::test
         const CapturedRequest& Request() const { return request_; }
 
     private:
+        // Block in select (not accept) so the destructor can wake us by setting stop_: a blocked
+        // accept() is not portably interruptible by closing the socket from another thread, which
+        // could deadlock the dtor's join() if no client ever connects. select() with a short
+        // timeout re-checks stop_ each tick and unblocks reliably on both platforms.
+        socket_t WaitForConnection()
+        {
+            while (!stop_.load(std::memory_order_acquire))
+            {
+                fd_set readfds;
+                FD_ZERO(&readfds);
+                FD_SET(listen_, &readfds);
+
+                timeval tv{};
+                tv.tv_sec = 0;
+                tv.tv_usec = 100000; // 100 ms
+
+#if defined(_WIN32)
+                const int nfds = 0; // ignored by winsock select; avoids a SOCKET->int truncation
+#else
+                const int nfds = listen_ + 1;
+#endif
+                const int ready = select(nfds, &readfds, nullptr, nullptr, &tv);
+                if (ready < 0)
+                    return INVALID_SOCKET; // socket torn down (dtor) or error
+                if (ready == 0)
+                    continue; // timeout — re-check stop_
+
+                return accept(listen_, nullptr, nullptr);
+            }
+            return INVALID_SOCKET;
+        }
+
         void AcceptOne()
         {
-            socket_t conn = accept(listen_, nullptr, nullptr);
+            socket_t conn = WaitForConnection();
             if (conn == INVALID_SOCKET)
                 return;
 
@@ -119,10 +152,18 @@ namespace hsm::test
                     if (header_end != std::string::npos)
                     {
                         const auto cl = FindHeader(raw.substr(0, header_end), "content-length");
-                        if (!cl.empty())
+                        // A malformed Content-Length must not throw out of the worker thread.
+                        try
                         {
-                            content_length = static_cast<size_t>(std::stoul(cl));
-                            have_length = true;
+                            if (!cl.empty())
+                            {
+                                content_length = static_cast<size_t>(std::stoul(cl));
+                                have_length = true;
+                            }
+                        }
+                        catch (...)
+                        {
+                            have_length = false;
                         }
                     }
                 }
@@ -135,19 +176,24 @@ namespace hsm::test
                 }
             }
 
+            // Parse defensively: a request line without the expected two spaces leaves the
+            // captured fields empty rather than throwing std::out_of_range out of the thread.
             if (header_end != std::string::npos)
             {
                 const std::string head = raw.substr(0, header_end);
                 const size_t line_end = head.find("\r\n");
-                const std::string request_line = head.substr(0, line_end);
+                const std::string request_line = head.substr(0, line_end == std::string::npos ? head.size() : line_end);
                 const size_t sp1 = request_line.find(' ');
-                const size_t sp2 = request_line.find(' ', sp1 + 1);
+                const size_t sp2 = sp1 == std::string::npos ? std::string::npos : request_line.find(' ', sp1 + 1);
 
-                request_.method = request_line.substr(0, sp1);
-                request_.path = request_line.substr(sp1 + 1, sp2 - sp1 - 1);
-                request_.headers = head.substr(line_end + 2);
-                request_.body = raw.substr(header_end + 4, have_length ? content_length : std::string::npos);
-                request_.received.store(true, std::memory_order_release);
+                if (sp1 != std::string::npos && sp2 != std::string::npos)
+                {
+                    request_.method = request_line.substr(0, sp1);
+                    request_.path = request_line.substr(sp1 + 1, sp2 - sp1 - 1);
+                    request_.headers = line_end == std::string::npos ? std::string{} : head.substr(line_end + 2);
+                    request_.body = raw.substr(header_end + 4, have_length ? content_length : std::string::npos);
+                    request_.received.store(true, std::memory_order_release);
+                }
             }
 
             const std::string response =

--- a/src/native/collector/tests/http_capture_server.hpp
+++ b/src/native/collector/tests/http_capture_server.hpp
@@ -1,0 +1,183 @@
+#pragma once
+
+// Minimal in-process HTTP capture server for the native HTTP-transport E2E tests (#1096 §12).
+// Test-only; compiled only in the HSM_COLLECTOR_HTTP build. Blocking accept loop on a single
+// worker thread (modelled on the .NET FakeHsmServer): captures one request's method/path/headers/
+// body and answers a configurable status. No TLS — the E2E lane is plaintext, matching the .NET
+// FakeServerE2ETests (AllowPlaintextTransport).
+
+#include <atomic>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <thread>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX // windows.h defines min/max macros that break std::min/std::max otherwise
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#pragma comment(lib, "ws2_32.lib")
+using socket_t = SOCKET;
+#else
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using socket_t = int;
+#define INVALID_SOCKET (-1)
+#define closesocket close
+#endif
+
+namespace hsm::test
+{
+    struct CapturedRequest
+    {
+        // Atomic release/acquire so the test thread reading the captured fields after observing
+        // received == true has a happens-before with the worker thread that wrote them (TSan-clean).
+        std::atomic<bool> received{ false };
+        std::string method;
+        std::string path;
+        std::string headers; // raw header block (lowercased lookups done by the test)
+        std::string body;
+    };
+
+    class HttpCaptureServer
+    {
+    public:
+        explicit HttpCaptureServer(int response_status = 200)
+            : response_status_(response_status)
+        {
+#if defined(_WIN32)
+            WSADATA wsa;
+            WSAStartup(MAKEWORD(2, 2), &wsa);
+#endif
+            listen_ = socket(AF_INET, SOCK_STREAM, 0);
+
+            sockaddr_in addr{};
+            addr.sin_family = AF_INET;
+            addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+            addr.sin_port = 0; // ephemeral
+
+            int yes = 1;
+            setsockopt(listen_, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char*>(&yes), sizeof(yes));
+            bind(listen_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+            listen(listen_, 1);
+
+            sockaddr_in bound{};
+            socklen_t len = sizeof(bound);
+            getsockname(listen_, reinterpret_cast<sockaddr*>(&bound), &len);
+            port_ = ntohs(bound.sin_port);
+
+            worker_ = std::thread([this] { AcceptOne(); });
+        }
+
+        ~HttpCaptureServer()
+        {
+            stop_.store(true);
+            if (listen_ != INVALID_SOCKET)
+                closesocket(listen_);
+            if (worker_.joinable())
+                worker_.join();
+#if defined(_WIN32)
+            WSACleanup();
+#endif
+        }
+
+        int Port() const { return port_; }
+
+        const CapturedRequest& Request() const { return request_; }
+
+    private:
+        void AcceptOne()
+        {
+            socket_t conn = accept(listen_, nullptr, nullptr);
+            if (conn == INVALID_SOCKET)
+                return;
+
+            std::string raw;
+            char buffer[4096];
+            size_t header_end = std::string::npos;
+            size_t content_length = 0;
+            bool have_length = false;
+
+            // Read until the headers are complete and the declared body has arrived.
+            for (;;)
+            {
+                const int n = recv(conn, buffer, sizeof(buffer), 0);
+                if (n <= 0)
+                    break;
+                raw.append(buffer, static_cast<size_t>(n));
+
+                if (header_end == std::string::npos)
+                {
+                    header_end = raw.find("\r\n\r\n");
+                    if (header_end != std::string::npos)
+                    {
+                        const auto cl = FindHeader(raw.substr(0, header_end), "content-length");
+                        if (!cl.empty())
+                        {
+                            content_length = static_cast<size_t>(std::stoul(cl));
+                            have_length = true;
+                        }
+                    }
+                }
+
+                if (header_end != std::string::npos)
+                {
+                    const size_t body_have = raw.size() - (header_end + 4);
+                    if (!have_length || body_have >= content_length)
+                        break;
+                }
+            }
+
+            if (header_end != std::string::npos)
+            {
+                const std::string head = raw.substr(0, header_end);
+                const size_t line_end = head.find("\r\n");
+                const std::string request_line = head.substr(0, line_end);
+                const size_t sp1 = request_line.find(' ');
+                const size_t sp2 = request_line.find(' ', sp1 + 1);
+
+                request_.method = request_line.substr(0, sp1);
+                request_.path = request_line.substr(sp1 + 1, sp2 - sp1 - 1);
+                request_.headers = head.substr(line_end + 2);
+                request_.body = raw.substr(header_end + 4, have_length ? content_length : std::string::npos);
+                request_.received.store(true, std::memory_order_release);
+            }
+
+            const std::string response =
+                "HTTP/1.1 " + std::to_string(response_status_) + " X\r\nContent-Length: 0\r\nConnection: close\r\n\r\n";
+            send(conn, response.c_str(), static_cast<int>(response.size()), 0);
+            closesocket(conn);
+        }
+
+        static std::string FindHeader(const std::string& headers, const std::string& name_lower)
+        {
+            std::string lower = headers;
+            for (auto& c : lower)
+                c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+
+            size_t pos = lower.find(name_lower + ":");
+            if (pos == std::string::npos)
+                return {};
+
+            pos = headers.find(':', pos) + 1;
+            const size_t line_end = headers.find("\r\n", pos);
+            std::string value = headers.substr(pos, line_end - pos);
+            const size_t first = value.find_first_not_of(" \t");
+            return first == std::string::npos ? std::string{} : value.substr(first);
+        }
+
+        socket_t listen_ = INVALID_SOCKET;
+        int port_ = 0;
+        int response_status_;
+        std::atomic<bool> stop_{ false };
+        std::thread worker_;
+        CapturedRequest request_;
+    };
+}

--- a/src/native/collector/vcpkg.json
+++ b/src/native/collector/vcpkg.json
@@ -1,0 +1,13 @@
+{
+  "name": "hsm-collector-native",
+  "version-string": "0.1.0",
+  "description": "Native HSM DataCollector core — HTTP transport dependency (#1096).",
+  "builtin-baseline": "6f29f12e82a8293156836ad81cc9bf5af41fe836",
+  "dependencies": [
+    {
+      "name": "curl",
+      "default-features": false,
+      "features": ["ssl"]
+    }
+  ]
+}


### PR DESCRIPTION
Part of #1096 (workstream 3 of epic #1093). Stacked on #1123 (PR1, wire serialization).

This PR delivers the native HTTP transport contract and the cross-language 4xx/5xx retry fix. Everything here is verified in CI lanes that need no live server; the one step that genuinely requires a staged HSM server is called out explicitly below.

## What landed

**libcurl transport** (`hsm_http_transport.{hpp,cpp}`) — easy-handle `Post`/`Get`, confined to one TU so the core never sees `<curl/curl.h>` and the `/WX`+clang `-Werror` gate stays green. `CURLOPT_TIMEOUT_MS` ↔ `RequestTimeout`, `CURLOPT_SSL_VERIFYPEER` ↔ `AllowUntrustedServerCertificate`, `CURLOPT_XFERINFOFUNCTION`-abort ↔ `CancelPendingRequests`. Built only with `HSM_COLLECTOR_HTTP=ON` (curl via vcpkg manifest); the default build is curl-free.

**Endpoint route table** (`hsm_http_endpoints.hpp`, pure header) — faithful mirror of `Endpoints.cs` + `DataHandlers`/`CommandHandler.GetUri`: scheme defaulting (bare host → https; explicit `http` kept only with `AllowPlaintextTransport`), the `/api/sensors` base path, the 15-route table, per-kind / batch / command routing.

**Retry policy** (`hsm_http_retry.hpp`, pure header) — mirror of the Polly pipelines: bounded data/priority/file = 10 retries exponential 1s→2min; unbounded commands = linear. `ShouldRetry` matches the managed fix exactly.

**.NET 4xx/5xx fix** (`BaseHandlers.ShouldRetry`) — the Polly pipeline previously retried only on exceptions, so a returned 5xx fell through to the slower queue re-enqueue. Now the **bounded** data/file pipelines retry 5xx within their budget; the **unbounded** command pipeline stays exceptions-only (a persistent 5xx must never hang it); 4xx are never retried. The only production .NET change, justified by the epic parity-bug policy.

## Verification

- **Routing + retry**: pure headers compiled into the always-on core, unit-tested in the default `/WX` lane (`native_http_endpoint_routing_matches_net`, `native_http_retry_policy_matches_net`) — exact route strings, scheme rules, full retry decision + backoff schedule vs the managed semantics.
- **Transport**: in-proc capture-server E2E (`native_http_transport_posts_to_capture_server`) drives real libcurl against a loopback socket and asserts method/route/`Key`+`ClientName` headers/exact body bytes. New CI `http-transport` lane (vcpkg curl, Windows + Linux). Flake-screened 12×.
- **5xx fix**: `Retry5xxParityTests` drives the real `HsmHttpsClient` handler stack against the fake server — proves a transient 5xx is absorbed inside one `SendDataAsync` (3 attempts, success) and that a command 5xx returns without retry/hang.
- Adversarial review pass (concurrency-focused): three must-fix findings fixed — dropped the racy `curl_global_cleanup`, made the capture-server shutdown reliable via `select`-timeout accept, hardened the worker parse path against malformed input.

## Remaining integration step (out of scope here)

The native live send path still records to an in-memory sender behind the `TrySendBatch` test seam (so the behavior corpus + fail/hang injection stay green). Swapping it to dispatch wire bytes through `HttpTransport` in production needs a staged/real HSM server for true request-parity E2E — that final wiring is tracked as the closing task of the native port, not bundled into this transport-contract PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
