### PR TITLE
Preserve alert template on partial DB failure during removal

### DIFF
--- a/src/server/HSMServer.Core/Cache/ITreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/ITreeValuesCache.cs
@@ -113,7 +113,7 @@ namespace HSMServer.Core.Cache
 
         AlertTemplateModel GetAlertTemplate(Guid id);
 
-        Task RemoveAlertTemplateAsync(Guid id, CancellationToken token = default);
+        Task<(bool Success, string Error)> RemoveAlertTemplateAsync(Guid id, CancellationToken token = default);
 
         Task RunSensorsSelfDestroyAsync(CancellationToken token = default);
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1519,53 +1519,60 @@ namespace HSMServer.Core.Cache
             return [.. _alertTemplates.Values];
         }
 
-        public async Task RemoveAlertTemplateAsync(Guid id, CancellationToken token = default)
+        public async Task<(bool Success, string Error)> RemoveAlertTemplateAsync(Guid id, CancellationToken token = default)
         {
             var templateModel = GetAlertTemplate(id);
 
             if (templateModel == null)
-                return;
+                return (true, null);
 
             var products = GetProducts().Where(x => x.FolderId == templateModel.FolderId).ToList();
 
-            try
+            // Collect all sensors (across products and their sub-products) that hold policies
+            // from this template, then dispatch a per-sensor removal request to each sensor's
+            // own product queue. This guarantees no sensor.Policies mutation happens outside
+            // the owning queue thread.
+            var affectedSensors = new List<BaseSensorModel>();
+            foreach (var product in products)
             {
-                // Collect all sensors (across products and their sub-products) that hold policies
-                // from this template, then dispatch a per-sensor removal request to each sensor's
-                // own product queue. This guarantees no sensor.Policies mutation happens outside
-                // the owning queue thread.
-                var affectedSensors = new List<BaseSensorModel>();
-                foreach (var product in products)
+                foreach (var sensor in product.GetAllSensors())
                 {
-                    foreach (var sensor in product.GetAllSensors())
-                    {
-                        var hasTemplateTtl = sensor.Policies.TTLPolicies.Any(t => t.TemplateId == id);
-                        if (hasTemplateTtl || sensor.Policies.Any(p => p.TemplateId == id))
-                            affectedSensors.Add(sensor);
-                    }
+                    var hasTemplateTtl = sensor.Policies.TTLPolicies.Any(t => t.TemplateId == id);
+                    if (hasTemplateTtl || sensor.Policies.Any(p => p.TemplateId == id))
+                        affectedSensors.Add(sensor);
                 }
+            }
 
-                await Parallel.ForEachAsync(affectedSensors, new ParallelOptions
-                {
-                    MaxDegreeOfParallelism = Environment.ProcessorCount,
-                    CancellationToken = token
-                }, async (sensor, ct) =>
-                {
-                    var request = new RemoveTemplateFromSensorRequest(sensor.Id, id);
-                    await ProcessRequestAsync(sensor.Root.Id, request, ct);
-                });
-            }
-            catch (OperationCanceledException)
+            // Capture per-sensor failures so a single DB error does not silently leave orphaned
+            // policies behind. UpdatesQueue converts thrown exceptions into TaskResult.FromError,
+            // so we inspect the returned TaskResult rather than wrapping the loop in try/catch.
+            var failedProducts = new ConcurrentDictionary<Guid, string>();
+
+            await Parallel.ForEachAsync(affectedSensors, new ParallelOptions
             {
-                throw;
-            }
-            catch (Exception ex)
+                MaxDegreeOfParallelism = Environment.ProcessorCount,
+                CancellationToken = token
+            }, async (sensor, ct) =>
             {
-                _logger.Error($"Partial failure removing template {id} from products", ex);
+                var request = new RemoveTemplateFromSensorRequest(sensor.Id, id);
+                var result = await ProcessRequestAsync(sensor.Root.Id, request, ct);
+
+                if (!result.IsOk)
+                    failedProducts.TryAdd(sensor.Root.Id, sensor.RootProductName);
+            });
+
+            if (!failedProducts.IsEmpty)
+            {
+                var names = string.Join(", ", failedProducts.Values.OrderBy(n => n));
+                var error = $"Failed to remove template from products: {names}";
+                _logger.Error($"Partial failure removing template {id}: {error}");
+                return (false, error);
             }
 
             _alertTemplates.TryRemove(id, out _);
             _database.RemoveAlertTemplate(id);
