### PR TITLE
Bound node-level TTL From-Parent to the node's own Settings.TTL

### DIFF
--- a/src/server/HSMServer.Core/Model/NodeSettings/CustomSettingsProperty.cs
+++ b/src/server/HSMServer.Core/Model/NodeSettings/CustomSettingsProperty.cs
@@ -3,7 +3,7 @@ using HSMDatabase.AccessManager.DatabaseEntities;
 
 namespace HSMServer.Core.Model.NodeSettings
 {
-    public sealed class TimeIntervalSettingProperty : SettingPropertyBase<TimeIntervalModel>
+    public class TimeIntervalSettingProperty : SettingPropertyBase<TimeIntervalModel>
     {
         private Func<bool> _isSetOverride;
 

--- a/src/server/HSMServer.Core/Model/Policies/DefaultPolicies/TTLPolicy.cs
+++ b/src/server/HSMServer.Core/Model/Policies/DefaultPolicies/TTLPolicy.cs
@@ -52,8 +52,9 @@ namespace HSMServer.Core.Model.Policies
         {
             if (entity?.TTL is not null and not long.MaxValue)
                 _ttl.TrySetValue(new TimeIntervalModel(entity.TTL.Value));
-            else if (node?.Settings?.TTL != null)
-                _ttl.SetParent(node.Settings.TTL);
+            // When entity.TTL is null, the policy stays in IsTTLFromParent state.
+            // The owning PolicyCollectionBase wires the parent via SetTTLParent(...)
+            // using its TTLParentSource (node-bounded for products, chain for sensors).
 
             Apply(entity ?? new PolicyEntity
             {

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/PolicyCollectionBase.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/PolicyCollectionBase.cs
@@ -1,6 +1,7 @@
 using HSMDatabase.AccessManager.DatabaseEntities;
 using HSMServer.Core.Cache.UpdateEntities;
 using HSMServer.Core.Journal;
+using HSMServer.Core.Model.NodeSettings;
 using HSMServer.Core.TableOfChanges;
 using System;
 using System.Collections.Generic;
@@ -26,6 +27,12 @@ namespace HSMServer.Core.Model.Policies
         public event Action<JournalRecordModel> ChangesHandler;
 
 
+        // Source used to resolve a TTL policy with IsTTLFromParent == true.
+        // Default: the owning model's Settings.TTL (walks the parent chain — sensor behaviour).
+        // ProductPolicyCollection overrides this to bound resolution to the node itself.
+        protected virtual TimeIntervalSettingProperty TTLParentSource => _model.Settings.TTL;
+
+
         internal virtual void Attach(BaseNodeModel model) => _model = model;
 
         internal virtual void BuildDefault(BaseNodeModel node, PolicyEntity entity = null)
@@ -33,7 +40,13 @@ namespace HSMServer.Core.Model.Policies
             lock (_ttlLock)
             {
                 if (entity != null)
-                    _ttlPolicies = [new TTLPolicy(node, entity)];
+                {
+                    var policy = new TTLPolicy(node, entity);
+                    if (policy.IsTTLFromParent)
+                        policy.SetTTLParent(TTLParentSource);
+
+                    _ttlPolicies = [policy];
+                }
                 else
                     _ttlPolicies = [];
             }
@@ -42,7 +55,24 @@ namespace HSMServer.Core.Model.Policies
         internal void BuildDefault(BaseNodeModel node, List<PolicyEntity> entities)
         {
             lock (_ttlLock)
-                _ttlPolicies = entities?.Select(e => new TTLPolicy(node, e)).ToList() ?? [];
+            {
+                _ttlPolicies = [];
+
+                if (entities is null)
+                    return;
+
+                var built = new List<TTLPolicy>(entities.Count);
+                foreach (var e in entities)
+                {
+                    var policy = new TTLPolicy(node, e);
+                    if (policy.IsTTLFromParent)
+                        policy.SetTTLParent(TTLParentSource);
+
+                    built.Add(policy);
+                }
+
+                _ttlPolicies = built;
+            }
         }
 
 
@@ -90,7 +120,7 @@ namespace HSMServer.Core.Model.Policies
                             policy.FullUpdate(update);
 
                             if (!update.TTL.HasValue)
-                                policy.SetTTLParent(_model.Settings.TTL);
+                                policy.SetTTLParent(TTLParentSource);
 
                             journalEntries.Add((oldValue, policy, update, update.IsParentRequest));
                         }
@@ -112,7 +142,7 @@ namespace HSMServer.Core.Model.Policies
                     policy.FullUpdate(update, _model as BaseSensorModel);
 
                     if (!update.TTL.HasValue)
-                        policy.SetTTLParent(_model.Settings.TTL);
+                        policy.SetTTLParent(TTLParentSource);
 
                     journalEntries.Add((string.Empty, policy, update, false));
                     newList.Add(policy);
@@ -132,7 +162,7 @@ namespace HSMServer.Core.Model.Policies
             policy.FullUpdate(update, _model as BaseSensorModel);
 
             if (!update.TTL.HasValue)
-                policy.SetTTLParent(_model.Settings.TTL);
+                policy.SetTTLParent(TTLParentSource);
 
             lock (_ttlLock)
                 _ttlPolicies = [.._ttlPolicies, policy];
@@ -143,7 +173,7 @@ namespace HSMServer.Core.Model.Policies
         internal void AddTTLPolicy(TTLPolicy policy)
         {
             if (policy.IsTTLFromParent)
-                policy.SetTTLParent(_model.Settings.TTL);
+                policy.SetTTLParent(TTLParentSource);
 
             lock (_ttlLock)
                 _ttlPolicies = [.._ttlPolicies, policy];

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
@@ -1,4 +1,4 @@
-﻿using HSMServer.Core.Cache;
+using HSMServer.Core.Cache;
 using HSMServer.Core.Model.NodeSettings;
 using System;
 using System.Collections.Concurrent;
@@ -17,32 +17,17 @@ namespace HSMServer.Core.Model.Policies
         // Bounded view of the owning product's Settings.TTL: same CurValue, no parent chain.
         // "From Parent" on a node-level TTL alert resolves against THIS node's own setting
         // and stops here — Never if the node itself has no explicit TTL.
-        private readonly TimeIntervalSettingProperty _boundedTtl = new();
+        // Reads through to the source on every access, so later changes to Settings.TTL
+        // are picked up without event subscriptions.
+        private readonly BoundedTtlSource _boundedTtl = new();
 
 
-        // Resolution source for node-level TTL policies with IsTTLFromParent == true.
-        // Refresh on every read so changes to the product's Settings.TTL are picked up
-        // without needing event subscriptions. This is not a hot path.
-        protected override TimeIntervalSettingProperty TTLParentSource
-        {
-            get
-            {
-                SyncBoundedTtl();
-                return _boundedTtl;
-            }
-        }
-
-        private void SyncBoundedTtl()
-        {
-            // TrySetValue no-ops when string representations match, so calling this
-            // on every TTLParentSource read is cheap and avoids event subscriptions.
-            _boundedTtl.TrySetValue(_model.Settings.TTL.CurValue);
-        }
+        protected override TimeIntervalSettingProperty TTLParentSource => _boundedTtl;
 
         internal override void Attach(BaseNodeModel model)
         {
             base.Attach(model);
-            SyncBoundedTtl();
+            _boundedTtl.SetSource(() => model.Settings.TTL.CurValue);
         }
 
 
@@ -114,6 +99,32 @@ namespace HSMServer.Core.Model.Policies
                     _templateToGroup.TryRemove(group.Template, out _);
                     _groups.Remove(groupId, out _);
                 }
+            }
+        }
+
+
+        // Self-bounded TTL source: behaves like a TimeIntervalSettingProperty whose CurValue
+        // is whatever the owning product's Settings.TTL holds, but with no parent chain —
+        // IsFromParent values fall through to EmptyValue (Never).
+        private sealed class BoundedTtlSource : TimeIntervalSettingProperty
+        {
+            private Func<TimeIntervalModel> _source;
+
+            internal void SetSource(Func<TimeIntervalModel> source) => _source = source;
+
+            private TimeIntervalModel Current => _source?.Invoke();
+
+            public override bool IsSet => Current is { } current && !current.IsFromParent;
+
+            public override TimeIntervalModel Value =>
+                Current is { } current && !current.IsFromParent ? current : EmptyValue;
+
+            public override string GetJournalValue(string customNone = null)
+            {
+                var current = Current;
+                if (current is null || current.IsNone)
+                    return customNone ?? EmptyValue.ToString();
+                return current.ToString();
             }
         }
     }

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
@@ -1,4 +1,5 @@
 ﻿using HSMServer.Core.Cache;
+using HSMServer.Core.Model.NodeSettings;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -12,6 +13,37 @@ namespace HSMServer.Core.Model.Policies
 
         private readonly ConcurrentDictionary<Guid, PolicyGroup> _groups = new();
         private readonly ConcurrentDictionary<Guid, Guid> _policyToGroup = new();
+
+        // Bounded view of the owning product's Settings.TTL: same CurValue, no parent chain.
+        // "From Parent" on a node-level TTL alert resolves against THIS node's own setting
+        // and stops here — Never if the node itself has no explicit TTL.
+        private readonly TimeIntervalSettingProperty _boundedTtl = new();
+
+
+        // Resolution source for node-level TTL policies with IsTTLFromParent == true.
+        // Refresh on every read so changes to the product's Settings.TTL are picked up
+        // without needing event subscriptions. This is not a hot path.
+        protected override TimeIntervalSettingProperty TTLParentSource
+        {
+            get
+            {
+                SyncBoundedTtl();
+                return _boundedTtl;
+            }
+        }
+
+        private void SyncBoundedTtl()
+        {
+            // TrySetValue no-ops when string representations match, so calling this
+            // on every TTLParentSource read is cheap and avoids event subscriptions.
+            _boundedTtl.TrySetValue(_model.Settings.TTL.CurValue);
+        }
+
+        internal override void Attach(BaseNodeModel model)
+        {
+            base.Attach(model);
+            SyncBoundedTtl();
+        }
 
 
         public PolicyExportGroup SaveStateToExportGroup(PolicyExportGroup exportGroup, string relativePath, Predicate<Guid> filter)

--- a/src/server/HSMServer/Controllers/HomeController.cs
+++ b/src/server/HSMServer/Controllers/HomeController.cs
@@ -291,7 +291,7 @@ namespace HSMServer.Controllers
                     };
 
                     if (isExpectedFromParent)
