### PR TITLE
Make ProductPolicyCollection.AddPolicy atomic on group creation

### DIFF
--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/PolicyGroup.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/PolicyGroup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Concurrent;
 
 namespace HSMServer.Core.Model.Policies
@@ -12,16 +12,16 @@ namespace HSMServer.Core.Model.Policies
 
         public bool IsEmpty => Policies.IsEmpty;
 
-        public string Template { get; private set; }
+        public string Template { get; }
 
 
-        public void AddPolicy(Policy policy)
+        public PolicyGroup(string template)
         {
-            if (IsEmpty)
-                Template = policy.ToString();
-
-            Policies.TryAdd(policy.Id, policy);
+            Template = template;
         }
+
+
+        public void AddPolicy(Policy policy) => Policies.TryAdd(policy.Id, policy);
 
         public void RemovePolicy(Guid id) => Policies.TryRemove(id, out _);
     }

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
@@ -9,10 +9,13 @@ namespace HSMServer.Core.Model.Policies
 {
     public sealed class ProductPolicyCollection : PolicyCollectionBase
     {
-        private readonly ConcurrentDictionary<string, Guid> _templateToGroup = new();
+        // _templateToGroup is the single source of truth; GetOrAdd ensures all callers
+        // converge on one group per template, so the old _groups lookup is unnecessary.
+        private readonly ConcurrentDictionary<string, PolicyGroup> _templateToGroup = new();
 
-        private readonly ConcurrentDictionary<Guid, PolicyGroup> _groups = new();
-        private readonly ConcurrentDictionary<Guid, Guid> _policyToGroup = new();
+        private readonly ConcurrentDictionary<Guid, PolicyGroup> _policyToGroup = new();
+
+        internal IReadOnlyDictionary<string, PolicyGroup> TemplateToGroup => _templateToGroup;
 
         // Bounded view of the owning product's Settings.TTL: same CurValue, no parent chain.
         // "From Parent" on a node-level TTL alert resolves against THIS node's own setting
@@ -33,21 +36,20 @@ namespace HSMServer.Core.Model.Policies
 
         public PolicyExportGroup SaveStateToExportGroup(PolicyExportGroup exportGroup, string relativePath, Predicate<Guid> filter)
         {
-            foreach (var (template, groupId) in _templateToGroup)
-                if (_groups.TryGetValue(groupId, out var group))
-                {
-                    var info = group.Policies.Where(u => filter(u.Value.Sensor.Id))
-                                             .Select(p => new PolicyExportInfo(p.Value, relativePath, exportGroup.CurrentProduct))
-                                             .ToList();
+            foreach (var (template, group) in _templateToGroup)
+            {
+                var info = group.Policies.Where(u => filter(u.Value.Sensor.Id))
+                                         .Select(p => new PolicyExportInfo(p.Value, relativePath, exportGroup.CurrentProduct))
+                                         .ToList();
 
-                    if (info.Count > 0)
-                    {
-                        if (exportGroup.TryGetValue(template, out var policies))
-                            policies.AddRange(info);
-                        else
-                            exportGroup.TryAdd(template, info);
-                    }
+                if (info.Count > 0)
+                {
+                    if (exportGroup.TryGetValue(template, out var policies))
+                        policies.AddRange(info);
+                    else
+                        exportGroup.TryAdd(template, info);
                 }
+            }
 
             return exportGroup;
         }
@@ -71,34 +73,20 @@ namespace HSMServer.Core.Model.Policies
 
         internal void AddPolicy(Policy policy)
         {
-            var template = policy.ToString();
-            var policyId = policy.Id;
+            var group = _templateToGroup.GetOrAdd(policy.ToString(), template => new PolicyGroup(template));
 
-            if (!_templateToGroup.TryGetValue(template, out var groudId))
-            {
-                var newGroup = new PolicyGroup();
-
-                groudId = newGroup.Id;
-
-                _templateToGroup.TryAdd(template, groudId);
-                _groups.TryAdd(groudId, newGroup);
-            }
-
-            if ((!_policyToGroup.ContainsKey(policyId) || _policyToGroup.TryRemove(policyId, out _)) && _policyToGroup.TryAdd(policyId, groudId))
-                _groups[groudId].AddPolicy(policy);
+            if (_policyToGroup.TryAdd(policy.Id, group))
+                group.AddPolicy(policy);
         }
 
         private void RemovePolicy(Guid policyId)
         {
-            if (_policyToGroup.TryRemove(policyId, out var groupId) && _groups.TryGetValue(groupId, out var group))
+            if (_policyToGroup.TryRemove(policyId, out var group))
             {
                 group.RemovePolicy(policyId);
 
                 if (group.IsEmpty)
-                {
                     _templateToGroup.TryRemove(group.Template, out _);
-                    _groups.Remove(groupId, out _);
-                }
             }
         }
 

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/ProductPolicyCollection.cs
@@ -15,7 +15,16 @@ namespace HSMServer.Core.Model.Policies
 
         private readonly ConcurrentDictionary<Guid, PolicyGroup> _policyToGroup = new();
 
+        // AddPolicy and RemovePolicy are serialized under _gate so the empty-group
+        // cleanup in RemovePolicy cannot race with a concurrent AddPolicy re-populating
+        // the same group (which would orphan the newly-added policy). Reads
+        // (SaveStateToExportGroup) stay lock-free — ConcurrentDictionary is safe for
+        // concurrent reads.
+        private readonly object _gate = new();
+
         internal IReadOnlyDictionary<string, PolicyGroup> TemplateToGroup => _templateToGroup;
+
+        internal IReadOnlyDictionary<Guid, PolicyGroup> PolicyToGroup => _policyToGroup;
 
         // Bounded view of the owning product's Settings.TTL: same CurValue, no parent chain.
         // "From Parent" on a node-level TTL alert resolves against THIS node's own setting
@@ -73,20 +82,31 @@ namespace HSMServer.Core.Model.Policies
 
         internal void AddPolicy(Policy policy)
         {
-            var group = _templateToGroup.GetOrAdd(policy.ToString(), template => new PolicyGroup(template));
+            lock (_gate)
+            {
+                // Pre-check under the lock so a duplicate policyId no-ops without
+                // creating an orphan empty group via GetOrAdd.
+                if (_policyToGroup.ContainsKey(policy.Id))
+                    return;
 
-            if (_policyToGroup.TryAdd(policy.Id, group))
+                var group = _templateToGroup.GetOrAdd(policy.ToString(), template => new PolicyGroup(template));
+
+                _policyToGroup[policy.Id] = group;
                 group.AddPolicy(policy);
+            }
         }
 
         private void RemovePolicy(Guid policyId)
         {
-            if (_policyToGroup.TryRemove(policyId, out var group))
+            lock (_gate)
             {
-                group.RemovePolicy(policyId);
+                if (_policyToGroup.TryRemove(policyId, out var group))
+                {
+                    group.RemovePolicy(policyId);
 
-                if (group.IsEmpty)
-                    _templateToGroup.TryRemove(group.Template, out _);
+                    if (group.IsEmpty)
+                        _templateToGroup.TryRemove(group.Template, out _);
+                }
             }
         }
 

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/ProductPolicyCollectionTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/ProductPolicyCollectionTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using HSMServer.Core.Cache;
+using HSMServer.Core.Cache.UpdateEntities;
+using HSMServer.Core.Model.Policies;
+using Xunit;
+
+namespace HSMServer.Core.Tests.TreeValuesCacheTests
+{
+    public class ProductPolicyCollectionTests
+    {
+        // === Concurrency: same-template AddPolicy must converge on one group ===
+
+        [Fact]
+        [Trait("Category", "Concurrency")]
+        public async Task AddPolicy_ConcurrentSameTemplate_ProducesSingleGroup()
+        {
+            const int threadCount = 10;
+            const int policiesPerThread = 100;
+            const int totalPolicies = threadCount * policiesPerThread;
+
+            var collection = new ProductPolicyCollection();
+
+            var policies = Enumerable.Range(0, totalPolicies)
+                .Select(_ => BuildPolicy(template: "shared-template"))
+                .ToList();
+
+            // Sanity: every policy must hash to the same _templateToGroup key.
+            var template = policies[0].ToString();
+            Assert.All(policies, p => Assert.Equal(template, p.ToString()));
+
+            using var barrier = new Barrier(threadCount);
+            var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (int i = 0; i < policiesPerThread; ++i)
+                    collection.AddPolicy(policies[t * policiesPerThread + i]);
+            })).ToArray();
+            await Task.WhenAll(tasks);
+
+            Assert.Single(collection.TemplateToGroup);
+
+            var group = collection.TemplateToGroup[template];
+            Assert.NotNull(group);
+            Assert.Equal(totalPolicies, group.Policies.Count);
+
+            var expectedIds = policies.Select(p => p.Id).ToHashSet();
+            Assert.Equal(expectedIds, group.Policies.Keys.ToHashSet());
+        }
+
+        [Fact]
+        [Trait("Category", "Concurrency")]
+        public async Task AddPolicy_ConcurrentDistinctTemplates_ProducesOneGroupPerTemplate()
+        {
+            const int threadCount = 8;
+            const int policiesPerThread = 25;
+
+            var collection = new ProductPolicyCollection();
+            var templates = Enumerable.Range(0, threadCount)
+                .Select(i => $"template-{i}")
+                .ToList();
+
+            // Pre-compute the deterministic ToString key per template so the
+            // assertion below uses the same key the collection will register.
+            var expectedKeys = templates.Select(t => BuildPolicy(t).ToString()).ToHashSet();
+
+            using var barrier = new Barrier(threadCount);
+            var tasks = Enumerable.Range(0, threadCount).Select(t => Task.Run(() =>
+            {
+                barrier.SignalAndWait();
+                for (int i = 0; i < policiesPerThread; ++i)
+                    collection.AddPolicy(BuildPolicy(templates[t]));
+            })).ToArray();
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(threadCount, collection.TemplateToGroup.Count);
+            foreach (var key in expectedKeys)
+            {
+                Assert.True(collection.TemplateToGroup.ContainsKey(key));
+                Assert.Equal(policiesPerThread, collection.TemplateToGroup[key].Policies.Count);
+            }
+        }
+
+
+        // === Regression: AddPolicy / RemovePolicy round-trip ===
+
+        [Fact]
+        public void AddPolicy_SinglePolicy_RegistersGroupAndPolicy()
+        {
+            var collection = new ProductPolicyCollection();
+            var policy = BuildPolicy("solo-template");
+
+            collection.AddPolicy(policy);
+
+            var (_, group) = Assert.Single(collection.TemplateToGroup);
+            Assert.Single(group.Policies);
+            Assert.Equal(policy.Id, group.Policies.First().Key);
+        }
+
+        [Fact]
+        public void AddPolicy_DuplicatePolicyId_DoesNotDoubleAdd()
+        {
+            var collection = new ProductPolicyCollection();
+            var policy = BuildPolicy("dupe-template");
+
+            collection.AddPolicy(policy);
+            collection.AddPolicy(policy);
+
+            var (_, group) = Assert.Single(collection.TemplateToGroup);
+            Assert.Single(group.Policies);
+        }
+
+        [Fact]
+        public void ReceivePolicyUpdate_Delete_RemovesPolicyAndClearsEmptyGroup()
+        {
+            var collection = new ProductPolicyCollection();
+            var policy = BuildPolicy("removable-template");
+
+            collection.ReceivePolicyUpdate(ActionType.Add, policy);
+            Assert.Single(collection.TemplateToGroup);
+
+            collection.ReceivePolicyUpdate(ActionType.Delete, policy);
+            Assert.Empty(collection.TemplateToGroup);
+        }
+
+        [Fact]
+        public void ReceivePolicyUpdate_Update_ReplacesPolicyInPlace()
+        {
+            var collection = new ProductPolicyCollection();
+            var policy = BuildPolicy("updatable-template");
+
+            collection.ReceivePolicyUpdate(ActionType.Add, policy);
+            Assert.Single(collection.TemplateToGroup);
+            Assert.Single(collection.TemplateToGroup[policy.ToString()].Policies);
+
+            // Update is implemented as Remove + Add; the empty group is cleared
+            // by Remove, then Add recreates it. Net result: one group, one policy.
+            collection.ReceivePolicyUpdate(ActionType.Update, policy);
+
+            Assert.Single(collection.TemplateToGroup);
+            var (_, currentGroup) = Assert.Single(collection.TemplateToGroup);
+            Assert.Single(currentGroup.Policies);
+            Assert.Equal(policy.Id, currentGroup.Policies.First().Key);
+        }
+
+
+        // === Helpers ===
+
+        private static Policy BuildPolicy(string template)
+        {
+            var policy = new IntegerPolicy();
+            var update = new PolicyUpdate
+            {
+                Id = Guid.NewGuid(),
+                Template = template,
+                Destination = new PolicyDestinationUpdate(),
+                Conditions =
+                [
+                    new PolicyConditionUpdate(
+                        PolicyOperation.Equal,
+                        PolicyProperty.Value,
+                        new TargetValue(TargetType.Const, "1")),
+                ],
+            };
+            policy.TryUpdate(update, out _, null);
+            return policy;
+        }
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/ProductPolicyCollectionTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/ProductPolicyCollectionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -82,6 +83,86 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                 Assert.True(collection.TemplateToGroup.ContainsKey(key));
                 Assert.Equal(policiesPerThread, collection.TemplateToGroup[key].Policies.Count);
             }
+        }
+
+        [Fact]
+        [Trait("Category", "Concurrency")]
+        public async Task AddRemove_InterleavedOnSameTemplate_NoOrphansOrLeaks()
+        {
+            // Regression coverage for the reviewer-flagged race on #1155: without
+            // the _gate lock, RemovePolicy's empty-group cleanup can evict a group
+            // that a concurrent AddPolicy just re-populated, orphaning that policy
+            // from _templateToGroup. The race window is narrow (a few instructions
+            // between the IsEmpty check and the TryRemove), so this test is mostly
+            // a probabilistic catcher + a check that the documented invariants hold
+            // under heavy churn. The lock itself is correct by construction.
+            //
+            // Cycler threads run tight add/add/remove/remove cycles on the shared
+            // template. Adder threads concurrently append policies that are never
+            // removed, so any orphan that does occur survives to the assertions.
+            const int cyclerThreads = 8;
+            const int adderThreads = 8;
+            const int cyclesPerCycler = 500;
+            const int addsPerAdder = 500;
+            const int expectedLivePolicies = adderThreads * addsPerAdder;
+
+            var collection = new ProductPolicyCollection();
+
+            using var barrier = new Barrier(cyclerThreads + adderThreads);
+            var tasks = new List<Task>();
+
+            for (int t = 0; t < cyclerThreads; ++t)
+            {
+                tasks.Add(Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < cyclesPerCycler; ++i)
+                    {
+                        var p1 = BuildPolicy("shared-template");
+                        var p2 = BuildPolicy("shared-template");
+
+                        collection.AddPolicy(p1);
+                        collection.AddPolicy(p2);
+                        collection.ReceivePolicyUpdate(ActionType.Delete, p1);
+                        collection.ReceivePolicyUpdate(ActionType.Delete, p2);
+                    }
+                }));
+            }
+
+            for (int t = 0; t < adderThreads; ++t)
+            {
+                tasks.Add(Task.Run(() =>
+                {
+                    barrier.SignalAndWait();
+                    for (int i = 0; i < addsPerAdder; ++i)
+                        collection.AddPolicy(BuildPolicy("shared-template"));
+                }));
+            }
+
+            await Task.WhenAll(tasks);
+
+            // Invariant 1: every entry in _policyToGroup points to a group still
+            // reachable via _templateToGroup, and the group still holds that policy.
+            // Without the lock, RemovePolicy's eviction can leave _policyToGroup
+            // pointing at an orphaned group that SaveStateToExportGroup cannot see.
+            var reachableGroups = collection.TemplateToGroup.Values.ToHashSet();
+            foreach (var (policyId, group) in collection.PolicyToGroup)
+            {
+                Assert.Contains(group, reachableGroups);
+                Assert.Contains(policyId, group.Policies.Keys);
+            }
+
+            // Invariant 2: the total policy count across groups matches _policyToGroup.
+            var totalInGroups = collection.TemplateToGroup.Values.Sum(g => g.Policies.Count);
+            Assert.Equal(collection.PolicyToGroup.Count, totalInGroups);
+
+            // Invariant 3: no empty groups leaked into _templateToGroup.
+            Assert.All(collection.TemplateToGroup.Values, g => Assert.False(g.IsEmpty));
+
+            // Invariant 4: every live (never-removed) policy survived the churn.
+            // A cascade from the race can orphan adder policies and then evict
+            // their replacements, dropping them from _policyToGroup entirely.
+            Assert.Equal(expectedLivePolicies, collection.PolicyToGroup.Count);
         }
 
 