+
+            return (true, null);
         }
 
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1581,19 +1581,32 @@ namespace HSMServer.Core.Cache
             if (!TryGetSensorById(request.SensorId, out var sensor))
                 return;
 
-            var sensorTtls = sensor.Policies.TTLPolicies;
-            var hasTemplateTtl = sensorTtls.Any(t => t.TemplateId == request.TemplateId);
+            var templatePolicyIds = sensor.Policies
+                .Where(p => p.TemplateId == request.TemplateId)
+                .Select(p => p.Id.ToString())
+                .ToHashSet();
 
-            if (!hasTemplateTtl && !sensor.Policies.Any(p => p.TemplateId == request.TemplateId))
+            var hasTemplateTtl = sensor.Policies.TTLPolicies.Any(t => t.TemplateId == request.TemplateId);
+
+            if (templatePolicyIds.Count == 0 && !hasTemplateTtl)
                 return;
+
+            // Persist FIRST, mutate in-memory only on success. If UpdateSensor throws, the
+            // in-memory sensor keeps its template policies so a retry of RemoveAlertTemplateAsync
+            // still targets this sensor. Mutating in-memory before the DB write would leave the
+            // sensor invisible to retry while the DB row still references the now-missing
+            // policies — orphaning them after the template is purged on the next attempt (#1127).
+            var targetEntity = sensor.ToEntity();
+            targetEntity.Policies.RemoveAll(templatePolicyIds.Contains);
+            targetEntity.TTLPolicies.RemoveAll(p => p.TemplateId != null && new Guid(p.TemplateId) == request.TemplateId);
+
+            _database.UpdateSensor(targetEntity);
 
             foreach (var policy in sensor.Policies.Where(p => p.TemplateId == request.TemplateId).ToList())
                 sensor.Policies.RemovePolicy(policy.Id, InitiatorInfo.AlertTemplate);
 
-            foreach (var ttl in sensorTtls.Where(t => t.TemplateId == request.TemplateId).ToList())
+            foreach (var ttl in sensor.Policies.TTLPolicies.Where(t => t.TemplateId == request.TemplateId).ToList())
                 sensor.Policies.RemoveTTLPolicy(ttl.Id);
-
-            _database.UpdateSensor(sensor.ToEntity());
 
             sensor.Revalidate();
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1598,7 +1598,7 @@ namespace HSMServer.Core.Cache
             // policies — orphaning them after the template is purged on the next attempt (#1127).
             var targetEntity = sensor.ToEntity();
             targetEntity.Policies.RemoveAll(templatePolicyIds.Contains);
-            targetEntity.TTLPolicies.RemoveAll(p => p.TemplateId != null && new Guid(p.TemplateId) == request.TemplateId);
+            targetEntity.TTLPolicies.RemoveAll(p => p.TemplateId is { Length: 16 } && new Guid(p.TemplateId) == request.TemplateId);
 
             _database.UpdateSensor(targetEntity);
 

--- a/src/server/HSMServer/Controllers/AlertTemplatesController.cs
+++ b/src/server/HSMServer/Controllers/AlertTemplatesController.cs
@@ -235,7 +235,7 @@ namespace HSMServer.Controllers
         [HttpGet]
         public async ValueTask<IActionResult> Remove(Guid id)
         {
-            await _cache.RemoveAlertTemplateAsync(id);
+            _ = await _cache.RemoveAlertTemplateAsync(id);
 
             return RedirectToAction("Index");
         }