-                        toastViewModel.AddCantChangeIntervalError(folder.Name, "Folder", "Time to live", TimeInterval.FromParent);
+                        toastViewModel.AddCantChangeIntervalError(folder.Name, "Folder", "Time to sensor(s) live", TimeInterval.FromParent);
                     else
                     {
                         toastViewModel.AddItem(folder);
@@ -318,7 +318,7 @@ namespace HSMServer.Controllers
                     };
 
                     if (!expectedUpdate)
-                        toastViewModel.AddCantChangeIntervalError(product.Name, !isProduct ? "Node" : "Product", "Time to live", TimeInterval.FromParent);
+                        toastViewModel.AddCantChangeIntervalError(product.Name, !isProduct ? "Node" : "Product", "Time to sensor(s) live", TimeInterval.FromParent);
                     else
                     {
                         toastViewModel.AddItem(product);

--- a/src/server/HSMServer/Model/DataAlerts/AlertViewModels/TimeToLiveAlertViewModel.cs
+++ b/src/server/HSMServer/Model/DataAlerts/AlertViewModels/TimeToLiveAlertViewModel.cs
@@ -30,7 +30,13 @@ namespace HSMServer.Model.DataAlerts
                 return;
             }
 
-            FillConditions(new TimeIntervalViewModel(PredefinedIntervals.ForTimeout, () => (node.Parent?.TTL, node.ParentIsFolder)) { IsAlertBlock = true });
+            // For a new TTL alert on a product/node, "From Parent" should reference this node's own
+            // Settings.TTL — not the parent product/folder. For sensors, climb the parent chain.
+            var (parent, isFolder) = node is ProductNodeViewModel
+                ? (node.TTL, false)
+                : (node.Parent?.TTL, node.ParentIsFolder);
+
+            FillConditions(new TimeIntervalViewModel(PredefinedIntervals.ForTimeout, () => (parent, isFolder)) { IsAlertBlock = true });
         }
 
         public TimeToLiveAlertViewModel(TTLPolicy policy, NodeViewModel node) : base(policy, node)
