### PR TITLE
Fix integration-tests: publish server image as ContainerImageName so branch source is actually tested

### DIFF
--- a/.github/workflows/collector-integration-tests.yml
+++ b/.github/workflows/collector-integration-tests.yml
@@ -23,10 +23,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     env:
-      # Matches the fixture's `FROM hsmonitoring/hierarchical_sensor_monitoring:latest`.
-      # HSMServer.csproj already sets `ContainerImageTags=$(Version);latest`, so the
-      # local build is automatically tagged `:latest` as well — Docker prefers local
-      # over remote when the tag matches, so no push is needed.
+      # Must match the fixture's `FROM hsmonitoring/hierarchical_sensor_monitoring:latest`
+      # (HsmServerFixture) so the locally-built source image shadows the published one.
+      # HSMServer.csproj sets `ContainerImageTags=$(Version);latest`, so the build is also
+      # tagged `:latest`; Docker prefers a matching local image over remote, so no push is needed.
       SERVER_REPOSITORY: hsmonitoring/hierarchical_sensor_monitoring
     steps:
       - uses: actions/checkout@v4
@@ -37,14 +37,17 @@ jobs:
 
       # Build the server container from the SAME branch the integration tests run against.
       # Without this step the fixture pulls master's published `:latest`, so any server-side
-      # API addition on the branch (e.g. a new /enum endpoint) is invisible to the tests
-      # and the matching collector-side route returns 404. Mirrors the pattern in tests.yml.
-      # `ContainerRepository` is the modern property name; the deprecated `ContainerImageName`
-      # also works but emits a warning. We do NOT set ContainerImageTag because the csproj
-      # already supplies `ContainerImageTags`, and the two are mutually exclusive (error
-      # CONTAINER2008).
+      # change on the branch (e.g. the #1068 history-API fix for Enum/TimeSpan/Version) is
+      # invisible to the tests. Mirrors the publish recipe in server-build.yml.
+      #
+      # IMPORTANT: override `ContainerImageName` (NOT `ContainerRepository`). HSMServer.csproj
+      # hard-codes `<ContainerImageName>$(MSBuildProjectName)</ContainerImageName>` (= `hsmserver`);
+      # a `-p:ContainerRepository=...` does NOT override it, so the build is tagged `hsmserver:latest`
+      # and the fixture silently falls back to the remote published image. server-build.yml uses
+      # `-p:ContainerImageName=...` for exactly this reason. We do NOT set ContainerImageTag — the
+      # csproj already supplies `ContainerImageTags` and the two are mutually exclusive (CONTAINER2008).
       - name: Build server container image from branch source
-        run: dotnet publish src/server/HSMServer/HSMServer.csproj -c Release --os linux --arch x64 -p:PublishProfile=DefaultContainer -p:ContainerRepository=${{ env.SERVER_REPOSITORY }}
+        run: dotnet publish src/server/HSMServer/HSMServer.csproj -c Release --os linux --arch x64 -p:PublishProfile=DefaultContainer -p:ContainerImageName=${{ env.SERVER_REPOSITORY }}
 
       - name: Run Integration Tests
         run: dotnet test src/collector/HSMDataCollector.IntegrationTests --logger "console;verbosity=detailed"

--- a/src/collector/HSMDataCollector.IntegrationTests/Tests/SensorDataSendingTests.cs
+++ b/src/collector/HSMDataCollector.IntegrationTests/Tests/SensorDataSendingTests.cs
@@ -213,7 +213,7 @@ namespace HSMDataCollector.IntegrationTests.Tests
         }
 
 
-        [Fact(Skip = "Server bug #1068: History API returns empty for Enum sensors. The /enum endpoint accepts the value (HTTP 200) and EnumValue is wired into ApiConverters.Convert(BaseValue), but the history API still returns []. Same class of bug as TimeSpan/Version; commit 07bc22791's converter fix is not sufficient.")]
+        [Fact]
         public async Task SendEnumValue_ServerReceivesCorrectData()
         {
             var path = CollectorOptionsHelper.UniqueSensorPath("enum_sensor");


### PR DESCRIPTION
## Problem

`integration-tests` has been **red on master** since `30b2d145b` (the `#1068` history-API fix that un-skipped the TimeSpan/Version tests). It fails on `SendTimeSpanValue` / `SendVersionValue` with *"value not received"* (30 s timeout), and `SendEnumValue` is still skipped for the "same" reason.

## Root cause

The *"Build server container image from branch source"* step published with:

```
-p:ContainerRepository=hsmonitoring/hierarchical_sensor_monitoring
```

but `HSMServer.csproj` hard-codes `<ContainerImageName>$(MSBuildProjectName)</ContainerImageName>` (= `hsmserver`), which **takes precedence**. So the source build was tagged `hsmserver:latest`, and the fixture's `FROM hsmonitoring/hierarchical_sensor_monitoring:latest` (`HsmServerFixture`) silently fell back to the **remote published image**. CI build log:

```
Building image 'hsmserver' with tags '3.40.32,latest' …
[testcontainers] Docker image hsmonitoring/hierarchical_sensor_monitoring:latest created  ← remote, not the source build
```

**The branch source server was never actually tested.** That's why the Enum/TimeSpan/Version converter fixes (`07bc22791`, `30b2d145b`) looked *"insufficient"* — they are correct, they were just never exercised. The published image simply predates them.

## Fix

- Override **`ContainerImageName`** (not `ContainerRepository`) in the publish step — exactly what `server-build.yml` does — so the source build is tagged `hsmonitoring/hierarchical_sensor_monitoring:latest` and shadows the remote image.
- Re-enable `SendEnumValue` (the last image-dependent skip). TimeSpan/Version were already un-skipped on master.

## Verification (local, Docker)

Built the server image from source with the corrected property, then ran the full class against it:

```
SensorDataSendingTests … 11/11 Passed
  incl. SendEnumValue (2 s), SendTimeSpanValue (2 s), SendVersionValue (2 s)
```

All three pass in ~2 s instead of timing out — confirming the source server's history API is correct and the only defect was the image-name mismatch in CI.

`#1068` is already closed; this makes its fix actually exercised in CI and restores `integration-tests` to green on master.