### PR TITLE
Native live send-path: HttpTransport sender seam + E2E (#1097)

### DIFF
--- a/aicontext/features/collector/http-client/feature.md
+++ b/aicontext/features/collector/http-client/feature.md
@@ -69,7 +69,13 @@ The native collector (`src/native/collector`) emits the **byte-identical** wire 
 
 Routing + retry are pure headers compiled into the always-on core, so they are unit-tested in the default `/WX` lane (`native_http_endpoint_routing_matches_net`, `native_http_retry_policy_matches_net`); the transport is exercised by an in-proc capture-server E2E (`native_http_transport_posts_to_capture_server`) in the `HSM_COLLECTOR_HTTP` CI lane. The .NET side of the 5xx fix is pinned by `Retry5xxParityTests` against the fake server.
 
-**Remaining integration step:** the native live send path still records to an in-memory sender behind the test seam (`TrySendBatch`); swapping it to dispatch wire bytes through `HttpTransport` in production requires a staged/real HSM server for true request-parity E2E and is the final wiring task of the native port.
+### Live send-path wiring (#1097)
+
+`TrySendBatch` delegates to a **sender seam** (`sender_`, a `std::function<bool(std::vector<std::string>&)>`). The default records each batch into `sent_values_` so the behavior corpus and the `sent_count`/`get_sent_json` accessors keep working in both build lanes. In the `HSM_COLLECTOR_HTTP` build, `TestInstallHttpSender()` swaps in a real libcurl POST: the batch is joined into a JSON array and sent to the `/list` route with `Key`/`ClientName` headers, exercising the full `add → queue → worker → POST` pipeline. Installed before `Start` (same one-way contract as the clock seam — the worker only reads `sender_` after `Start`, so the swap needs no lock). `StopWorker` calls `HttpTransport::Cancel()` (aborting an in-flight POST so the join stays bounded) and `StartWorker` calls `ResetCancel()` to re-arm after a restart.
+
+Send semantics: **one POST attempt per batch**. A non-2xx or transport failure returns `false`, so the dispatcher re-enqueues the batch at the tail — the same durable-retry contract the C# queue uses (re-enqueue on `PackageSendingInfo.Error != null`, including 5xx and 4xx). The Polly-equivalent in-send exponential/linear backoff (`hsm_http_retry.hpp`, unit-tested separately) is a non-blocking refinement layered on later; doing it inline would block the single worker thread for up to the policy max-delay per batch. The end-to-end live path is pinned by `native_http_live_send_posts_to_capture_server` (drives a real int value through the collector and asserts the captured POST route/headers/body).
+
+**Remaining integration step:** the HTTP sender is currently reachable only through the test-install seam (the production default stays recording so the conformance corpus runs unchanged in the HTTP lane). Making the libcurl transport the production default in the `HSM_COLLECTOR_HTTP` build — with the corpus driver explicitly installing the recording sender — is the next step, alongside per-command error-dictionary parse and the in-send backoff (#1097 / public-API #1100).
 
 ## Known Issues / Limitations
 

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -136,6 +136,9 @@ if(HSM_COLLECTOR_HTTP)
     add_test(NAME native_http_transport_posts_to_capture_server
         COMMAND hsm_collector_tests native_http_transport_posts_to_capture_server
     )
+    add_test(NAME native_http_live_send_posts_to_capture_server
+        COMMAND hsm_collector_tests native_http_live_send_posts_to_capture_server
+    )
 endif()
 
 add_test(NAME native_invalid_argument_clears_out_params

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -25,6 +25,11 @@
 #include <utility>
 #include <vector>
 
+#if defined(HSM_COLLECTOR_HTTP)
+#include "hsm_http_endpoints.hpp"
+#include "hsm_http_transport.hpp"
+#endif
+
 namespace
 {
     constexpr size_t MaxCommentLength = 1024;
@@ -1321,6 +1326,11 @@ namespace
                 },
                 [this] { return EarliestNextPostMs(); },
                 [this] { TickPeriodicSensors(); });
+
+            // Send seam default: record batches into sent_values_ (the behavior corpus and the
+            // sent_count/get_sent_json accessors observe this). The HTTP build swaps in a real
+            // libcurl POST via TestInstallHttpSender before Start.
+            sender_ = [this](std::vector<std::string>& batch) { return RecordBatch(batch); };
         }
 
         // Test-only seam (no public C ABI surface): swap the scheduling clock before Start.
@@ -1338,6 +1348,21 @@ namespace
         {
             SetClock(std::make_shared<ManualClock>(base_ms, base_ms));
         }
+
+#if defined(HSM_COLLECTOR_HTTP)
+        // Live-path seam (HTTP build): swap the recording sender for a real libcurl POST to the
+        // batch /list route. Install before Start, same one-way contract as SetClock — the worker
+        // thread only reads sender_ after Start, so the swap needs no lock. One transport per
+        // collector; Cancel()/ResetCancel() are wired into Stop/StartWorker so a Stop aborts an
+        // in-flight POST (the CancelPendingRequests primitive) and a restart re-arms it.
+        void TestInstallHttpSender()
+        {
+            http_transport_ = std::make_unique<hsm::http::HttpTransport>(
+                request_timeout_ms_, /*verify_peer=*/!allow_untrusted_certificate_);
+            endpoints_ = hsm::http::MakeEndpoints(server_address_, port_, allow_plaintext_transport_);
+            sender_ = [this](std::vector<std::string>& batch) { return HttpSendBatch(batch); };
+        }
+#endif
 
         // Advance the installed manual clock and wake the scheduler so it re-evaluates the
         // virtual due-time at once (no real-time wait).
@@ -2111,6 +2136,13 @@ namespace
                 send_cancelled_ = false;
             }
 