--- a/src/server/HSMServer/Controllers/AlertTemplatesController.cs
+++ b/src/server/HSMServer/Controllers/AlertTemplatesController.cs
@@ -1,6 +1,7 @@
 using HSMCommon.Model;
 using HSMServer.ApiObjectsConverters;
 using HSMServer.Authentication;
+using HSMServer.Constants;
 using HSMServer.Core.Cache;
 using HSMServer.Core.Model;
 using HSMServer.Core.Schedule;
@@ -235,7 +236,10 @@ namespace HSMServer.Controllers
         [HttpGet]
         public async ValueTask<IActionResult> Remove(Guid id)
         {
-            _ = await _cache.RemoveAlertTemplateAsync(id);
+            var (success, error) = await _cache.RemoveAlertTemplateAsync(id);
+
+            if (!success)
+                TempData[TextConstants.TempDataErrorText] = error;
 
             return RedirectToAction("Index");
         }

--- a/src/server/HSMServer/Views/AlertTemplates/Index.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/Index.cshtml
@@ -13,6 +13,10 @@
 <div class="container">
     <div class="row w-100 justify-content-center">
         <div class="m-2">
+            @if (TempData[TextConstants.TempDataErrorText] != null)
+            {
+                <div class="alert alert-danger">@TempData[TextConstants.TempDataErrorText].ToString()</div>
+            }
             <div class="d-flex justify-content-between my-2">
                 <h5>Alert Templates</h5>
                 <div class='d-flex col-md-auto'>