### PR DESCRIPTION
## Summary

Fixes the three races in `ProductPolicyCollection.AddPolicy` listed in #1130, plus a fourth race flagged in review on #1155 (AddPolicy/RemovePolicy interleave orphaning a policy) and a latent empty-group leak in AddPolicy.

**Original three races (from the issue):**
- `_templateToGroup.TryGetValue + TryAdd` (check-then-add) → `GetOrAdd(template, t => new PolicyGroup(t))` — all callers converge on one canonical `PolicyGroup`.
- `_groups[groudId]` null-deref on losing `TryAdd` → gone (`_groups` is removed entirely).
- `(!ContainsKey || TryRemove) && TryAdd` non-atomic prelude → replaced by atomic ops under `_gate`.

**Fourth race (review feedback):**
- Without serialization, RemovePolicy's empty-group cleanup could evict a group that a concurrent AddPolicy had just re-populated, orphaning that policy from `_templateToGroup` (invisible to `SaveStateToExportGroup`). Closed by holding `_gate` across both AddPolicy and RemovePolicy bodies.

**Latent leak (review feedback):**
- If `GetOrAdd` created a fresh group but `_policyToGroup.TryAdd` then failed (duplicate policyId), the empty group stayed in `_templateToGroup` forever. Closed by a `ContainsKey` pre-check under the lock — safe because the lock makes check-then-add atomic.

**PolicyGroup** takes `template` via constructor (kills the `IsEmpty` check-then-set on `Template`); the `Id` field stays as-is per the issue's "Out of scope".

Reads (`SaveStateToExportGroup`) stay lock-free — `ConcurrentDictionary` is safe for concurrent reads. The lock only serializes mutations.

## Test plan

- [x] `ProductPolicyCollectionTests`: 7 tests covering concurrent same-template adds, concurrent distinct-template adds, interleaved add/remove on shared template (4 invariants), single add/remove round-trip, duplicate-id dedup, and `ReceivePolicyUpdate(Update)` round-trip.
- [x] Stress-run the concurrency tests 15× — stable.
- [x] Existing `SensorPolicyCollectionTests`, `TTLTemplateProtectionTests`, `NodeTTLFromParentResolutionTests`, `TemplateConcurrencyTests` — 38/38 pass.

Note on the interleaved test: the race window is narrow (a few instructions between `IsEmpty` check and `TryRemove`), so the test is mostly a probabilistic catcher plus a check that the documented invariants hold under heavy churn. The lock correctness is established by construction.

Closes #1130

🤖 Generated with [Claude Code](https://claude.com/claude-code)