### PR TITLE
Gate TTL orphan-cleanup on batch initiator only (#1129)

### DIFF
--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/PolicyCollectionBase.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/PolicyCollectionBase.cs
@@ -86,8 +86,7 @@ namespace HSMServer.Core.Model.Policies
                 .GroupBy(u => u.Id)
                 .ToDictionary(g => g.Key, g => g.Last());
             var newPolicyUpdates = updates.Where(u => u.Id == Guid.Empty).ToList();
-            var isTemplateInitiated = initiator == InitiatorInfo.AlertTemplate
-                || updates.Any(u => u.Initiator == InitiatorInfo.AlertTemplate);
+            var isTemplateInitiated = initiator == InitiatorInfo.AlertTemplate;
 
             var journalEntries = new List<(string oldValue, TTLPolicy policy, PolicyUpdate update, bool isParent)>();
 

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TTLTemplateProtectionTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TTLTemplateProtectionTests.cs
@@ -111,6 +111,50 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
         [Fact]
         [Trait("Category", "Template TTL protection")]
+        public void UpdateTTLs_MixedInitiatorBatch_ClearsUserOwnedTTLsNotInUpdate()
+        {
+            // Regression for #1129: a user-initiated batch that happens to carry a
+            // template-initiator item must not preserve user-owned TTLs that the
+            // user request was supposed to clear. The orphan-cleanup check must
+            // depend on the batch initiator, not on sibling items' initiators.
+            var keepUserId = AddManualTTL(600_000_000);
+            var dropUserId = AddManualTTL(3_000_000_000);
+            var templateAAlertId = Guid.NewGuid();
+            AddTemplateTTL(TemplateA, 6_000_000_000, templateAAlertId);
+
+            // Mixed-initiator batch: top-level user initiator, but the second item
+            // is template-initiated.
+            _sensor.Policies.UpdateTTLs(
+            [
+                new PolicyUpdate
+                {
+                    Id = keepUserId,
+                    TTL = 600_000_000,
+                    Initiator = InitiatorInfo.AsUser("test"),
+                    Conditions = [],
+                    Destination = new PolicyDestinationUpdate(),
+                },
+                new PolicyUpdate
+                {
+                    Id = Guid.NewGuid(),
+                    TTL = 9_000_000_000,
+                    TemplateId = TemplateB,
+                    TemplateAlertId = Guid.NewGuid(),
+                    Initiator = InitiatorInfo.AlertTemplate,
+                    Conditions = [],
+                    Destination = new PolicyDestinationUpdate(),
+                },
+            ], InitiatorInfo.AsUser("test"));
+
+            Assert.Equal(3, _sensor.Policies.TTLPolicies.Count);
+            Assert.DoesNotContain(_sensor.Policies.TTLPolicies, p => p.Id == dropUserId);
+            Assert.Single(_sensor.Policies.TTLPolicies, p => p.Id == keepUserId);
+            Assert.Single(_sensor.Policies.TTLPolicies, p => p.TemplateId == TemplateA);
+            Assert.Single(_sensor.Policies.TTLPolicies, p => p.TemplateId == TemplateB);
+        }
+
+        [Fact]
+        [Trait("Category", "Template TTL protection")]
         public void UpdateTTLs_EmptySensor_TemplateAddsAll()
         {
             ApplyTemplateTTLs(TemplateA,


### PR DESCRIPTION
## Summary

`PolicyCollectionBase.UpdateTTLs` computed `isTemplateInitiated` as `initiator == AlertTemplate || updates.Any(u => u.Initiator == AlertTemplate)`. The second clause caused a user-initiated `SensorUpdate` that happened to carry a template-initiator TTL item to preserve **every** TTL not named in `updates` — including user-owned TTLs the user request was supposed to clear.

The top-level `initiator` parameter has been the source of truth since #1120 propagated `InitiatorInfo` through the whole `UpdateTTLs` call chain (`BaseNodeModel` → `ProductModel` / `BaseSensorModel` → `PolicyCollectionBase`), so the sibling-items inspection is no longer needed. This PR drops it.

## Test plan

- [x] New test `UpdateTTLs_MixedInitiatorBatch_ClearsUserOwnedTTLsNotInUpdate` — user-initiated batch with a template-initiator sibling item; verifies the user-owned TTL not in `updates` is cleared, the kept user TTL survives, the unrelated template TTL is preserved via `policy.TemplateId != null`, and the new template TTL is added. Fails on master, passes with this change.
- [x] `TTLTemplateProtectionTests`: 9/9 pass (8 existing + new).
- [x] `SensorPolicyCollectionTests` + `NodeTTLFromParentResolutionTests` + `TemplateConcurrencyTests`: 29/29 pass.
- [ ] Pre-existing failure `TemplateApplicationTests.NewSensor_MatchingTemplateWithTTL_GetsTemplateTTLPolicy` — unrelated, documented in #1119 / #1120 as a separate path-matching limitation; fails identically on master.

Closes #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)