### PR TITLE
#1100: Conan recipe + vcpkg overlay port + packaging CI (Closes #1100)

### DIFF
--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -264,6 +264,12 @@ jobs:
 
       - name: Install the overlay port from branch source
         shell: bash
+        # run-vcpkg defaults VCPKG_BINARY_SOURCES to "clear;x-gha,readwrite", whose GHA backend needs
+        # ACTIONS_RUNTIME_TOKEN / ACTIONS_CACHE_URL that aren't reliably exported here — failing the
+        # install. Override to "clear" so the port builds from source, no cache tokens (same fix as
+        # the http-transport lane).
+        env:
+          VCPKG_BINARY_SOURCES: clear
         run: |
           "$VCPKG_ROOT/vcpkg" install hsm-collector --overlay-ports=src/native/collector/vcpkg-port
 

--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -221,3 +221,64 @@ jobs:
       - name: Test
         run: ctest --preset ${{ matrix.preset }}
         working-directory: src/native/collector
+
+  conan-consume:
+    # Packaging proof (#1100): `conan create` builds the package from this branch's source and runs
+    # the test_package (a clean consumer via find_package(hsm_collector)).
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install Conan
+        run: pip install "conan>=2.0"
+      - name: Detect Conan profile
+        run: conan profile detect --force
+      - name: conan create + test_package
+        run: conan create src/native/collector --build=missing
+
+  vcpkg-consume:
+    # Packaging proof (#1100): build the overlay port from this branch's source, then build + run a
+    # consumer against the vcpkg-installed package via the vcpkg CMake toolchain.
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    env:
+      VCPKG_DISABLE_METRICS: '1'
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up vcpkg
+        uses: lukka/run-vcpkg@v11
+        with:
+          vcpkgGitCommitId: 6f29f12e82a8293156836ad81cc9bf5af41fe836
+
+      - name: Install the overlay port from branch source
+        shell: bash
+        run: "$VCPKG_ROOT/vcpkg" install hsm-collector --overlay-ports=src/native/collector/vcpkg-port
+
+      - name: Configure consumer against the vcpkg package
+        shell: bash
+        run: >
+          cmake -S src/native/collector/examples/console/standalone -B build/vcpkg-consume
+          -DCMAKE_BUILD_TYPE=Release
+          -DCMAKE_TOOLCHAIN_FILE="$VCPKG_ROOT/scripts/buildsystems/vcpkg.cmake"
+
+      - name: Build consumer
+        run: cmake --build build/vcpkg-consume --config Release --parallel
+
+      - name: Run consumer
+        shell: bash
+        run: |
+          bin=$(find build/vcpkg-consume \( -name 'hsm_console_standalone' -o -name 'hsm_console_standalone.exe' \) -type f | head -1)
+          echo "running $bin"
+          "$bin"

--- a/.github/workflows/native-collector-conformance.yml
+++ b/.github/workflows/native-collector-conformance.yml
@@ -264,7 +264,8 @@ jobs:
 
       - name: Install the overlay port from branch source
         shell: bash