+#if defined(HSM_COLLECTOR_HTTP)
+            // Re-arm the transport's cancellation so sends after a restart are not aborted by a
+            // Cancel() left set from the previous Stop.
+            if (http_transport_)
+                http_transport_->ResetCancel();
+#endif
+
             {
                 std::lock_guard<std::mutex> guard(queue_mutex_);
                 worker_stop_ = false;
@@ -2178,6 +2210,14 @@ namespace
             }
 
             hang_cv_.notify_all();
+
+#if defined(HSM_COLLECTOR_HTTP)
+            // Abort an in-flight POST so a worker blocked in libcurl wakes up (the send fails, the
+            // batch re-enqueues, the stop drain drops it) and the join below stays bounded. The
+            // xfer-abort reads a lock-free atomic, so this is safe without the hang/queue locks.
+            if (http_transport_)
+                http_transport_->Cancel();
+#endif
 
             {
                 std::lock_guard<std::mutex> guard(queue_mutex_);
@@ -2289,6 +2329,13 @@ namespace
             if (TryConsumeFailToken())
                 return false;
 
+            return sender_(batch);
+        }
+
+        // Default send seam: record the batch for the behavior corpus + the sent_count/get_sent_json
+        // accessors. Swapped for a libcurl POST by TestInstallHttpSender (HTTP build) before Start.
+        bool RecordBatch(std::vector<std::string>& batch)
+        {
             std::lock_guard<std::mutex> guard(mutex_);
 
             for (auto& json : batch)
@@ -2296,6 +2343,37 @@ namespace
 
             return true;
         }
