### PR TITLE
Surface rename collision as TaskResult error

### DIFF
--- a/src/server/HSMServer.Core/Cache/ITreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/ITreeValuesCache.cs
@@ -44,7 +44,7 @@ namespace HSMServer.Core.Cache
         List<AccessKeyModel> GetAccessKeys();
 
         Task<ProductModel> AddProductAsync(string productName, Guid authorId, CancellationToken token = default);
-        Task UpdateProductAsync(ProductUpdate product, CancellationToken token = default);
+        Task<TaskResult> UpdateProductAsync(ProductUpdate product, CancellationToken token = default);
         Task RemoveProductAsync(Guid id, InitiatorInfo initiator = null, CancellationToken token = default);
         ProductModel GetProduct(Guid id);
         ProductModel GetProductByName(string name);

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -228,17 +228,17 @@ namespace HSMServer.Core.Cache
             return false;
         }
 
-        public async Task UpdateProductAsync(ProductUpdate request, CancellationToken token)
+        public async Task<TaskResult> UpdateProductAsync(ProductUpdate request, CancellationToken token)
         {
             var product = GetProduct(request.Id);
 
             if (product == null)
-                return;
+                return TaskResult.FromError(ErrorProductNotFound);
 
             if (!product.IsRoot)
                 product = product.Root;
 
-            await ProcessRequestAsync(product.Id, request, token);
+            return await ProcessRequestAsync(product.Id, request, token);
         }
 
 
@@ -255,10 +255,8 @@ namespace HSMServer.Core.Cache
                     if (_productsByName.TryAdd(update.Name, product))
                         _productsByName.TryRemove(oldName, out _);
                     else
-                    {
-                        _logger.Warn($"Cannot rename root product {product.Id} from '{oldName}' to '{update.Name}': target name already in use");
-                        update = update with { Name = null };
-                    }
+                        throw new InvalidOperationException(
+                            $"Cannot rename root product {product.Id} from '{oldName}' to '{update.Name}': target name already in use");
                 }
             }
 

--- a/src/server/HSMServer/Controllers/ProductController.cs
+++ b/src/server/HSMServer/Controllers/ProductController.cs
@@ -158,7 +158,12 @@ namespace HSMServer.Controllers
         public async ValueTask<IActionResult> EditProduct(ProductGeneralInfoViewModel viewModel)
         {
             if (_treeViewModel.Nodes.TryGetValue(viewModel.Id, out var product) && ModelState.IsValid)
-                await _treeValuesCache.UpdateProductAsync(viewModel.ToUpdate(product, _telegramChatsManager, _folderManager, CurrentInitiator));
+            {
+                var result = await _treeValuesCache.UpdateProductAsync(viewModel.ToUpdate(product, _telegramChatsManager, _folderManager, CurrentInitiator));
+
+                if (!result.IsOk)
+                    ModelState.AddModelError(nameof(ProductGeneralInfoViewModel.Name), result.Error);
+            }
             else
                 viewModel.DefaultChats = new(product);
 

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -224,6 +224,26 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
         [Fact]
+        [Trait("Category", "Update product(s)")]
+        public async Task RenameToTakenNameReturnsErrorTest()
+        {
+            var keeper = await _valuesCache.AddProductAsync($"keeper_{Guid.NewGuid():N}", Guid.Empty);
+            var challenger = await _valuesCache.AddProductAsync($"challenger_{Guid.NewGuid():N}", Guid.Empty);
+            var challengerOriginalName = challenger.DisplayName;
+
+            var result = await _valuesCache.UpdateProductAsync(
+                new ProductUpdate { Id = challenger.Id, Name = keeper.DisplayName }, default);
+
+            Assert.False(result.IsOk);
+            Assert.Contains("already in use", result.Error);
+
+            // The challenger must keep its original name and remain reachable.
+            var current = _valuesCache.GetProduct(challenger.Id);
+            Assert.Equal(challengerOriginalName, current.DisplayName);
+            Assert.Same(current, _valuesCache.GetProductByName(current.DisplayName));
+        }
+
+        [Fact]
         [Trait("Category", "Remove product(s)")]
         public async Task RemoveProductTest()
         {


### PR DESCRIPTION
## Summary

`UpdateProductAsync` was discarding the queue's `TaskResult`, so a rename rejected because the target name was already held by another root silently no-op'd while the caller saw success. This makes the collision observable:

- `UpdateProduct(ProductUpdate)` now throws `InvalidOperationException` inside `_productsByNameLock` (replacing the silent `update = update with { Name = null }`). The queue's `ProcessQueueAsync` already converts thrown exceptions to `TaskResult.FromError`.
- `UpdateProductAsync` returns `Task<TaskResult>` (matching `AddOrUpdateSensorAsync`, `UpdateSensorAsync`, `UpdateSensorValueAsync`).
- `ProductController.EditProduct` adds `ModelState.AddModelError("Name", ...)` on failure; the existing `<span asp-validation-for="Name">` renders it with no JS change.

Note: the rejected update now fails atomically — previously other fields bundled with the colliding `Name` would silently persist while the rename was dropped.

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.sln` — passes, 0 errors.
- [x] New `RenameToTakenNameReturnsErrorTest` passes (asserts `result.IsOk == false`, error text contains "already in use", challenger's `DisplayName` unchanged).
- [x] Existing `ConcurrentProductRenameTest`, `ConcurrentProductRenameToSameNameTest` still pass (state invariants hold; signature change is source-compatible for `await`-without-assignment callers).
- [ ] Manual smoke test: rename a root to a taken name via the EditProduct form; the form should re-render with a validation error under the Name field.

Closes #1152

🤖 Generated with [Claude Code](https://claude.com/claude-code)