--- a/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
+++ b/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using HSMCommon.Model;
+using HSMCommon.TaskResult;
+using HSMDatabase.AccessManager;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMDatabase.AccessManager.DatabaseSettings;
+using HSMServer.Core.DataLayer;
+
+namespace HSMServer.Core.Tests.Infrastructure
+{
+    internal sealed class FailingDatabaseCore : IDatabaseCore
+    {
+        private readonly IDatabaseCore _inner;
+        private readonly Func<SensorEntity, bool> _shouldFail;
+
+        internal FailingDatabaseCore(IDatabaseCore inner, Func<SensorEntity, bool> shouldFail)
+        {
+            _inner = inner;
+            _shouldFail = shouldFail;
+        }
+
+        public IDashboardCollection Dashboards => _inner.Dashboards;
+
+        public ISnapshotDatabase Snapshots => _inner.Snapshots;
+
+        public bool IsCompactRunning => _inner.IsCompactRunning;
+
+        public bool IsExportRunning => _inner.IsExportRunning;
+
+        public long SensorHistoryDbSize => _inner.SensorHistoryDbSize;
+
+        public long JournalDbSize => _inner.JournalDbSize;
+
+        public long ConfigDbSize => _inner.ConfigDbSize;
+
+        public long BackupsSize => _inner.BackupsSize;
+
+        public long TotalDbSize => _inner.TotalDbSize;
+
+        public int SensorValuesPageCount => _inner.SensorValuesPageCount;
+
+        public List<ISensorValuesDatabase> SensorValuesDatabases => _inner.SensorValuesDatabases;
+
+        public IDatabaseSettings DatabaseSettings => _inner.DatabaseSettings;
+
+        public TaskResult<string> BackupEnvironment(string backupPath) => _inner.BackupEnvironment(backupPath);
+
+        public void AddFolder(FolderEntity entity) => _inner.AddFolder(entity);
+        public void UpdateFolder(FolderEntity entity) => _inner.UpdateFolder(entity);
+        public void RemoveFolder(string id) => _inner.RemoveFolder(id);
+        public FolderEntity GetFolder(string id) => _inner.GetFolder(id);
+        public List<FolderEntity> GetAllFolders() => _inner.GetAllFolders();
+
+        public void AddProduct(ProductEntity entity) => _inner.AddProduct(entity);
+        public void UpdateProduct(ProductEntity entity) => _inner.UpdateProduct(entity);
+        public void RemoveProduct(string id) => _inner.RemoveProduct(id);
+        public ProductEntity GetProduct(string id) => _inner.GetProduct(id);
+        public List<ProductEntity> GetAllProducts() => _inner.GetAllProducts();
+
+        public void RemoveAccessKey(Guid id) => _inner.RemoveAccessKey(id);
+        public void AddAccessKey(AccessKeyEntity entity) => _inner.AddAccessKey(entity);
+        public void UpdateAccessKey(AccessKeyEntity entity) => _inner.UpdateAccessKey(entity);
+        public AccessKeyEntity GetAccessKey(Guid id) => _inner.GetAccessKey(id);
+        public List<AccessKeyEntity> GetAccessKeys() => _inner.GetAccessKeys();
+
+        public void AddSensor(SensorEntity entity) => _inner.AddSensor(entity);
+
+        public void UpdateSensor(SensorEntity entity)
+        {
+            if (_shouldFail(entity))
+                throw new InvalidOperationException($"Simulated DB failure for sensor {entity.Id}");
+
+            _inner.UpdateSensor(entity);
+        }
+
+        public void RemoveSensorWithMetadata(Guid sensorId) => _inner.RemoveSensorWithMetadata(sensorId);
+        public void AddSensorValue(Guid sensorId, BaseValue value) => _inner.AddSensorValue(sensorId, value);
+        public void ClearSensorValues(Guid sensorId, DateTime from, DateTime to) => _inner.ClearSensorValues(sensorId, from, to);
+        public byte[] GetLatestValue(Guid sensorId, long to) => _inner.GetLatestValue(sensorId, to);
+        public byte[] GetFirstValue(Guid sensorId) => _inner.GetFirstValue(sensorId);
+        public Dictionary<Guid, (byte[], byte[])> GetLastAndFirstValues(IEnumerable<Guid> sensorIds) => _inner.GetLastAndFirstValues(sensorIds);
+        public Dictionary<Guid, byte[]> GetLatestValuesFromTo(Dictionary<Guid, (long, long)> sensors) => _inner.GetLatestValuesFromTo(sensors);
+        public IAsyncEnumerable<List<byte[]>> GetSensorValuesPage(Guid sensorId, DateTime from, DateTime to, int count) => _inner.GetSensorValuesPage(sensorId, from, to, count);
+        public IAsyncEnumerable<byte[]> GetSensorValues(Guid sensorId, DateTime from, DateTime to) => _inner.GetSensorValues(sensorId, from, to);
+        public List<SensorEntity> GetAllSensors() => _inner.GetAllSensors();
+        public void ExportValuesDatabase(string databaseName, Dictionary<Guid, string> sensors) => _inner.ExportValuesDatabase(databaseName, sensors);
+        public (long dateCnt, long keySize, long valueSize) CalculateSensorHistorySize(Guid sensorId) => _inner.CalculateSensorHistorySize(sensorId);
+        public IEnumerable<(byte[], byte[])> MigrateDatabaseV2() => _inner.MigrateDatabaseV2();
+
+        public List<PolicyEntity> GetAllPolicies() => _inner.GetAllPolicies();
+        public void AddPolicy(PolicyEntity policy) => _inner.AddPolicy(policy);
+        public void UpdatePolicy(PolicyEntity policy) => _inner.UpdatePolicy(policy);
+        public void RemovePolicy(Guid id) => _inner.RemovePolicy(id);
+
+        public void AddUser(UserEntity user) => _inner.AddUser(user);
+        public void UpdateUser(UserEntity user) => _inner.UpdateUser(user);
+        public void RemoveUser(UserEntity user) => _inner.RemoveUser(user);
+        public List<UserEntity> GetUsers() => _inner.GetUsers();
+        public List<UserEntity> GetUsersPage(int page, int pageSize) => _inner.GetUsersPage(page, pageSize);
+
+        public void AddTelegramChat(TelegramChatEntity chat) => _inner.AddTelegramChat(chat);
+        public void UpdateTelegramChat(TelegramChatEntity chat) => _inner.UpdateTelegramChat(chat);
+        public void RemoveTelegramChat(byte[] chatId) => _inner.RemoveTelegramChat(chatId);
+        public TelegramChatEntity GetTelegramChat(byte[] chatId) => _inner.GetTelegramChat(chatId);
+        public List<TelegramChatEntity> GetTelegramChats() => _inner.GetTelegramChats();
+
+        public List<AlertTemplateEntity> GetAllAlertTemplates() => _inner.GetAllAlertTemplates();
+        public void AddAlertTemplate(AlertTemplateEntity policy) => _inner.AddAlertTemplate(policy);
+        public void RemoveAlertTemplate(Guid id) => _inner.RemoveAlertTemplate(id);
+
+        public List<AlertScheduleEntity> GetAllAlertSchedules() => _inner.GetAllAlertSchedules();
+        public AlertScheduleEntity GetAlertSchedule(Guid id) => _inner.GetAlertSchedule(id);
+        public void AddAlertSchedule(AlertScheduleEntity schedule) => _inner.AddAlertSchedule(schedule);
+        public void RemoveAlertSchedule(Guid id) => _inner.RemoveAlertSchedule(id);
+
+        public void AddJournalValue(JournalKey journalKey, JournalRecordEntity value) => _inner.AddJournalValue(journalKey, value);
+        public void RemoveJournalValues(Guid id, Guid parentId) => _inner.RemoveJournalValues(id, parentId);
+        public IAsyncEnumerable<List<(byte[] Key, JournalRecordEntity Entity)>> GetJournalValuesPage(Guid sensorId, DateTime from, DateTime to, RecordType types, int count) => _inner.GetJournalValuesPage(sensorId, from, to, types, count);
+
+        public void Compact() => _inner.Compact();
+
+        public IEnumerable<(byte[], byte[])> GetAll() => _inner.GetAll();
+
+        public void Dispose() => _inner.Dispose();
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/MonitoringCoreTests/MonitoringCoreTestsBase.cs
+++ b/src/tests/HSMServer.Core.Tests/MonitoringCoreTests/MonitoringCoreTestsBase.cs
@@ -1,6 +1,7 @@
 ﻿using HSMDatabase.AccessManager.DatabaseEntities.SnapshotEntity;
 using HSMServer.Authentication;
 using HSMServer.Core.Cache;
+using HSMServer.Core.DataLayer;
 using HSMServer.Core.SensorsUpdatesQueue;
 using HSMServer.Core.Tests.Infrastructure;
 using HSMServer.Core.Tests.MonitoringCoreTests.Fixture;
@@ -47,7 +48,9 @@ namespace HSMServer.Core.Tests.MonitoringCoreTests
 
             _alertScheduleProvider = new AlertScheduleProvider(_databaseCoreManager.DatabaseCore);
 
-            _valuesCache = new TreeValuesCache(_databaseCoreManager.DatabaseCore, snaphot.Object, _journalService, _alertScheduleProvider);
+            var database = WrapDatabase(_databaseCoreManager.DatabaseCore);
+
+            _valuesCache = new TreeValuesCache(database, snaphot.Object, _journalService, _alertScheduleProvider);
 
             var userManagerLogger = CommonMoqs.CreateNullLogger<UserManager>();
             _userManager = new UserManager(_databaseCoreManager.DatabaseCore, _valuesCache, userManagerLogger);
@@ -57,5 +60,8 @@ namespace HSMServer.Core.Tests.MonitoringCoreTests
         public Task InitializeAsync() => _userManager.Initialize();
 
         public Task DisposeAsync() => Task.CompletedTask;
+
+
+        protected virtual IDatabaseCore WrapDatabase(IDatabaseCore inner) => inner;
     }
 }

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/AlertTemplatePartialFailureTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/AlertTemplatePartialFailureTests.cs
@@ -80,6 +80,36 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             var dbTemplates = _databaseCoreManager.DatabaseCore.GetAllAlertTemplates();
             Assert.Contains(dbTemplates, t => new Guid(t.Id) == template.Id);
