### PR TITLE
Serialize _productsByName mutations under dedicated lock (#1126)

### DIFF
--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -252,9 +252,13 @@ namespace HSMServer.Core.Cache
                 var oldName = product.DisplayName;
                 lock (_productsByNameLock)
                 {
-                    _productsByName.TryRemove(oldName, out _);
-                    if (!_productsByName.TryAdd(update.Name, product))
+                    if (_productsByName.TryAdd(update.Name, product))
+                        _productsByName.TryRemove(oldName, out _);
+                    else
+                    {
                         _logger.Warn($"Cannot rename root product {product.Id} from '{oldName}' to '{update.Name}': target name already in use");
+                        update = update with { Name = null };
+                    }
                 }
             }
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -72,6 +72,7 @@ namespace HSMServer.Core.Cache
         private readonly ConcurrentDictionary<Guid, ProductModel> _tree = new();
         private readonly ConcurrentDictionary<Guid, AlertTemplateModel> _alertTemplates = new();
         private readonly ConcurrentDictionary<string, ProductModel> _productsByName = new(StringComparer.Ordinal);
+        private readonly object _productsByNameLock = new();
 
         private readonly CDict<bool> _fileHistoryLocks = new(); // TODO: get file history should be fixed without this crutch
 
@@ -248,8 +249,13 @@ namespace HSMServer.Core.Cache
 
             if (product.IsRoot && !string.IsNullOrEmpty(update.Name) && product.DisplayName != update.Name)
             {
-                _productsByName.Remove(product.DisplayName, out _);
-                _productsByName.TryAdd(update.Name, product);
+                var oldName = product.DisplayName;
+                lock (_productsByNameLock)
+                {
+                    _productsByName.TryRemove(oldName, out _);
+                    if (!_productsByName.TryAdd(update.Name, product))
+                        _logger.Warn($"Cannot rename root product {product.Id} from '{oldName}' to '{update.Name}': target name already in use");
+                }
             }
 
             _database.UpdateProduct(product.Update(update).ToEntity());
@@ -303,7 +309,8 @@ namespace HSMServer.Core.Cache
                 {
                     if (product.IsRoot)
                     {
-                        _productsByName.TryRemove(product.DisplayName, out _);
+                        lock (_productsByNameLock)
+                            _productsByName.TryRemove(product.DisplayName, out _);
                     }
 
                     RemoveProduct(request.Id, request.InitiatorInfo);
@@ -2014,8 +2021,12 @@ namespace HSMServer.Core.Cache
 
             _logger.Info("Links between products are built");
 
-            foreach (var product in _tree.Values.Where(x => x.IsRoot))
-                _productsByName.TryAdd(product.DisplayName, product);
+            var rootProducts = _tree.Values.Where(x => x.IsRoot).ToList();
+            lock (_productsByNameLock)
+            {
+                foreach (var product in rootProducts)
+                    _productsByName.TryAdd(product.DisplayName, product);
+            }
 
             _logger.Info($"Produts cache by name initialized [{_productsByName.Count}]");
         }
@@ -2187,7 +2198,8 @@ namespace HSMServer.Core.Cache
 
                     product.Update(update);
 
-                    _productsByName.TryAdd(product.DisplayName, product);
+                    lock (_productsByNameLock)
+                        _productsByName.TryAdd(product.DisplayName, product);
                 }
 
                 AddBaseNodeSubscription(product);

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -161,12 +161,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             // succeeds and the final state is fully determined: every created
             // product must resolve through _productsByName under its DisplayName.
             var nameCounter = 0;
