### PR TITLE
Return TimeSpan/Version values from history API

### DIFF
--- a/src/collector/HSMDataCollector.IntegrationTests/Tests/SensorDataSendingTests.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Tests/SensorDataSendingTests.cs
@@ -102,7 +102,7 @@ namespace HSMDataCollector.IntegrationTests.Tests
             await collector.Stop();
         }
 
-        [Fact(Skip = "Server bug #1068: History API returns empty for TimeSpan sensors")]
+        [Fact]
         public async Task SendTimeSpanValue_ServerReceivesCorrectData()
         {
             var path = CollectorOptionsHelper.UniqueSensorPath("timespan_sensor");
@@ -123,7 +123,7 @@ namespace HSMDataCollector.IntegrationTests.Tests
         }
 
 
-        [Fact(Skip = "Server bug #1068: History API returns empty for Version sensors")]
+        [Fact]
         public async Task SendVersionValue_ServerReceivesCorrectData()
         {
             var path = CollectorOptionsHelper.UniqueSensorPath("version_sensor");

--- a/src/server/HSMServer.Core/Extensions/ApiConverters.cs
+++ b/src/server/HSMServer.Core/Extensions/ApiConverters.cs
@@ -238,42 +238,6 @@ namespace HSMServer.Core.ApiObjectsConverters
             };
 
 
-        public static object Convert(this BaseValue value) =>
-            value switch
-            {
-                BooleanValue sv => sv.Convert(),
-                IntegerValue sv => sv.Convert(),
-                DoubleValue sv => sv.Convert(),
-                StringValue sv => sv.Convert(),
-                IntegerBarValue sv => sv.Convert(),
-                DoubleBarValue sv => sv.Convert(),
-                FileValue sv => sv.Convert(),
-                RateValue sv => sv.Convert(),
-                EnumValue sv => sv.Convert(),
-                _ => null,
-            };
-
-
-        public static List<object> Convert(this List<BaseValue> values)
-        {
-            var apiValues = new List<object>(values.Count);
-
-            foreach (var value in values)
-            {
-                var apiValue = value.Convert();
-                if (apiValue != null)
-                    apiValues.Add(apiValue);
-            }
-
-            return apiValues;
-        }
-
-
-
-
-  
-
-
         public static SensorStatus Convert(this ApiSensorStatus status) =>
             status switch
             {

--- a/src/server/HSMServer/ApiObjectsConverters/ApiConverters.cs
+++ b/src/server/HSMServer/ApiObjectsConverters/ApiConverters.cs
@@ -256,6 +256,8 @@ namespace HSMServer.ApiObjectsConverters
                 FileValue sv => sv.Convert(),
                 RateValue sv => sv.Convert(),
                 EnumValue sv => sv.Convert(),
+                TimeSpanValue sv => sv.Convert(),
+                VersionValue sv => sv.Convert(),
                 _ => null,
             };
 