+
+            // Critical for retry semantics: the failing sensor must still hold its template
+            // policies in memory, otherwise a retry of RemoveAlertTemplateAsync won't find it
+            // in affectedSensors and the template will be purged while the DB row still
+            // references the now-missing policies (#1127 follow-up).
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductBId, sensorBPath, out var sensorBAfterFailure));
+            Assert.Contains(sensorBAfterFailure.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+
+            // Product A's sensor had no failure and should already be cleaned.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorAPath, out var sensorAAfterFailure));
+            Assert.DoesNotContain(sensorAAfterFailure.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+
+            // Retry after the DB recovers: the failing sensor is still targeted, the template
+            // is purged, and both sensors end up clean.
+            _failProductId = Guid.Empty;
+
+            var (retryOk, retryError) = await _valuesCache.RemoveAlertTemplateAsync(template.Id);
+            Assert.True(retryOk, retryError);
+            await Task.Delay(300);
+
+            Assert.Null(_valuesCache.GetAlertTemplate(template.Id));
+
+            var dbTemplatesAfterRetry = _databaseCoreManager.DatabaseCore.GetAllAlertTemplates();
+            Assert.DoesNotContain(dbTemplatesAfterRetry, t => new Guid(t.Id) == template.Id);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductBId, sensorBPath, out var sensorBAfterRetry));
+            Assert.DoesNotContain(sensorBAfterRetry.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorAPath, out var sensorAAfterRetry));
+            Assert.DoesNotContain(sensorAAfterRetry.Policies.TTLPolicies, p => p.TemplateId == template.Id);
         }
 
 

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/AlertTemplatePartialFailureTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/AlertTemplatePartialFailureTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using HSMCommon.Model;
+using HSMServer.Core.Cache;
+using HSMServer.Core.DataLayer;
+using HSMServer.Core.Model;
+using HSMServer.Core.Model.NodeSettings;
+using HSMServer.Core.Model.Policies;
+using HSMServer.Core.Tests.Infrastructure;
+using HSMServer.Core.Tests.MonitoringCoreTests;
+using HSMServer.Core.Tests.MonitoringCoreTests.Fixture;
+using HSMServer.Core.Tests.TreeValuesCacheTests.Fixture;
+using Xunit;
+
+namespace HSMServer.Core.Tests.TreeValuesCacheTests
+{
+    [Collection("Database collection")]
+    public class AlertTemplatePartialFailureTests : MonitoringCoreTestsBase<TemplateConcurrencyFixture>
+    {
+        private readonly TemplateConcurrencyFixture _fixture;
+        private Guid _failProductId = Guid.Empty;
+
+
+        public AlertTemplatePartialFailureTests(TemplateConcurrencyFixture fixture, DatabaseRegisterFixture registerFixture)
+            : base(fixture, registerFixture, addTestProduct: false)
+        {
+            _fixture = fixture;
+        }
+
+
+        protected override IDatabaseCore WrapDatabase(IDatabaseCore inner)
+        {
+            return new FailingDatabaseCore(inner, entity =>
+                _failProductId != Guid.Empty &&
+                Guid.TryParse(entity.ProductId, out var pid) &&
+                pid == _failProductId);
+        }
+
+
+        // Regression for #1127: when one product's UpdateSensor fails during template removal,
+        // RemoveAlertTemplateAsync must NOT purge the template from _alertTemplates or _database.
+        // Otherwise the failing product's sensors are left with orphaned template policies that
+        // can no longer be cleaned up through the normal edit/remove flow.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task RemoveAlertTemplateAsync_OnPartialDbFailure_PreservesTemplate()
+        {
+            var sensorAPath = "sensorPartialA";
+            var sensorBPath = "sensorPartialB";
+
+            var template = BuildIntegerTemplate(TimeSpan.FromMinutes(5));
+            template.Paths = [$"*/{sensorAPath}", $"*/{sensorBPath}"];
+            Assert.True(template.TryApplyPathTemplates(out _));
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var valueA = SensorValuesFactory.BuildSensorValue(SensorType.Integer, sensorAPath, DateTime.UtcNow);
+            var valueB = SensorValuesFactory.BuildSensorValue(SensorType.Integer, sensorBPath, DateTime.UtcNow);
+
+            await _valuesCache.AddSensorValueAsync(_fixture.AccessKeyAId, _fixture.ProductAId, valueA);
+            await _valuesCache.AddSensorValueAsync(_fixture.AccessKeyBId, _fixture.ProductBId, valueB);
+            await Task.Delay(300);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorAPath, out var sensorA));
+            Assert.Contains(sensorA.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductBId, sensorBPath, out var sensorB));
+            Assert.Contains(sensorB.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+
+            _failProductId = _fixture.ProductBId;
+
+            var (success, error) = await _valuesCache.RemoveAlertTemplateAsync(template.Id);
+
+            Assert.False(success);
+            Assert.Contains("ProductB_concurrency", error);
+
+            Assert.NotNull(_valuesCache.GetAlertTemplate(template.Id));
+
+            var dbTemplates = _databaseCoreManager.DatabaseCore.GetAllAlertTemplates();
+            Assert.Contains(dbTemplates, t => new Guid(t.Id) == template.Id);
+        }
+
+
+        private AlertTemplateModel BuildIntegerTemplate(TimeSpan ttlInterval)
+        {
+            var ttlSetting = new TimeIntervalSettingProperty();
+            ttlSetting.TrySetValue(new TimeIntervalModel(ttlInterval.Ticks));
+
+            var model = new AlertTemplateModel
+            {
+                Name = $"Partial-failure template {Guid.NewGuid():N}",
+                FolderId = _fixture.FolderId,
+                SensorType = (byte)SensorType.Integer,
+                Paths = ["placeholder"],
+                TtlEntries =
+                [
+                    new TtlEntry(new TTLPolicy(ttlSetting, null), ttlSetting.Value ?? TimeIntervalModel.None),
+                ],
+            };
+            model.TryApplyPathTemplates(out _);
+            return model;
+        }
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateConcurrencyTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateConcurrencyTests.cs
@@ -138,7 +138,8 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorSubPath, out var sensorBefore));
             Assert.Contains(sensorBefore.Policies.TTLPolicies, p => p.TemplateId == template.Id);
 