@@ -39,9 +45,28 @@ namespace HSMServer.Model.DataAlerts
 
             if (policy.IsTTLFromParent && node != null)
             {
-                interval = new TimeIntervalViewModel(
-                    PredefinedIntervals.ForTimeout,
-                    () => (node.Parent?.TTL, node.ParentIsFolder)) { IsAlertBlock = true };
+                if (node is ProductNodeViewModel)
+                {
+                    // Node-level TTL alert: "From Parent" resolves against this node's own Settings.TTL
+                    // (bounded — does not climb to the parent product/folder). Build the parent view
+                    // from the policy's resolved TTL so the UI matches the node's "Time to live" field.
+                    var resolved = policy.TTLInterval.UseTicks
+                        ? new TimeIntervalModel(policy.TTLInterval.Ticks)
+                        : policy.TTLInterval;
+
+                    var resolvedParent = new TimeIntervalViewModel(PredefinedIntervals.ForTimeout) { IsAlertBlock = true };
+                    resolvedParent.FromModel(resolved, PredefinedIntervals.ForTimeout);
+
+                    interval = new TimeIntervalViewModel(PredefinedIntervals.ForTimeout, () => (resolvedParent, false)) { IsAlertBlock = true };
+                }
+                else
+                {
+                    // Sensor-level TTL alert: keep the parent-chain resolution.
+                    interval = new TimeIntervalViewModel(
+                        PredefinedIntervals.ForTimeout,
+                        () => (node.Parent?.TTL, node.ParentIsFolder)) { IsAlertBlock = true };
+                }
+
                 interval.Interval = TimeInterval.FromParent;
             }
             else

