### PR TITLE
Native HTTP transport: fix curl_slist leak guard + IPv6 host note (#1124 review)

### DIFF
--- a/src/native/collector/src/hsm_http_endpoints.hpp
+++ b/src/native/collector/src/hsm_http_endpoints.hpp
@@ -66,7 +66,9 @@ namespace hsm::http
 
         // Keep only the host: drop any path, query, or :port that an explicit URL might carry
         // (the collector passes Port separately, so an embedded port is ignored just as UriBuilder
-        // overwrites it with the explicit Port).
+        // overwrites it with the explicit Port). NOTE: a bracketed IPv6 literal ("[::1]") would be
+        // truncated at its first ':' — out of scope because the collector only feeds a hostname or
+        // "scheme://hostname", never an IPv6 literal; revisit if ServerAddress becomes IPv6-capable.
         inline std::string HostOnly(const std::string& authority)
         {
             std::string host = authority;

--- a/src/native/collector/src/hsm_http_transport.cpp
+++ b/src/native/collector/src/hsm_http_transport.cpp
@@ -53,9 +53,22 @@ namespace hsm::http
                 return response;
             }
 
+            // curl_slist_append returns nullptr on allocation failure WITHOUT freeing the existing
+            // list — overwriting header_list with that null would leak the earlier nodes and
+            // silently drop already-appended headers. Append into a temp and only commit on success.
             curl_slist* header_list = nullptr;
             for (const auto& header : headers)
-                header_list = curl_slist_append(header_list, (header.name + ": " + header.value).c_str());
+            {
+                curl_slist* appended = curl_slist_append(header_list, (header.name + ": " + header.value).c_str());
+                if (appended == nullptr)
+                {
+                    curl_slist_free_all(header_list);
+                    curl_easy_cleanup(curl);
+                    response.error = "curl_slist_append failed";
+                    return response;
+                }
+                header_list = appended;
+            }
 
             curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
             curl_easy_setopt(curl, CURLOPT_HTTPHEADER, header_list);


### PR DESCRIPTION
Post-merge follow-up to the [#1124](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/pull/1124) review (all findings were non-blocking). Addresses the one actionable bug plus a cheap doc note; the other findings (#2 `ResetCancel` wiring, #3 5xx blocking) are intended/follow-up and already captured in the feature doc.

**1 — `curl_slist_append` leak-on-failure (the bug).** `curl_slist_append` returns `nullptr` on allocation failure *without* freeing the existing list, so `header_list = curl_slist_append(header_list, …)` would leak the earlier nodes and silently drop the already-appended headers. Now appends into a temp, frees + bails on failure, commits only on success. Low likelihood (alloc failure only), but this is the reference transport others will copy.

**2 — IPv6 host note.** Documented that `HostOnly` truncates a bracketed IPv6 literal (`[::1]`) at its first `:` — out of scope today (the collector only feeds a hostname or `scheme://hostname`), flagged for any future IPv6-capable `ServerAddress`.

Verification: HTTP lane green (transport E2E + route table + retry), `/WX` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