-            await _valuesCache.RemoveAlertTemplateAsync(template.Id);
+            var (removeOk, removeError) = await _valuesCache.RemoveAlertTemplateAsync(template.Id);
+            Assert.True(removeOk, removeError);
             await Task.Delay(300);
 
             Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorSubPath, out var sensorAfter));

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateConcurrencyTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateConcurrencyTests.cs
@@ -146,6 +146,49 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             Assert.DoesNotContain(sensorAfter.Policies.TTLPolicies, p => p.TemplateId == template.Id);
         }
 
+        // Regression for #1127 review: RemoveTemplateFromSensor builds the target SensorEntity
+        // and filters TTLPolicies by TemplateId. Manual TTL policies are serialized with an
+        // empty byte[] TemplateId (TTLPolicy.ToEntity), so the filter must guard against
+        // length-0 arrays — otherwise new Guid(byte[0]) throws ArgumentException, the queue
+        // converts it to TaskResult.FromError, and removal is reported as a partial failure
+        // for any sensor that carries a manual TTL alongside the template TTL.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task RemoveAlertTemplateAsync_SensorWithManualAndTemplateTtl_RemovesOnlyTemplateTtl()
+        {
+            var sensorPath = "sensorMixedTtl";
+
+            var template = BuildIntegerTemplate(ttlInterval: TimeSpan.FromMinutes(5));
+            template.Paths = [$"*/{sensorPath}"];
+            Assert.True(template.TryApplyPathTemplates(out _));
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var value = SensorValuesFactory.BuildSensorValue(SensorType.Integer, sensorPath, DateTime.UtcNow);
+            var addResult = await _valuesCache.AddSensorValueAsync(_fixture.AccessKeyAId, _fixture.ProductAId, value);
+            Assert.True(addResult.IsOk, addResult.Error);
+            await Task.Delay(200);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorPath, out var sensorBefore));
+            Assert.Single(sensorBefore.Policies.TTLPolicies);
+            Assert.Equal(template.Id, sensorBefore.Policies.TTLPolicies[0].TemplateId);
+
+            await AddManualTtlToSensor(_fixture.ProductAId, sensorPath, TimeSpan.FromMinutes(10));
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorPath, out var sensorWithBoth));
+            Assert.Equal(2, sensorWithBoth.Policies.TTLPolicies.Count);
+
+            var (success, error) = await _valuesCache.RemoveAlertTemplateAsync(template.Id);
+            Assert.True(success, $"Removal should succeed but failed: {error}");
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductAId, sensorPath, out var sensorAfter));
+            var remainingTtl = sensorAfter.Policies.TTLPolicies;
+            Assert.Single(remainingTtl);
+            Assert.Null(remainingTtl[0].TemplateId);
+        }
+
+
         // Regression for #1125 review follow-up: RemoveChatsFromPoliciesAsync must dispatch
         // sub-product TTL-policy updates to the ROOT product's queue (matching UpdateProductAsync's
         // contract), not the sub-product's own queue. Each CachedValue owns its own queue thread;