--- a/src/tests/HSMServer.Core.Tests/ConverterTests/BaseValueToHistoryConverterTests.cs
+++ b/src/tests/HSMServer.Core.Tests/ConverterTests/BaseValueToHistoryConverterTests.cs
@@ -1,0 +1,107 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HSMCommon.Model;
+using HSMServer.ApiObjectsConverters;
+using HSMServer.Core.Model.HistoryValues;
+using HSMServer.Core.Tests.Infrastructure;
+using Xunit;
+
+namespace HSMServer.Core.Tests.ConverterTests
+{
+    public class BaseValueToHistoryConverterTests
+    {
+        [Theory]
+        [InlineData(SensorType.Boolean)]
+        [InlineData(SensorType.Integer)]
+        [InlineData(SensorType.Double)]
+        [InlineData(SensorType.String)]
+        [InlineData(SensorType.Rate)]
+        [InlineData(SensorType.Enum)]
+        [InlineData(SensorType.TimeSpan)]
+        [InlineData(SensorType.Version)]
+        [Trait("Category", "Simple")]
+        public void Convert_BaseValue_ReturnsNonNullResult(SensorType type)
+        {
+            var value = SensorValuesFactory.BuildValue(type);
+
+            var result = value.Convert();
+
+            Assert.NotNull(result);
+        }
+
+        [Fact]
+        [Trait("Category", "Simple")]
+        public void Convert_TimeSpanValue_ReturnsSimpleSensorHistoryWithValueString()
+        {
+            var expected = TimeSpan.FromMinutes(5);
+            var value = new TimeSpanValue
+            {
+                Comment = "timespan comment",
+                Time = DateTime.UtcNow,
+                Status = SensorStatus.Ok,
+                Value = expected,
+            };
+
+            var result = value.Convert() as SimpleSensorHistory;
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(), result.Value);
+            Assert.Equal("timespan comment", result.Comment);
+            Assert.Equal(value.Time, result.Time);
+        }
+
+        [Fact]
+        [Trait("Category", "Simple")]
+        public void Convert_VersionValue_ReturnsSimpleSensorHistoryWithValueString()
+        {
+            var expected = new Version(1, 2, 3);
+            var value = new VersionValue
+            {
+                Comment = "version comment",
+                Time = DateTime.UtcNow,
+                Status = SensorStatus.Ok,
+                Value = expected,
+            };
+
+            var result = value.Convert() as SimpleSensorHistory;
+
+            Assert.NotNull(result);
+            Assert.Equal(expected.ToString(), result.Value);
+            Assert.Equal("version comment", result.Comment);
+            Assert.Equal(value.Time, result.Time);
+        }
+
+        [Fact]
+        [Trait("Category", "Simple")]
+        public void Convert_List_PreservesTimeSpanAndVersionValues()
+        {
+            var values = new List<BaseValue>
+            {
+                SensorValuesFactory.BuildValue(SensorType.TimeSpan),
+                SensorValuesFactory.BuildValue(SensorType.Version),
+                SensorValuesFactory.BuildValue(SensorType.Boolean),
+            };
+
+            var result = values.Convert();
+
+            Assert.Equal(values.Count, result.Count);
+            Assert.All(result, Assert.NotNull);
+        }
+
+        [Fact]
+        [Trait("Category", "Simple")]
+        public void Convert_List_DropsNullEntries()
+        {
+            var values = new List<BaseValue>
+            {
+                SensorValuesFactory.BuildValue(SensorType.TimeSpan),
+                null,
+            };
+
+            var result = values.Convert();
+
+            Assert.Single(result);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1068 — the `/api/sensors/history` endpoint returned an empty array `[]` for TimeSpan and Version sensors. The `Convert(this BaseValue)` switch in `ApiConverters.cs` was missing `TimeSpanValue` and `VersionValue` cases, so they fell through to `_ => null` and the list converter dropped them. Added both cases so they resolve to the generic `BaseValue<T>` converter (producing `SimpleSensorHistory`).

Also removes a dead duplicate of the same buggy switch that lived in `HSMServer.Core/Extensions/ApiConverters.cs` (review finding) — it had no callers, so deleting it eliminates the trap instead of letting two copies diverge again.

## Changes

- `src/server/HSMServer/ApiObjectsConverters/ApiConverters.cs` — add `TimeSpanValue` and `VersionValue` cases to `Convert(this BaseValue value)`.
- `src/server/HSMServer.Core/Extensions/ApiConverters.cs` — delete the unused `Convert(this BaseValue)` and `Convert(this List<BaseValue>)` overloads (dead duplicate of the above; no callers found).
- `src/tests/HSMServer.Core.Tests/ConverterTests/BaseValueToHistoryConverterTests.cs` — new unit tests covering the `BaseValue → history` conversion for all simple sensor types plus the list-filtering behavior.
- `src/collector/HSMDataCollector.IntegrationTests/Tests/SensorDataSendingTests.cs` — re-enable `SendTimeSpanValue_ServerReceivesCorrectData` and `SendVersionValue_ServerReceivesCorrectData`.

## Test plan

- [x] New unit tests pass (12/12) — `BaseValueToHistoryConverterTests`
- [x] All converter + history tests pass (79/79) — no regressions from the dead-code deletion
- [ ] Integration tests `SendTimeSpanValue_ServerReceivesCorrectData` / `SendVersionValue_ServerReceivesCorrectData` pass in CI (require Docker server fixture)
- [ ] Manual: `/api/sensors/history` returns non-empty results for a TimeSpan sensor
- [ ] Manual: `/api/sensors/history` returns non-empty results for a Version sensor

Closes #1068

🤖 Generated with [Claude Code](https://claude.com/claude-code)