+
+#if defined(HSM_COLLECTOR_HTTP)
+        // One POST attempt per batch. A non-2xx or transport failure returns false, so the
+        // dispatcher re-enqueues the batch at the tail — the same durable-retry contract the C#
+        // queue uses (it re-enqueues on PackageSendingInfo.Error != null, including 5xx and 4xx).
+        // The Polly-equivalent in-send backoff (RetryPolicy, unit-tested separately) is a
+        // non-blocking refinement layered on later; doing it inline would block the single worker
+        // thread for up to the RetryPolicy max-delay per batch.
+        bool HttpSendBatch(std::vector<std::string>& batch)
+        {
+            // The data queue batches values to /list (DataHandlers RouteForSensorValue is_batch=true)
+            // as a JSON array; each element is the already-serialized wire value.
+            std::string body = "[";
+            for (size_t index = 0; index < batch.size(); ++index)
+            {
+                if (index != 0)
+                    body += ',';
+                body += batch[index];
+            }
+            body += "]";
+
+            const std::vector<hsm::http::HttpHeader> headers = {
+                { "Key", access_key_ },
+                { "ClientName", client_name_ },
+                { "Content-Type", "application/json" },
+            };
+
+            const auto response = http_transport_->Post(endpoints_.List(), body, headers);
+            return response.IsSuccess();
+        }
+#endif
 
         bool TryConsumeFailToken()
         {
@@ -2329,6 +2407,15 @@ namespace
         std::condition_variable hang_cv_;
         bool send_hang_ = false;
         bool send_cancelled_ = false;
+
+        // Send seam: TrySendBatch delegates here. Default records into sent_values_; the HTTP build
+        // swaps in a libcurl POST via TestInstallHttpSender (installed before Start, read only by
+        // the worker thread after Start — no lock needed for the swap).
+        std::function<bool(std::vector<std::string>&)> sender_;
+#if defined(HSM_COLLECTOR_HTTP)
+        std::unique_ptr<hsm::http::HttpTransport> http_transport_;
+        hsm::http::Endpoints endpoints_;
+#endif
 
         // Periodic scheduler (issue #1095 §13): a single ScheduledTask worker that sleeps
         // until the earliest sensor due-time, read through the swappable clock seam. The
@@ -2895,6 +2982,17 @@ extern "C" void hsm_collector_test_log_error(hsm_collector_t* collector, const c
     if (collector != nullptr && message != nullptr)
         collector->impl->TestLogError(message);
 }
+
+#if defined(HSM_COLLECTOR_HTTP)
+// Test-only seam (#1097): swap the recording sender for the live libcurl transport so the native
+// unit tests exercise the real queue -> worker -> POST path against the in-proc capture server.
+// Install before Start (same contract as the clock seam). HTTP-build only.
+extern "C" void hsm_collector_test_install_http_sender(hsm_collector_t* collector)
+{
+    if (collector != nullptr && collector->impl != nullptr)
+        collector->impl->TestInstallHttpSender();
+}
+#endif
 
 // Test-only seam (#1096): exercise the real-wire serializers directly from the native unit
 // tests without a live collector. Return into a thread-local buffer (valid until the next call

--- a/src/native/collector/tests/hsm_collector_tests.cpp
+++ b/src/native/collector/tests/hsm_collector_tests.cpp
@@ -30,6 +30,10 @@
 extern "C" void hsm_collector_test_install_manual_clock(hsm_collector_t* collector, int64_t base_ms);
 extern "C" void hsm_collector_test_advance_clock_ms(hsm_collector_t* collector, int64_t delta_ms);
 extern "C" void hsm_collector_test_log_error(hsm_collector_t* collector, const char* message);
+#if defined(HSM_COLLECTOR_HTTP)
+// Live-path seam (#1097): swap the recording sender for the libcurl transport before Start.
+extern "C" void hsm_collector_test_install_http_sender(hsm_collector_t* collector);
+#endif
 // Real-wire serializers (#1096): exercised directly from the unit tests.
 extern "C" const char* hsm_collector_test_iso_from_unix_ms(int64_t unix_ms);
 extern "C" const char* hsm_collector_test_timespan_c_format(int64_t ticks);
@@ -2789,6 +2793,53 @@ namespace
         Contains(request.headers, "ClientName: test-client");
         Require(request.body == body, "captured body must be the exact wire bytes sent");
     }
+
+    // #1097: drive a value through the REAL collector pipeline (add -> queue -> worker -> sender)
+    // with the libcurl transport installed, and assert the capture server saw the live POST. This
+    // is the end-to-end proof that TestInstallHttpSender wires the transport into the live send
+    // path, not just that HttpTransport can POST in isolation (the test above).
+    void NativeHttpLiveSendPostsToCaptureServer()
+    {
+        hsm::test::HttpCaptureServer server(200);
+
+        hsm_collector_options_t options{};
+        options.access_key = "live-key";
+        // Explicit http:// scheme + AllowPlaintextTransport is what the collector requires for a
+        // plaintext target (a bare host defaults to https — MakeEndpoints/Endpoints parity).
+        options.server_address = "http://127.0.0.1";
+        options.port = server.Port();
+        options.client_name = "live-client";
+        // module/computer left null so JoinPathParts keeps the wire Path exactly "live/int".
+        options.allow_plaintext_transport = true; // the capture server is plaintext HTTP
+        options.max_values_in_package = 50;
+        options.package_collect_period_ms = 20; // fast dispatch so the worker flushes promptly
+
+        CollectorHandle collector = CreateCollector(options);
+        hsm_collector_test_install_http_sender(collector.value);
+
+        Require(hsm_collector_start(collector.value) == HSM_RESULT_OK, "collector start failed");
+
+        SensorHandle sensor = CreateIntSensor(collector.value, "live/int");
+        Require(
+            hsm_sensor_add_int(sensor.value, 42, HSM_SENSOR_STATUS_OK, "") == HSM_RESULT_OK,
+            "add int value failed");
+
+        for (int i = 0; i < 400 && !server.Request().received.load(std::memory_order_acquire); ++i)
+            std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        const auto& request = server.Request();
+        Require(request.received.load(std::memory_order_acquire), "the capture server must have received the live POST");
+        Require(request.method == "POST", "live send method must be POST");
+        Require(request.path == "/api/sensors/list", "live data batch must route to /list");
+        Contains(request.headers, "Key: live-key");
+        Contains(request.headers, "ClientName: live-client");
+        // The batch is a JSON array of wire values carrying the added int and its path.
+        Require(!request.body.empty() && request.body.front() == '[' && request.body.back() == ']', "live body must be a JSON array");
+        Contains(request.body, "\"Value\":42");
+        Contains(request.body, "\"Path\":\"live/int\"");
+
+        Require(hsm_collector_stop(collector.value) == HSM_RESULT_OK, "collector stop failed");
+    }
 #endif
 
     void NativeWireTimeSpanAndVersionMatchNet()
