### PR TITLE
Reject duplicate DisplayName on AddProductAsync

### DIFF
--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -196,12 +196,57 @@ namespace HSMServer.Core.Cache
         {
             var request = new AddProductRequest(productName, authorId);
 
+            // Reserve the DisplayName atomically before touching _cache or
+            // _tree. If two concurrent adds race on the same name, exactly
+            // one wins; the other throws here, before any state mutation, so
+            // no second root can land in _tree but go missing from
+            // _productsByName (and thus from GetProducts()/GetProductByName()
+            // until a restart rebuilds the index). Mirrors the rename
+            // collision handling in UpdateProduct(ProductUpdate). Done here
+            // rather than in AddProduct(ProductModel) because ProcessRequestAsync
+            // swallows exceptions from the queue worker into TaskResult, which
+            // AddProductAsync surfaces via the IsOk check below.
+            //
+            // Both failure modes throw InvalidOperationException for
+            // consistency. AddProductAsync's signature returns ProductModel
+            // (not TaskResult like UpdateProductAsync), so it cannot report a
+            // graceful TaskResult error; callers like
+            // ProductController.CreateProduct rely on the [UniqueValidation]
+            // model-state check for the common duplicate case, and this
+            // throw only fires in the TOCTOU race window.
+            lock (_productsByNameLock)
+            {
+                if (!_productsByName.TryAdd(request.ProductModel.DisplayName, request.ProductModel))
+                    throw new InvalidOperationException(
+                        $"Cannot add root product '{productName}': name already in use by another root product");
+            }
+
             if (!_cache.TryAdd(request.ProductModel.Id, new CachedValue(request.ProductModel, this)))
-                throw new Exception($"Product {productName} already exists");
+            {
+                // ID collision (shouldn't happen with fresh GUIDs, but be
+                // safe). Roll back the name reservation so a future add with
+                // this name can succeed.
+                lock (_productsByNameLock)
+                    _productsByName.TryRemove(request.ProductModel.DisplayName, out _);
+                throw new InvalidOperationException($"Cannot add root product '{productName}': id already in use");
+            }
 
-            await ProcessRequestAsync(request.ProductModel.Id, request, token);
+            var result = await ProcessRequestAsync(request.ProductModel.Id, request, token);
+            if (!result.IsOk)
+            {
+                // The queue worker failed (DB write error, cancellation,
+                // etc.) before the product entered _tree. Roll back both the
+                // _cache entry and the name reservation — otherwise the name
+                // stays permanently reserved for an unreachable product,
+                // which is the inverse of the orphan this method prevents.
+                _cache.TryRemove(request.ProductModel.Id, out _);
+                lock (_productsByNameLock)
+                    _productsByName.TryRemove(request.ProductModel.DisplayName, out _);
+                throw new InvalidOperationException(
+                    $"Cannot add root product '{productName}': {result.Error}");
+            }
+
             return request.ProductModel;
-
         }
 
         private void UpdateProduct(ProductModel product)

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -94,7 +94,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             for (int i = 0; i < count; ++i)
             {
-                var productName = RandomGenerator.GetRandomString();
+                // GUID-based names: the cache now rejects duplicate DisplayNames
+                // (see AddProductWithDuplicateNameThrowsTest), and the DB persists
+                // between test runs, so RandomGenerator.GetRandomString() — which
+                // uses a fixed seed — would collide with products from prior runs.
+                var productName = $"prod_{Guid.NewGuid():N}";
                 productNames.Add(productName);
 
                 addedProducts.Add(await _valuesCache.AddProductAsync(productName, Guid.Empty));
@@ -131,7 +135,7 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             var addedProducts = new List<Guid>(count);
             for (int i = 0; i < count; ++i)
-                addedProducts.Add((await _valuesCache.AddProductAsync(RandomGenerator.GetRandomString(), Guid.Empty)).Id);
+                addedProducts.Add((await _valuesCache.AddProductAsync($"prod_{Guid.NewGuid():N}", Guid.Empty)).Id);
 
             //await Task.Delay(100);
 
@@ -224,6 +228,28 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
         [Fact]
+        [Trait("Category", "Add product(s)")]
+        public async Task AddProductWithDuplicateNameThrowsTest()
+        {
+            var sharedName = $"dup_{Guid.NewGuid():N}";
+
+            var first = await _valuesCache.AddProductAsync(sharedName, Guid.Empty);
+
+            // Second add with the same DisplayName must throw — without this
+            // guard the second root would land in _tree but never in
+            // _productsByName, becoming unreachable until a restart.
+            await Assert.ThrowsAsync<InvalidOperationException>(() =>
+                _valuesCache.AddProductAsync(sharedName, Guid.Empty));
+
+            // The first root must still be reachable under the shared name.
+            Assert.Same(first, _valuesCache.GetProductByName(sharedName));
+
+            // The rejected add must not have leaked into the tree: the root
+            // count is exactly one for this name.
+            Assert.Equal(1, _valuesCache.GetProducts().Count(p => p.DisplayName == sharedName));
+        }
+
+        [Fact]
         [Trait("Category", "Update product(s)")]
         public async Task RenameToTakenNameReturnsErrorTest()
         {
@@ -241,6 +267,43 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             var current = _valuesCache.GetProduct(challenger.Id);
             Assert.Equal(challengerOriginalName, current.DisplayName);
             Assert.Same(current, _valuesCache.GetProductByName(current.DisplayName));
+        }
+
+        [Fact]
+        [Trait("Category", "Concurrency")]
+        public async Task ConcurrentAddProductWithSameNameTest()
+        {
+            var initialRootCount = _valuesCache.GetProducts().Count;
+            var sharedName = $"race_{Guid.NewGuid():N}";
+
+            // Two threads add a root with the same DisplayName. Exactly one
+            // must win; the loser must throw and leave no unreachable orphan.
+            ProductModel winner = null;
+            InvalidOperationException loserError = null;
+
+            using var barrier = new Barrier(2);
+            var tasks = Enumerable.Range(0, 2).Select(_ => Task.Run(async () =>
+            {
+                barrier.SignalAndWait();
+                try
+                {
+                    var added = await _valuesCache.AddProductAsync(sharedName, Guid.Empty);
+                    Interlocked.CompareExchange(ref winner, added, null);
+                }
+                catch (InvalidOperationException ex)
+                {
+                    Interlocked.CompareExchange(ref loserError, ex, null);
+                }
+            })).ToArray();
+            await Task.WhenAll(tasks);
+
+            Assert.NotNull(winner);
+            Assert.NotNull(loserError);
+            Assert.Contains("already in use", loserError.Message);
+
+            // Exactly one root was added under the shared name.
+            Assert.Equal(initialRootCount + 1, _valuesCache.GetProducts().Count);
+            Assert.Same(winner, _valuesCache.GetProductByName(sharedName));
         }
 
         [Fact]


### PR DESCRIPTION
## Summary

`AddProductAsync` now reserves the root product's `DisplayName` in `_productsByName` under `_productsByNameLock` before touching `_cache` or `_tree`, and throws `InvalidOperationException` if the name is already taken by another root. Previously the second root landed in `_tree` but was silently dropped from `_productsByName`, making it unreachable via `GetProductByName`/`GetProducts` until a restart rebuilt the index.

Implementation differs slightly from the issue's hinted site (`AddProduct(ProductModel)`): the check has to live in `AddProductAsync` itself because `ProcessRequestAsync` swallows worker exceptions into `TaskResult`, which `AddProductAsync` never surfaces. Mirrors the rename collision handling from #1152.

## Test plan

- [x] `AddProductWithDuplicateNameThrowsTest` — second add with same name throws, first stays reachable, only one root exists in `_productsByName`.
- [x] `ConcurrentAddProductWithSameNameTest` — two threads race on same name; exactly one wins, loser throws, winner reachable.
- [x] Updated `AddProductsTest`/`RemoveProductsTest` to use GUID-based names — `RandomGenerator` uses a fixed seed and the DB persists across runs, so the previous names collided with prior-run products and silently relied on the masked duplicate.
- [ ] `TemplateApplicationTests` (3 tests) fail on this branch, but they also fail on master with the same DB state — pre-existing, unrelated.

Closes #1153

🤖 Generated with [Claude Code](https://claude.com/claude-code)