-            var rnd = new Random();
             var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(async () =>
             {
                 for (int i = 0; i < iterationsPerThread; ++i)
                 {
-                    var product = createdProducts[rnd.Next(productCount)];
+                    var product = createdProducts[Random.Shared.Next(productCount)];
                     var newName = $"target_{Interlocked.Increment(ref nameCounter)}";
                     await _valuesCache.UpdateProductAsync(new ProductUpdate
                     {

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -190,6 +190,41 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
         [Fact]
+        [Trait("Category", "Concurrency")]
+        public async Task ConcurrentProductRenameToSameNameTest()
+        {
+            var initialRootCount = _valuesCache.GetProducts().Count;
+
+            var p1 = await _valuesCache.AddProductAsync($"prod_{Guid.NewGuid():N}", Guid.Empty);
+            var p2 = await _valuesCache.AddProductAsync($"prod_{Guid.NewGuid():N}", Guid.Empty);
+            var sharedName = $"shared_{Guid.NewGuid():N}";
+
+            using var barrier = new Barrier(2);
+            var t1 = Task.Run(async () =>
+            {
+                barrier.SignalAndWait();
+                await _valuesCache.UpdateProductAsync(new ProductUpdate { Id = p1.Id, Name = sharedName }, default);
+            });
+            var t2 = Task.Run(async () =>
+            {
+                barrier.SignalAndWait();
+                await _valuesCache.UpdateProductAsync(new ProductUpdate { Id = p2.Id, Name = sharedName }, default);
+            });
+            await Task.WhenAll(t1, t2);
+
+            // Collision: exactly one product can own sharedName. The loser must
+            // keep its original name in _productsByName — neither p1 nor p2 is
+            // allowed to be orphaned by the collision.
+            Assert.Equal(initialRootCount + 2, _valuesCache.GetProducts().Count);
+
+            foreach (var created in new[] { p1, p2 })
+            {
+                var current = _valuesCache.GetProduct(created.Id);
+                Assert.Same(current, _valuesCache.GetProductByName(current.DisplayName));
+            }
+        }
+
+        [Fact]
         [Trait("Category", "Remove product(s)")]
         public async Task RemoveProductTest()
         {

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -15,6 +15,7 @@ using Moq;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
 using SensorModelFactory = HSMServer.Core.Tests.Infrastructure.SensorModelFactory;
@@ -156,17 +157,17 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             for (int i = 0; i < productCount; ++i)
                 createdProducts.Add(await _valuesCache.AddProductAsync($"prod_{Guid.NewGuid():N}", Guid.Empty));
 
-            var namesPool = Enumerable.Range(0, productCount * 4)
-                .Select(_ => $"target_{Guid.NewGuid():N}")
-                .ToList();
-
+            // Each rename picks a globally-unique target name, so TryAdd always
+            // succeeds and the final state is fully determined: every created
+            // product must resolve through _productsByName under its DisplayName.
+            var nameCounter = 0;
             var rnd = new Random();
             var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(async () =>
             {
                 for (int i = 0; i < iterationsPerThread; ++i)
                 {
                     var product = createdProducts[rnd.Next(productCount)];
-                    var newName = namesPool[rnd.Next(namesPool.Count)];
+                    var newName = $"target_{Interlocked.Increment(ref nameCounter)}";
                     await _valuesCache.UpdateProductAsync(new ProductUpdate
                     {
                         Id = product.Id,
@@ -176,15 +177,16 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             })).ToArray();
             await Task.WhenAll(tasks);
 
+            // _productsByName must never hold duplicate product references.
             var currentRoots = _valuesCache.GetProducts();
-
             Assert.Equal(currentRoots.Count, currentRoots.Distinct().Count());
 
-            foreach (var root in currentRoots)
-                Assert.Same(root, _valuesCache.GetProductByName(root.DisplayName));
-
+            // The real invariant: every created product must be reachable via its
+            // current DisplayName. Iterating GetProducts() (= _productsByName.Values)
+            // instead would be tautological — an orphaned product never reaches
+            // Values, so the loop wouldn't inspect it.
             foreach (var created in createdProducts)
-                Assert.NotNull(_valuesCache.GetProduct(created.Id));
+                Assert.Same(created, _valuesCache.GetProductByName(created.DisplayName));
         }
 
         [Fact]

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -145,6 +145,49 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
         [Fact]
+        [Trait("Category", "Concurrency")]
+        public async Task ConcurrentProductRenameTest()
+        {
+            const int productCount = 5;
+            const int threadCount = 10;
+            const int iterationsPerThread = 50;
+
+            var createdProducts = new List<ProductModel>(productCount);
+            for (int i = 0; i < productCount; ++i)
+                createdProducts.Add(await _valuesCache.AddProductAsync($"prod_{Guid.NewGuid():N}", Guid.Empty));
+
+            var namesPool = Enumerable.Range(0, productCount * 4)
+                .Select(_ => $"target_{Guid.NewGuid():N}")
+                .ToList();
+
+            var rnd = new Random();
+            var tasks = Enumerable.Range(0, threadCount).Select(_ => Task.Run(async () =>
+            {
+                for (int i = 0; i < iterationsPerThread; ++i)
+                {
+                    var product = createdProducts[rnd.Next(productCount)];
+                    var newName = namesPool[rnd.Next(namesPool.Count)];
+                    await _valuesCache.UpdateProductAsync(new ProductUpdate
+                    {
+                        Id = product.Id,
+                        Name = newName,
+                    }, default);
+                }
+            })).ToArray();
+            await Task.WhenAll(tasks);
+
+            var currentRoots = _valuesCache.GetProducts();
+
+            Assert.Equal(currentRoots.Count, currentRoots.Distinct().Count());
+
+            foreach (var root in currentRoots)
+                Assert.Same(root, _valuesCache.GetProductByName(root.DisplayName));
+
+            foreach (var created in createdProducts)
+                Assert.NotNull(_valuesCache.GetProduct(created.Id));
+        }
+
+        [Fact]
         [Trait("Category", "Remove product(s)")]
         public async Task RemoveProductTest()
         {


### PR DESCRIPTION
## Summary

`UpdateProduct(ProductUpdate)` mutated `_productsByName` in two non-atomic steps
(`Remove(oldName)` + `TryAdd(newName)`). Each root product has its own
`UpdatesQueue`, so operations on *different* roots run in parallel and could
interleave on the shared `_productsByName` index — producing stale entries,
silently lost renames, or products unmappable by name (`GetProduct(name)`
returning the wrong product or null).

This PR introduces `_productsByNameLock` held during every mutation of
`_productsByName` (rename, `AddProduct`, `RemoveProduct`, the init loop).
Reads keep going through `ConcurrentDictionary` directly.

### Rename handling

TryAdd-first, then on success remove oldName. If the target name is already
taken by another root, the rename is rejected: `update.Name` is cleared so
`ProductModel.Update` (`update.Name ?? DisplayName`) leaves `DisplayName` alone,
and the loser stays indexed under its original name. A warning is logged.

TryAdd-first also closes the brief window where `GetProductByName(newName)`
returned null between Remove and Add.

## Known limitations (tracked as follow-ups)

- **Collision is silently rejected to the caller.** `UpdateProductAsync` returns
  `Task` and discards the `TaskResult` from the queue, so a REST/UI caller
  renaming to a taken name sees success with no change. Strictly better than the
  pre-PR corruption, but bad UX — tracked in #1152.
- **`AddProduct` does not guard duplicate `DisplayName`.** Pre-existing, same
  class of issue — tracked in #1153.

## Test plan

- [x] `dotnet build src/server/HSMServer.Core/HSMServer.Core.csproj` — green
- [x] `dotnet build src/tests/HSMServer.Core.Tests/HSMServer.Core.Tests.csproj` — green
- [x] `ConcurrentProductRenameTest` (5 products, 10 threads × 50 iterations,
      globally-unique target names, `Random.Shared`) — verifies every created
      product resolves through its current `DisplayName` and `_productsByName`
      has no duplicate references. Stable across 5+ runs.
- [x] `ConcurrentProductRenameToSameNameTest` — two roots race via `Barrier` to
      the same target name; verifies neither is orphaned. Stable across 10 runs.
- [ ] Pre-existing `TemplateApplicationTests.*` failures on master are
      unrelated (3 tests fail on `origin/master` without these changes).

Closes #1126

🤖 Generated with [Claude Code](https://claude.com/claude-code)