--- a/src/server/HSMServer/Model/DataAlerts/AlertViewModels/TimeToLiveAlertViewModel.cs
+++ b/src/server/HSMServer/Model/DataAlerts/AlertViewModels/TimeToLiveAlertViewModel.cs
@@ -49,7 +49,7 @@ namespace HSMServer.Model.DataAlerts
                 {
                     // Node-level TTL alert: "From Parent" resolves against this node's own Settings.TTL
                     // (bounded — does not climb to the parent product/folder). Build the parent view
-                    // from the policy's resolved TTL so the UI matches the node's "Time to live" field.
+                    // from the policy's resolved TTL so the UI matches the node's "Time to sensor(s) live" field.
                     var resolved = policy.TTLInterval.UseTicks
                         ? new TimeIntervalModel(policy.TTLInterval.Ticks)
                         : policy.TTLInterval;

--- a/src/server/HSMServer/Model/ViewModel/EditAlertsViewModel.cs
+++ b/src/server/HSMServer/Model/ViewModel/EditAlertsViewModel.cs
@@ -12,7 +12,7 @@ public sealed class EditAlertsViewModel
     public List<Guid> SelectedNodes => string.IsNullOrEmpty(NodeIds) ? new() : NodeIds.Split(',').Select(x => x.ToGuid()).ToList();
 
 
-    [Display(Name = "Time to live interval")]
+    [Display(Name = "Time to sensor(s) live")]
     [MinTimeInterval(TimeInterval.OneMinute, ErrorMessage = "{0} minimal value is {1}.")]
     public TimeIntervalViewModel ExpectedUpdateInterval { get; set; } = new(PredefinedIntervals.ForFolderTimeout);
 

--- a/src/server/HSMServer/Model/ViewModel/NodeInfoBaseViewModel.cs
+++ b/src/server/HSMServer/Model/ViewModel/NodeInfoBaseViewModel.cs
@@ -25,7 +25,7 @@ namespace HSMServer.Model.ViewModel
 
         public SensorStatus Status { get; set; }
 
-        [Display(Name = "Time to live interval")]
+        [Display(Name = "Time to sensor(s) live")]
         [MinTimeInterval(TimeInterval.OneMinute, ErrorMessage = "{0} minimal value is {1}.")]
         public TimeIntervalViewModel ExpectedUpdateInterval { get; set; }
 

--- a/src/server/HSMServer/Views/Home/_GeneralInfo.cshtml
+++ b/src/server/HSMServer/Views/Home/_GeneralInfo.cshtml
@@ -31,7 +31,7 @@
         </div>
 
         <div class="d-flex flex-row text-nowrap align-items-center ms-3 mt-1">
-            <span class="meta-info-label">Time to live</span>
+            <span class="meta-info-label">Time to sensor(s) live</span>
             <span id="node_ttlLabel" class="meta-info-value">@Model.ExpectedUpdateInterval.DisplayValue</span>
             <div id="node_ttl" class="d-none meta-info-interval">
                 <partial name="_TimeIntervalSelect" for="ExpectedUpdateInterval" />

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/NodeTTLFromParentResolutionTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/NodeTTLFromParentResolutionTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using HSMCommon.Model;
+using HSMServer.Core.Cache.UpdateEntities;
+using HSMServer.Core.Model;
+using HSMServer.Core.Model.Policies;
+using HSMServer.Core.Schedule;
+using HSMServer.Core.TableOfChanges;
+using HSMServer.Core.Tests.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace HSMServer.Core.Tests.TreeValuesCacheTests
+{
+    public class NodeTTLFromParentResolutionTests
+    {
+        // 5 minutes in .NET ticks. TimeIntervalModel stores raw ticks for Ticks-kind intervals.
+        private const long FiveMinutesTicks = 5 * TimeSpan.TicksPerMinute;
+
+        // 10 minutes — distinct value used on a grandparent to prove the chain is NOT climbed.
+        private const long TenMinutesTicks = 10 * TimeSpan.TicksPerMinute;
+
+
+        [Fact]
+        [Trait("Category", "Node TTL From Parent resolution")]
+        public void NodeTTL_FromParent_ResolvesFromNodeOwnSettings()
+        {
+            // Build parent → child product so the child has a real parent chain that could be climbed.
+            var parentProduct = new ProductModel("parent");
+            var childProduct = new ProductModel("child");
+            parentProduct.AddSubProduct(childProduct);
+
+            // Grandparent has an explicit TTL — would be picked up if the chain were climbed.
+            parentProduct.Settings.TTL.TrySetValue(new TimeIntervalModel(TenMinutesTicks));
+
+            // The child product itself has an explicit "Time to sensors live" of 5 minutes.
+            childProduct.Settings.TTL.TrySetValue(new TimeIntervalModel(FiveMinutesTicks));
+
+            // Add a TTL alert on the child product with the period set to "From Parent" (TTL == null).
+            childProduct.Policies.UpdateTTLs(
+            [
+                new PolicyUpdate
+                {
+                    Id = Guid.NewGuid(),
+                    TTL = null,
+                    Initiator = InitiatorInfo.AsUser("test"),
+                    Conditions = [],
+                    Destination = new PolicyDestinationUpdate(),
+                },
+            ], InitiatorInfo.AsUser("test"));
+
+            var policy = Assert.Single(childProduct.Policies.TTLPolicies);
+
+            Assert.True(policy.IsTTLFromParent, "policy should still report IsTTLFromParent (no concrete TTL stored)");
+            Assert.Equal(FiveMinutesTicks, policy.TTLTicks);
+            Assert.Equal(FiveMinutesTicks, policy.TTLInterval.Ticks);
+        }
+
+        [Fact]
+        [Trait("Category", "Node TTL From Parent resolution")]
+        public void NodeTTL_FromParent_WithNodeOwnSettingsAlsoFromParent_ReturnsNever()
+        {
+            var parentProduct = new ProductModel("parent");
+            var childProduct = new ProductModel("child");
+            parentProduct.AddSubProduct(childProduct);
+
+            // Grandparent has an explicit TTL of 10 minutes. If resolution climbed the chain,
+            // this is what the child's TTL policy would pick up.
+            parentProduct.Settings.TTL.TrySetValue(new TimeIntervalModel(TenMinutesTicks));
+
+            // The child product itself has NO explicit TTL — default is FromParent.
+            // Do not call TrySetValue on childProduct.Settings.TTL — leave it as the default.
+
+            childProduct.Policies.UpdateTTLs(
+            [
+                new PolicyUpdate
+                {
+                    Id = Guid.NewGuid(),
+                    TTL = null,
+                    Initiator = InitiatorInfo.AsUser("test"),
+                    Conditions = [],
+                    Destination = new PolicyDestinationUpdate(),
+                },
+            ], InitiatorInfo.AsUser("test"));
+
+            var policy = Assert.Single(childProduct.Policies.TTLPolicies);
+
+            Assert.True(policy.IsTTLFromParent);
+            // Bounded resolution: with no explicit value on this node, the result is Never (None).
+            Assert.True(policy.TTLInterval.IsNone);
+            Assert.Equal(long.MaxValue, policy.TTLInterval.Ticks);
+        }
+
+        [Fact]
+        [Trait("Category", "Node TTL From Parent resolution")]
+        public void NodeTTL_FromParent_PropagatesToChildSensor()
+        {
+            // Mirrors TreeValuesCache.AddSensor: when a sensor is added under a product,
+            // it inherits a child TTL policy for each of the product's TTLPolicies via ApplyParent.
+            var product = new ProductModel("parent");
+            product.Settings.TTL.TrySetValue(new TimeIntervalModel(FiveMinutesTicks));
+
+            product.Policies.UpdateTTLs(
+            [
+                new PolicyUpdate
+                {
+                    Id = Guid.NewGuid(),
+                    TTL = null,
+                    Initiator = InitiatorInfo.AsUser("test"),
+                    Conditions = [],
+                    Destination = new PolicyDestinationUpdate(),
+                },
+            ], InitiatorInfo.AsUser("test"));
+
+            var scheduleProvider = new Mock<IAlertScheduleProvider>();
+            var sensorEntity = EntitiesFactory.BuildSensorEntity(type: (byte)SensorType.Integer);
+            var sensor = new IntegerSensorModel(sensorEntity, null, scheduleProvider.Object);
+            product.AddSensor(sensor);
+
+            // Reproduce the inheritance step from TreeValuesCache.AddSensor (line ~2241).
+            foreach (var parentTtl in product.Policies.TTLPolicies)
+            {
+                var childTtl = new TTLPolicy();
+                childTtl.ApplyParent(parentTtl);
+                sensor.Policies.AddTTLPolicy(childTtl);
+            }
+
+            var sensorTtl = Assert.Single(sensor.Policies.TTLPolicies);
+
+            // The inherited policy must reflect the product's own TTL (5 minutes),
+            // not climb further up the chain.
+            Assert.Equal(FiveMinutesTicks, sensorTtl.TTLTicks);
+        }
+
+        [Fact]
+        [Trait("Category", "Node TTL From Parent resolution")]
+        public void SensorTTL_FromParent_StillClimbsParentChain()
+        {
+            // Regression test: sensor-level TTL alert with "From Parent" must keep resolving
+            // via the sensor's parent chain (sensor → product → grandparent).
+            var grandparent = new ProductModel("grandparent");
+            grandparent.Settings.TTL.TrySetValue(new TimeIntervalModel(TenMinutesTicks));
+
+            var parent = new ProductModel("parent");
+            grandparent.AddSubProduct(parent);
+
+            var scheduleProvider = new Mock<IAlertScheduleProvider>();
+            var sensorEntity = EntitiesFactory.BuildSensorEntity(type: (byte)SensorType.Integer);
+            var sensor = new IntegerSensorModel(sensorEntity, null, scheduleProvider.Object);
+            parent.AddSensor(sensor);
+
+            // Add a TTL alert on the sensor with "From Parent" (TTL == null).
+            sensor.Policies.UpdateTTLs(
+            [
+                new PolicyUpdate
+                {
+                    Id = Guid.NewGuid(),
+                    TTL = null,
+                    Initiator = InitiatorInfo.AsUser("test"),
+                    Conditions = [],
+                    Destination = new PolicyDestinationUpdate(),
+                },
+            ], InitiatorInfo.AsUser("test"));
+
+            var policy = Assert.Single(sensor.Policies.TTLPolicies);
+
+            Assert.True(policy.IsTTLFromParent);
+            // Sensor's parent chain: sensor.Settings.TTL → parent.Settings.TTL → grandparent.Settings.TTL (10 min).
+            Assert.Equal(TenMinutesTicks, policy.TTLTicks);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

TTL alerts defined directly on a product/node no longer resolve \"From Parent\" via the parent chain. They now stop at the defining node: the policy's TTL parent is a self-bounded view of `_model.Settings.TTL` (same `CurValue`, no chain), so \"From Parent\" on a node picks up that node's own \"Time to sensors live\" and yields Never if the node has no explicit value. Sensor-level TTL alerts keep the existing chain semantics; `AlertTemplate` application is unchanged.

Implementation: virtual `TTLParentSource` on `PolicyCollectionBase`; default returns `_model.Settings.TTL`, `ProductPolicyCollection` overrides with the bounded view. `TTLPolicy(BaseNodeModel, PolicyEntity)` no longer wires the parent itself — `BuildDefault` calls `SetTTLParent` via the virtual source so both sensor and product paths share the wiring.

## Test plan

- [x] `dotnet test --filter NodeTTL` — 4 new tests pass:
  - `NodeTTL_FromParent_ResolvesFromNodeOwnSettings` — node with explicit TTL → policy resolves to that value, not grandparent's.
  - `NodeTTL_FromParent_WithNodeOwnSettingsAlsoFromParent_ReturnsNever` — node with no explicit TTL → policy resolves to Never, not grandparent's value.
  - `NodeTTL_FromParent_PropagatesToChildSensor` — sensor added under a node with bounded TTL inherits the resolved value.
  - `SensorTTL_FromParent_StillClimbsParentChain` — regression: sensor-level TTL still walks the chain.
- [x] `dotnet test --filter TTLTemplateProtection` — 8 existing tests pass (no regression).
- [ ] Manual UI verification (per plan):
  - Product with explicit \"Time to sensors live\" = 5 min + TTL alert \"From Parent\" → resolves to 5 min.
  - Change product's \"Time to sensors live\" → re-open the alert, confirm it tracks the new value.
  - Product with no explicit TTL + TTL alert \"From Parent\" → resolves to Never, not parent's value.
  - Sensor-level TTL alert \"From Parent\" still resolves via the chain (no regression).

Note: 3 tests in `TemplateApplicationTests` (`NewSensor_MatchingTemplateWithTTL_GetsTemplateTTLPolicy`, `NewSensor_MatchingMultipleTemplates_GetsAllPolicies`, `NewSensor_MatchingPathWildcard_GetsPolicies`) currently fail on `origin/master` as well — pre-existing, not introduced by this PR.

Closes #1139

🤖 Generated with [Claude Code](https://claude.com/claude-code)