-        run: "$VCPKG_ROOT/vcpkg" install hsm-collector --overlay-ports=src/native/collector/vcpkg-port
+        run: |
+          "$VCPKG_ROOT/vcpkg" install hsm-collector --overlay-ports=src/native/collector/vcpkg-port
 
       - name: Configure consumer against the vcpkg package
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ src/module/HSMPingModule/Config/*
 #AI
 # Claude Code local state (permissions, worktrees) - machine-local, never commit
 .claude/
+
+# Conan/CMake user presets (generated, never committed)
+CMakeUserPresets.json

--- a/aicontext/features/integrations/native-collector/feature.md
+++ b/aicontext/features/integrations/native-collector/feature.md
@@ -54,6 +54,8 @@ The wrapper is a **thin convenience layer**: it adds no wire behavior. Every reg
 | `src/native/collector/examples/console/main.cpp` | console example (WrapperConsole equivalent) |
 | `src/native/collector/examples/console/standalone/CMakeLists.txt` | clean-machine `find_package` consumer |
 | `src/native/collector/cmake/hsm_collectorConfig.cmake.in` | package config template |
+| `src/native/collector/conanfile.py` + `test_package/` | Conan recipe + clean-consumer test |
+| `src/native/collector/vcpkg-port/` | vcpkg overlay port (portfile + manifest + copyright) |
 | `docs/native-collector-migration.md` | source-compat audit vs the C++/CLI wrapper |
 | `docs/native-collector/Doxyfile` | API-reference generation (CI doxygen lane) |
 
@@ -66,7 +68,15 @@ The wrapper is a **thin convenience layer**: it adds no wire behavior. Every reg
 
 ## Packaging & versioning
 
-`cmake --install` emits the headers, the static core lib, and a `find_package(hsm_collector)` package (`hsm_collectorConfig.cmake` + version file + exported namespaced targets). The package version tracks the C ABI semver (`HSM_COLLECTOR_VERSION`, currently 0.4.0); `find_package(hsm_collector 0.4)` version checks use it. The CI **install-consume** lane proves the clean-machine path end-to-end. A **Conan recipe** and **NuGet native assets** are a deferred follow-up under #1100.
+Three consumption paths, all built on the one set of CMake `install()` rules; the package version tracks the C ABI semver (`HSM_COLLECTOR_VERSION`, currently 0.4.0):
+
+- **CMake `find_package`** (baseline). `cmake --install` emits the headers, the static core lib, and `hsm_collectorConfig.cmake` + version file + exported namespaced targets (`hsm_collector::hsm_collector_core` / `::hsm_collector_cpp`). `find_package(hsm_collector 0.4)` version checks work. Proven by the CI **install-consume** lane (build → install → standalone `find_package` build+run, Win+Linux).
+- **Conan** (`conanfile.py` + `test_package/`). `conan create` builds from source with tests/examples gated off; Conan owns the CMake integration (the project's own config is dropped in `package()`, components re-declared). An optional `http` Conan option pulls `libcurl`. Proven by the **conan-consume** lane (`conan create` runs the `test_package` consumer).
+- **vcpkg** (overlay port `vcpkg-port/`). `portfile.cmake` + manifest build the library from the adjacent source (`SOURCE_PATH=../`), with an `http` feature for curl; for registry publication the `SOURCE_PATH` line is swapped for a `vcpkg_from_github` block at a release tag. Proven by the **vcpkg-consume** lane (install the overlay port → build+run a consumer through the vcpkg toolchain, Win+Linux).
+
+CMake gates: `HSM_COLLECTOR_INSTALL`, `HSM_COLLECTOR_BUILD_EXAMPLES`, `HSM_COLLECTOR_BUILD_TESTS` (each defaults to `PROJECT_IS_TOP_LEVEL`), and `HSM_COLLECTOR_HTTP`. Package builds set tests/examples OFF.
+
+**NuGet native assets** were intentionally **dropped** — there is no concrete mixed managed/native consumer to justify the `.nuspec` + native-asset layout; .NET consumers use the managed `HSMDataCollector` package, native consumers use one of the three paths above.
 
 ## Divergences from the C++/CLI wrapper (`DataCollector.h`)
 

--- a/docs/native-collector-migration.md
+++ b/docs/native-collector-migration.md
@@ -66,10 +66,23 @@ sensor.AttachAlert(alert);
 
 ## Building against the native API
 
+Whichever package manager you use, the CMake usage is identical:
+
 ```cmake
 find_package(hsm_collector CONFIG REQUIRED)
 target_link_libraries(my_app PRIVATE hsm_collector::hsm_collector_cpp)
 ```
+
+Consume the package one of three ways:
+
+- **CMake `find_package`** — `cmake --install` the collector to a prefix, then point
+  `CMAKE_PREFIX_PATH` at it.
+- **Conan** — `conan create src/native/collector` (or add `hsm-collector/0.4.0` to your
+  `conanfile`), with `-o hsm-collector/*:http=True` for the libcurl transport.
+- **vcpkg** — add the overlay port: `vcpkg install hsm-collector
+  --overlay-ports=src/native/collector/vcpkg-port` (feature `http` for curl), then build with the
+  vcpkg toolchain. For a registry, replace the port's `SOURCE_PATH` with a `vcpkg_from_github` block
+  at a release tag.
 
 See `src/native/collector/examples/console/` for a complete example (and its `standalone/`
 subproject for the `find_package` consume path). API reference: `docs/native-collector/Doxyfile`

--- a/src/native/collector/CMakeLists.txt
+++ b/src/native/collector/CMakeLists.txt
@@ -42,6 +42,10 @@ option(HSM_COLLECTOR_INSTALL "Generate install + find_package package for the na
 # Build the in-tree console example (#1100). Defaults to the install setting.
 option(HSM_COLLECTOR_BUILD_EXAMPLES "Build the native collector example apps" ${_hsm_default_install})
 
+# Build the test/conformance binary (#1100). Off for package builds (Conan/vcpkg) and
+# add_subdirectory consumers, which want only the library.
+option(HSM_COLLECTOR_BUILD_TESTS "Build the native collector test + conformance binary" ${_hsm_default_install})
+
 # Treat warnings as errors (off by default so local dev is not blocked; CI
 # turns it on). The corpus + unit tests must build warning-clean under it.
 option(HSM_COLLECTOR_WERROR "Treat compiler warnings as errors" OFF)
@@ -137,8 +141,9 @@ target_compile_features(hsm_collector_cpp INTERFACE cxx_std_17)
 # ---------------------------------------------------------------------------
 # Packaging (#1100): CMake install + find_package(hsm_collector) consumer
 # config (the baseline that satisfies native consumers and the standalone
-# example's clean-build proof). A Conan recipe / NuGet native assets are a
-# deferred follow-up under the same issue.
+# example's clean-build proof). The Conan recipe (conanfile.py) and the vcpkg
+# overlay port (vcpkg-port/) build on top of these install rules. NuGet native
+# assets were intentionally dropped (no mixed .NET/native consumer).
 # ---------------------------------------------------------------------------
 if(HSM_COLLECTOR_INSTALL)
     include(CMakePackageConfigHelpers)
@@ -184,6 +189,10 @@ endif()
 if(HSM_COLLECTOR_BUILD_EXAMPLES)
     add_subdirectory(examples/console)
 endif()
+
+# The test/conformance binary and its ctest registrations (gated so package/consumer builds skip
+# them). The body below is intentionally left un-indented to keep the guard a minimal diff.
+if(HSM_COLLECTOR_BUILD_TESTS)
 
 add_executable(hsm_collector_tests
     tests/hsm_collector_tests.cpp
@@ -364,3 +373,5 @@ add_meta_conformance_test(meta_sent_count_overcount.hsmtest)
 add_meta_conformance_test(meta_sent_count_zero_but_sent.hsmtest)
 add_meta_conformance_test(meta_unknown_action_rejected.hsmtest)
 add_meta_conformance_test(meta_value_sequence_wrong_start.hsmtest)
+
+endif() # HSM_COLLECTOR_BUILD_TESTS

--- a/src/native/collector/conanfile.py
+++ b/src/native/collector/conanfile.py
@@ -1,0 +1,81 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
+from conan.tools.files import rmdir
+
+
+class HsmCollectorConan(ConanFile):
+    """Conan 2 recipe for the native HSM collector (#1100).
+
+    Packages the static C-ABI core (`hsm_collector_core`) plus the header-only C++ RAII wrapper
+    (`hsm_collector_cpp`). The package version tracks the C ABI semver (HSM_COLLECTOR_VERSION).
+    Builds via the project's own CMakeLists (the same install() rules the find_package package
+    uses); Conan owns the CMake integration, so consumers do:
+
+        find_package(hsm_collector CONFIG REQUIRED)
+        target_link_libraries(app PRIVATE hsm_collector::hsm_collector_cpp)
+    """
+
+    name = "hsm-collector"
+    version = "0.4.0"
+    license = "See repository (SoftFx/Hierarchical-Sensor-Monitoring)"
+    url = "https://github.com/SoftFx/Hierarchical-Sensor-Monitoring"
+    description = "Native C++ HSM DataCollector — stable C ABI core + header-only RAII C++ wrapper."
+    topics = ("monitoring", "telemetry", "collector", "metrics", "hsm")
+
+    settings = "os", "arch", "compiler", "build_type"
+    options = {"http": [True, False], "fPIC": [True, False]}
+    default_options = {"http": False, "fPIC": True}
+
+    # Only the library sources — tests/examples are gated OFF for the package build.
+    exports_sources = "CMakeLists.txt", "CMakePresets.json", "include/*", "src/*", "cmake/*"
+
+    def config_options(self):
+        if self.settings.os == "Windows":
+            del self.options.fPIC
+
+    def requirements(self):
+        # libcurl is a private dependency of the static core, pulled in only for the HTTP transport.
+        if self.options.http:
+            self.requires("libcurl/8.10.1")
+
+    def layout(self):
+        cmake_layout(self)
+
+    def generate(self):
+        CMakeDeps(self).generate()
+        tc = CMakeToolchain(self)
+        tc.cache_variables["HSM_COLLECTOR_BUILD_TESTS"] = False
+        tc.cache_variables["HSM_COLLECTOR_BUILD_EXAMPLES"] = False
+        tc.cache_variables["HSM_COLLECTOR_INSTALL"] = True
+        tc.cache_variables["HSM_COLLECTOR_HTTP"] = bool(self.options.http)
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        # Conan generates the CMake package config from the components below; drop the project's own
+        # exported config so a consumer resolves a single, Conan-owned hsm_collector package.
+        rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "hsm_collector")
+
+        core = self.cpp_info.components["core"]
+        core.set_property("cmake_target_name", "hsm_collector::hsm_collector_core")
+        core.libs = ["hsm_collector_core"]
+        if self.settings.os in ("Linux", "FreeBSD"):
+            core.system_libs.append("pthread")
+        if self.options.http:
+            core.requires.append("libcurl::libcurl")
+
+        # Header-only wrapper: no libs, just the include dir + a link to the core.
+        cpp = self.cpp_info.components["cpp"]
+        cpp.set_property("cmake_target_name", "hsm_collector::hsm_collector_cpp")
+        cpp.requires = ["core"]

--- a/src/native/collector/test_package/CMakeLists.txt
+++ b/src/native/collector/test_package/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.21)
+
+project(hsm_consumer LANGUAGES CXX)
+
+find_package(hsm_collector CONFIG REQUIRED)
+
+add_executable(hsm_consumer src/consumer.cpp)
+target_link_libraries(hsm_consumer PRIVATE hsm_collector::hsm_collector_cpp)
+target_compile_features(hsm_consumer PRIVATE cxx_std_17)

--- a/src/native/collector/test_package/conanfile.py
+++ b/src/native/collector/test_package/conanfile.py
@@ -1,0 +1,29 @@
+import os
+
+from conan import ConanFile
+from conan.tools.cmake import CMake, cmake_layout
+from conan.tools.build import can_run
+
+
+class HsmCollectorTestConan(ConanFile):
+    """Clean-consumer proof for the hsm-collector Conan package (#1100): builds a tiny app purely
+    through find_package(hsm_collector) provided by Conan, and runs it."""
+
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+    test_type = "explicit"
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def layout(self):
+        cmake_layout(self)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            self.run(os.path.join(self.cpp.build.bindir, "hsm_consumer"), env="conanrun")

--- a/src/native/collector/test_package/src/consumer.cpp
+++ b/src/native/collector/test_package/src/consumer.cpp
@@ -1,0 +1,29 @@
+// Minimal consumer exercising the hsm-collector package purely through find_package(hsm_collector).
+// With the default (no-HTTP) build the core uses the in-memory recording sender, so this runs with
+// no server and is a clean-consumer smoke check.
+
+#include <hsm_collector/hsm_collector.hpp>
+
+#include <iostream>
+
+int main()
+{
+    namespace hc = hsm::collector;
+
+    hc::CollectorOptions options;
+    options.access_key = "package-test-key";
+    options.server_address = "https://localhost";
+    options.port = 443;
+    options.module = "conan-test";
+    options.package_collect_period_ms = 50;
+
+    hc::Collector collector(options);
+    auto sensor = collector.CreateIntSensor("TestPackage/Value");
+
+    collector.Start();
+    sensor.AddValue(42);
+    collector.Stop();
+
+    std::cout << "hsm-collector package consumed OK; sent=" << collector.SentCount() << '\n';
+    return 0;
+}

--- a/src/native/collector/vcpkg-port/copyright
+++ b/src/native/collector/vcpkg-port/copyright
@@ -1,0 +1,7 @@
+Native HSM DataCollector (hsm-collector).
+
+Source: https://github.com/SoftFx/Hierarchical-Sensor-Monitoring (src/native/collector)
+Copyright (c) SoftFx.
+
+The repository does not ship a standalone LICENSE file; refer to the upstream repository for the
+authoritative license terms.

--- a/src/native/collector/vcpkg-port/portfile.cmake
+++ b/src/native/collector/vcpkg-port/portfile.cmake
@@ -1,0 +1,32 @@
+# Overlay port for the native HSM collector (#1100). It builds the library from the adjacent
+# in-repo source tree (../), which lets CI verify the port against the current branch with
+# --overlay-ports. For an upstream/registry publication, replace the SOURCE_PATH assignment with a
+# vcpkg_from_github(REPO SoftFx/Hierarchical-Sensor-Monitoring REF <release-tag> SHA512 <hash>
+# HEAD_REF master) block — the rest of the recipe is unchanged.
+set(SOURCE_PATH "${CMAKE_CURRENT_LIST_DIR}/..")
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        http HSM_COLLECTOR_HTTP
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DHSM_COLLECTOR_BUILD_TESTS=OFF
+        -DHSM_COLLECTOR_BUILD_EXAMPLES=OFF
+        -DHSM_COLLECTOR_INSTALL=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+# The project installs its package config to lib/cmake/hsm_collector; relocate it to the
+# vcpkg-canonical share/hsm_collector and fix up the absolute paths.
+vcpkg_cmake_config_fixup(PACKAGE_NAME hsm_collector CONFIG_PATH lib/cmake/hsm_collector)
+
+# Header-only wrapper + static C core: no debug headers, and the static core has no DLLs/tools.
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+
+# The repository ships no LICENSE file; record provenance as the package copyright.
+vcpkg_install_copyright(FILE_LIST "${CMAKE_CURRENT_LIST_DIR}/copyright")

--- a/src/native/collector/vcpkg-port/vcpkg.json
+++ b/src/native/collector/vcpkg-port/vcpkg.json
@@ -1,0 +1,29 @@
+{
+  "name": "hsm-collector",
+  "version": "0.4.0",
+  "description": "Native C++ HSM DataCollector — stable C ABI core + header-only RAII C++ wrapper.",
+  "homepage": "https://github.com/SoftFx/Hierarchical-Sensor-Monitoring",
+  "supports": "!uwp",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "http": {
+      "description": "libcurl HTTP transport (Schannel on Windows, OpenSSL elsewhere)",
+      "dependencies": [
+        {
+          "name": "curl",
+          "default-features": false,
+          "features": ["ssl"]
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The packaging follow-up under #1100 — the deferred half of workstream 7, on top of the CMake `find_package` install rules merged in [#1147](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/pull/1147). **Closes #1100.**

## What's here
- **Conan recipe** (`src/native/collector/conanfile.py` + `test_package/`). `conan create` builds the package from source (tests/examples gated off); Conan owns the CMake integration — the project's own config is removed in `package()` and the components are re-declared as `hsm_collector::hsm_collector_core` / `::hsm_collector_cpp`. An optional `http` option pulls `libcurl`. The `test_package` is a clean consumer via `find_package(hsm_collector)`.
- **vcpkg overlay port** (`src/native/collector/vcpkg-port/`: `portfile.cmake` + manifest + copyright). Builds the library from the adjacent source (`SOURCE_PATH=../`), with an `http` feature for curl; `vcpkg_cmake_config_fixup` relocates the package config. For registry publication the `SOURCE_PATH` line is swapped for a `vcpkg_from_github` block at a release tag (documented in the portfile).
- **CMake** — new `HSM_COLLECTOR_BUILD_TESTS` option (defaults to `PROJECT_IS_TOP_LEVEL`) so package/consumer builds skip the test binary.
- **CI** — `conan-consume` and `vcpkg-consume` lanes (Windows + Linux): build the package from branch source and build+run a clean consumer against it.
- **Docs** — feature.md packaging section (the three consume paths + the NuGet-drop rationale) and the migration guide's build section.

## Decisions
- **vcpkg:** full overlay port in-repo (your call), verified end-to-end.
- **NuGet native assets:** dropped — no concrete mixed managed/native consumer; .NET consumers use the managed package, native consumers use CMake / Conan / vcpkg.

## Verification (local)
- `conan create src/native/collector` → builds + `test_package` runs (`sent=1`).
- `vcpkg install hsm-collector --overlay-ports=…` → consumer built via the vcpkg toolchain runs (`sent=1`).
- Top-level `cmake`/`ctest` still green with the new test gate.