@@ -229,6 +272,35 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             var result = await _valuesCache.UpdateSensorAsync(sensorUpdate);
             Assert.True(result.IsOk, result.Error);
         }
+
+        private async Task AddManualTtlToSensor(Guid productId, string sensorPath, TimeSpan ttl)
+        {
+            Assert.True(_valuesCache.TryGetSensorByPath(productId, sensorPath, out var sensor),
+                $"Sensor {sensorPath} not found");
+
+            var force = InitiatorInfo.AsSystemForce("test_add_manual_ttl");
+
+            // Id = Guid.Empty signals "new TTL policy" to UpdateTTLs.
+            var ttlUpdate = new PolicyUpdate
+            {
+                Id = Guid.Empty,
+                TTL = ttl.Ticks,
+                Initiator = force,
+                ConfirmationPeriod = 0,
+                Conditions = [],
+            };
+
+            var sensorUpdate = new SensorUpdate
+            {
+                Id = sensor.Id,
+                TTLPolicies = [ttlUpdate],
+                Initiator = force,
+            };
+
+            var result = await _valuesCache.UpdateSensorAsync(sensorUpdate);
+            Assert.True(result.IsOk, result.Error);
+        }
+
 
         private async Task AddTtlPolicyWithChatsToProduct(Guid productId, params Guid[] chats)
         {


### PR DESCRIPTION
## Summary
- `RemoveAlertTemplateAsync` now captures per-sensor `TaskResult` inside the `Parallel.ForEachAsync` instead of swallowing failures. When any product's sensor fails (e.g. transient DB error), the template is left intact in `_alertTemplates` and `_database`, and the method returns `(false, "Failed to remove template from products: X, Y")` naming the affected products. Mirrors the `AddAlertTemplateAsync` return contract.
- Test infrastructure: added a `WrapDatabase` hook in `MonitoringCoreTestsBase` and a `FailingDatabaseCore` decorator that throws on `UpdateSensor` for a configurable predicate.

## Test plan
- [x] `dotnet build` succeeds for `HSMServer`, `HSMServer.Core`, and `HSMServer.Core.Tests`.
- [x] `AlertTemplatePartialFailureTests.RemoveAlertTemplateAsync_OnPartialDbFailure_PreservesTemplate` passes: with UpdateSensor failing for ProductB's sensor, returns `(false, error mentioning ProductB_concurrency)`; template remains in `_alertTemplates` and in `_database.GetAllAlertTemplates()`.
- [x] Existing `TemplateConcurrencyTests` still pass (5/5), including the updated `RemoveAlertTemplateAsync_RemovesFromSensorsInSubProducts` success path.

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)