@@ -2918,6 +2969,7 @@ namespace
         static const std::map<std::string, std::function<void(const std::string&)>> tests = {
 #if defined(HSM_COLLECTOR_HTTP)
             { "native_http_transport_posts_to_capture_server", [](const std::string&) { NativeHttpTransportPostsToCaptureServer(); } },
+            { "native_http_live_send_posts_to_capture_server", [](const std::string&) { NativeHttpLiveSendPostsToCaptureServer(); } },
 #endif
             { "native_http_endpoint_routing_matches_net", [](const std::string&) { NativeHttpEndpointRoutingMatchesNet(); } },
             { "native_http_retry_policy_matches_net", [](const std::string&) { NativeHttpRetryPolicyMatchesNet(); } },


### PR DESCRIPTION
## Summary

First concrete step of **#1097** (data pipeline): wire the libcurl `HttpTransport` (built in #1096) into the collector's **live send path**, proven end-to-end through the real `add → queue → worker → POST` pipeline. Carried over from #1096's close note.

### What changed (native only — no .NET touched)

- **Sender seam.** `TrySendBatch` now delegates to `sender_` (`std::function<bool(std::vector<std::string>&)>`). The **default records into `sent_values_`**, so the behavior corpus and the `sent_count`/`get_sent_json` accessors keep working unchanged in both build lanes.
- **HTTP sender** (`HSM_COLLECTOR_HTTP` build). `TestInstallHttpSender()` swaps in a real POST: the batch is joined into a JSON array and sent to the `/list` route with `Key`/`ClientName` headers. Installed before `Start` (same one-way contract as the clock seam — the worker only reads `sender_` after `Start`, so no lock).
- **Cancellation.** `StopWorker` → `HttpTransport::Cancel()` (aborts an in-flight POST so the join stays bounded); `StartWorker` → `ResetCancel()` (re-arm after restart).
- **Send semantics.** One POST attempt per batch; a non-2xx or transport failure returns `false`, so the dispatcher **re-enqueues at the tail** — the same durable-retry contract the C# queue uses (re-enqueue on `PackageSendingInfo.Error != null`, including 5xx and 4xx). The Polly-equivalent in-send backoff (`hsm_http_retry.hpp`, already unit-tested) is a non-blocking refinement layered on later.

### Tests

- **New** `native_http_live_send_posts_to_capture_server` — drives a real int value through the collector against the in-proc capture server and asserts the captured POST **route** (`/api/sensors/list`), **headers** (`Key`/`ClientName`), and **body** (`"Value":42`, `"Path":"live/int"`).
- `/WX` core: **78/78** green. `HSM_COLLECTOR_HTTP` lane: **80/80** green. clang-format clean.

### Out of scope (documented #1097 follow-ups)

- Make the libcurl transport the **production default** in the HTTP build (corpus driver installs the recording sender instead).
- Per-command **error-dictionary** parse for the `/commands` response.
- In-send exponential/linear **backoff** wiring (policy already unit-tested).

Part of #1097

🤖 Generated with [Claude Code](https://claude.com/claude-code)