### PR TITLE
#1167: server-side per-product HSM Agent download (W6/W7)

### DIFF
--- a/aicontext/features/server/agent-download/feature.md
+++ b/aicontext/features/server/agent-download/feature.md
@@ -1,0 +1,60 @@
+# Feature: Per-product HSM Agent download (server side)
+
+> Owner: server | Last reviewed: 2026-06-23 | Canonical: yes
+> Scope: The admin-only server endpoint + UI that hand an operator a ready-to-run, per-product HSM Agent
+> bundle (epic #1167, W6/W7). The agent product itself (the C++ Windows service) is `agent/feature.md`.
+
+---
+
+## Description
+
+An admin opens a product's access-keys view and clicks **Download agent**; the server streams a zip
+containing the byte-identical signed `hsm-agent.exe` + a generated `config.json` (this server's address
++ the product's access key) + silent `install.cmd`/`uninstall.cmd`. The client runs `install.cmd` → the
+**C++ exe self-installs** as an auto-start Windows service and connects — zero configuration.
+
+**The server only generates + serves the zip.** It is NOT an installer: the client-side install is the
+pure-native exe's own `--install`. No .NET runtime, no C#/MSI installer is produced or required.
+
+## Invariants
+
+- **Signed-exe invariant.** The bundled `hsm-agent.exe` is served **byte-identical** to the published,
+  signed binary. Only `config.json` is generated per product — the PE is never patched (Authenticode).
+  Pinned by `AgentInstallerBundleTests.Zip_KeepsExeByteIdentical`.
+- **Admin-only.** `[AuthorizeIsAdmin]` on the endpoint; the UI button renders only for `User.IsAdmin`.
+- **The baked key is the product's access-key GUID.** The agent sends it in the `Key` header. Selection
+  prefers the product **DefaultKey** (full permissions, never expires), else any valid key with
+  send-data + add-node/add-sensor permissions.
+
+## Key components
+
+| Component | Location |
+|---|---|
+| Download endpoint `GET /api/agent/installer?productId=…` | `HSMServer/Controllers/AgentController.cs` |
+| Bundle builder (config.json + scripts + zip; pure/testable) | `HSMServer/Model/Agent/AgentInstallerBundle.cs` |
+| Server setting "Agent connection URL" | `HSMServer/ServerConfiguration/Sections/AgentConfig.cs` (+ `IServerConfig`/`ServerConfig`) |
+| Settings UI (Agent tab) | `Views/Configuration/_Agent.cshtml`, `Views/Configuration/Index.cshtml`, `AgentSettingsViewModel`, `ConfigurationController.SaveAgentSettings` |
+| Download button | `Views/AccessKeys/_ProductAccessKeys.cshtml` (admin-only) |
+| Exe drop-point | `HSMServer/wwwroot/agent/hsm-agent.exe` (published by CI, W8) |
+| Tests | `tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs` (5 cases) |
+
+## Connection URL resolution
+
+`AgentController.ResolveConnection()`: if the admin set `AgentConfig.ExternalConnectionUrl`, parse it
+into `address` (scheme://host) + `port` (explicit port, else the configured `Kestrel.SensorPort`).
+Behind Docker/NAT the server cannot infer its external address, so this setting exists; when blank it
+falls back to the request host + the Sensor port. The result is written into the bundle's
+`config.json` (`server.address` / `server.port`), which the agent maps onto `CollectorOptions`.
+
+## Behavior notes
+
+- If `wwwroot/agent/hsm-agent.exe` is absent (binary not yet published by CI), the endpoint returns
+  **503** with a clear message — config/script generation is still unit-tested independently.
+- The generated `config.json` matches the agent's config schema; only `server.address` + `server.accessKey`
+  are required, the rest defaults (`identity.computerName: "auto"`, all sensor groups on).
+
+## Out of scope (follow-up)
+
+- Publishing the signed exe into `wwwroot/agent/` from CI (W8).
+- A dedicated, separately-revocable per-download "agent key" (currently reuses the product DefaultKey).
+- End-to-end download→install→data CI lane (W9).

--- a/src/server/HSMServer/Controllers/AgentController.cs
+++ b/src/server/HSMServer/Controllers/AgentController.cs
@@ -1,0 +1,126 @@
+using HSMCommon.Constants;
+using HSMServer.Attributes;
+using HSMServer.Authentication;
+using HSMServer.Core.Cache;
+using HSMServer.Core.Model;
+using HSMServer.Model.Agent;
+using HSMServer.ServerConfiguration;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.IO;
+using System.Linq;
+
+namespace HSMServer.Controllers
+{
+    /// <summary>
+    /// Per-product HSM Agent download (epic #1167, W6/W7). The admin opens a product, clicks "Download
+    /// Windows agent", and gets a zip with the byte-identical signed exe + a generated config.json
+    /// (this server's address + the product's access key) + silent install scripts. The server ONLY
+    /// generates + serves the zip — it is not an installer; the client install is the C++ exe's own
+    /// <c>--install</c> (no .NET/MSI on the client).
+    /// </summary>
+    [Authorize]
+    [Route("api/[controller]")]
+    public class AgentController : BaseController
+    {
+        // The agent registers its default sensors at start and streams values, so its key needs both
+        // the add-node/add-sensor and send-data permissions. The product DefaultKey has all of these.
+        private const KeyPermissions AgentPermissions =
+            KeyPermissions.CanSendSensorData | KeyPermissions.CanAddNodes | KeyPermissions.CanAddSensors;
+
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetCurrentClassLogger();
+
+        private readonly ITreeValuesCache _cache;
+        private readonly IServerConfig _config;
+        private readonly IWebHostEnvironment _environment;
+
+
+        public AgentController(IUserManager userManager, ITreeValuesCache cache, IServerConfig config, IWebHostEnvironment environment)
+            : base(userManager)
+        {
+            _cache = cache;
+            _config = config;
+            _environment = environment;
+        }
+
+
+        [HttpGet("installer")]
+        [AuthorizeIsAdmin]
+        public IActionResult Installer(Guid productId)
+        {
+            if (!_cache.TryGetProduct(productId, out var product))
+                return NotFound("Product not found.");
+
+            var key = SelectAgentKey(product);
+            if (key is null)
+                return BadRequest("This product has no usable access key. Create one with send-data permission first.");
+
+            var exePath = Path.Combine(_environment.WebRootPath ?? string.Empty, "agent", AgentInstallerBundle.ExeName);
+            if (!System.IO.File.Exists(exePath))
+                return StatusCode(StatusCodes.Status503ServiceUnavailable,
+                    "The agent binary is not available on this server yet. Publish hsm-agent.exe to wwwroot/agent/ (CI packaging, W8).");
+
+            var (address, port) = ResolveConnection();
+            var options = new AgentBundleOptions(address, port, key.Id.ToString(), AllowUntrustedCertificate: false);
+            var zip = AgentInstallerBundle.BuildZip(System.IO.File.ReadAllBytes(exePath), options);
+
+            _logger.Info($"{CurrentUser?.Name} downloaded the HSM Agent bundle for product '{product.DisplayName}' ({productId}).");
+
+            return File(zip, "application/zip", $"hsm-agent-{Sanitize(product.DisplayName)}.zip");
+        }
+
+
+        private (string address, int port) ResolveConnection()
+        {
+            var external = _config.Agent.ExternalConnectionUrl;
+            if (!string.IsNullOrWhiteSpace(external))
+            {
+                var raw = external.Trim();
+                if (!raw.Contains("://"))
+                    raw = $"https://{raw}";
+
+                if (Uri.TryCreate(raw, UriKind.Absolute, out var uri))
+                {
+                    var port = uri.IsDefaultPort ? _config.Kestrel.SensorPort : uri.Port;
+                    return ($"{uri.Scheme}://{uri.Host}", port);
+                }
+            }
+
+            // No external URL configured: best-effort fallback to the request host + the Sensor port.
+            return ($"{Request.Scheme}://{Request.Host.Host}", _config.Kestrel.SensorPort);
+        }
+
+        private static AccessKeyModel SelectAgentKey(ProductModel product)
+        {
+            var keys = product.AccessKeys.Values;
+
+            // Prefer the product's DefaultKey (it carries full permissions and never expires).
+            foreach (var key in keys)
+                if (key.DisplayName == CommonConstants.DefaultAccessKey && key.IsValid(AgentPermissions, out _))
+                    return key;
+
+            // Otherwise any valid key with the permissions the agent needs.
+            var valid = keys.FirstOrDefault(k => k.IsValid(AgentPermissions, out _));
+            if (valid is not null)
+                return valid;
+
+            // Last resort: the DefaultKey regardless of state, else any key (the admin can fix it up).
+            return keys.FirstOrDefault(k => k.DisplayName == CommonConstants.DefaultAccessKey) ?? keys.FirstOrDefault();
+        }
+
+        private static string Sanitize(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+                return "product";
+
+            var sanitized = name.Trim();
+            foreach (var invalid in Path.GetInvalidFileNameChars())
+                sanitized = sanitized.Replace(invalid, '_');
+
+            return sanitized.Replace(' ', '_');
+        }
+    }
+}

--- a/src/server/HSMServer/Controllers/ConfigurationController.cs
+++ b/src/server/HSMServer/Controllers/ConfigurationController.cs
@@ -54,6 +54,24 @@ namespace HSMServer.Controllers
         }
 
         [HttpPost]
+        public IActionResult SaveAgentSettings(AgentSettingsViewModel settings)
+        {
+            if (ModelState.IsValid)
+            {
+                var newUrl = settings.ExternalConnectionUrl?.Trim() ?? string.Empty;
+                if (config.Agent.ExternalConnectionUrl != newUrl)
+                {
+                    _logger.Info($"SaveAgentSettings: {GetUserName()} changed Agent connection URL '{config.Agent.ExternalConnectionUrl}' -> '{newUrl}'");
+
+                    config.Agent.ExternalConnectionUrl = newUrl;
+                    config.ResaveSettings();
+                }
+            }
+
+            return PartialView("_Agent", settings);
+        }
+
+        [HttpPost]
         public IActionResult SaveBackupSettings(BackupSettingsViewModel settings)
         {
             if (ModelState.IsValid)

--- a/src/server/HSMServer/Model/Agent/AgentInstallerBundle.cs
+++ b/src/server/HSMServer/Model/Agent/AgentInstallerBundle.cs
@@ -1,0 +1,120 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+
+namespace HSMServer.Model.Agent
+{
+    /// <summary>
+    /// Parameters baked into one per-product agent bundle. <see cref="AccessKey"/> is the product's
+    /// access-key GUID (string) the agent sends in the <c>Key</c> header.
+    /// </summary>
+    public sealed record AgentBundleOptions(string ServerAddress, int Port, string AccessKey, bool AllowUntrustedCertificate);
+
+    /// <summary>
+    /// Builds the downloadable HSM Agent bundle (epic #1167, W7): a zip of the byte-identical signed
+    /// <c>hsm-agent.exe</c> + a generated <c>config.json</c> (server address + key) + silent
+    /// install/uninstall scripts. The exe is NEVER modified — all per-product data lives in
+    /// <c>config.json</c> (Authenticode invariant). Install is 100% native C++ (the exe self-installs);
+    /// no .NET/MSI on the client. Pure + side-effect-free so it is unit-tested without a web host.
+    /// </summary>
+    public static class AgentInstallerBundle
+    {
+        public const string ExeName = "hsm-agent.exe";
+        public const string ConfigName = "config.json";
+        public const string InstallScript = "install.cmd";
+        public const string UninstallScript = "uninstall.cmd";
+
+        private static readonly JsonSerializerOptions _jsonOptions = new() { WriteIndented = true };
+
+        /// <summary>The generated config.json — matches the agent's config schema (only address + key required).</summary>
+        public static string BuildConfigJson(AgentBundleOptions options)
+        {
+            var config = new
+            {
+                server = new
+                {
+                    address = options.ServerAddress,
+                    port = options.Port,
+                    accessKey = options.AccessKey,
+                    allowUntrustedCertificate = options.AllowUntrustedCertificate,
+                },
+                identity = new
+                {
+                    computerName = "auto",
+                },
+            };
+
+            return JsonSerializer.Serialize(config, _jsonOptions);
+        }
+
+        /// <summary>Self-elevating silent installer: copy exe + config, register the service, start it.</summary>
+        public static string BuildInstallScript()
+        {
+            return Join(
+                "@echo off",
+                "setlocal",
+                ":: Self-elevate if not already running as administrator.",
+                "net session >nul 2>&1",
+                "if %errorlevel% neq 0 (",
+                "  echo Requesting administrator privileges...",
+                "  powershell -NoProfile -Command \"Start-Process -FilePath '%~f0' -Verb RunAs\"",
+                "  exit /b",
+                ")",
+                "set \"INSTALL_DIR=%ProgramFiles%\\HSM Agent\"",
+                "set \"DATA_DIR=%ProgramData%\\HSM Agent\"",
+                "if not exist \"%INSTALL_DIR%\" mkdir \"%INSTALL_DIR%\"",
+                "if not exist \"%DATA_DIR%\" mkdir \"%DATA_DIR%\"",
+                "copy /Y \"%~dp0" + ExeName + "\" \"%INSTALL_DIR%\\" + ExeName + "\" >nul",
+                "copy /Y \"%~dp0" + ConfigName + "\" \"%DATA_DIR%\\" + ConfigName + "\" >nul",
+                "\"%INSTALL_DIR%\\" + ExeName + "\" --install",
+                "sc start HSMAgent",
+                "echo HSM Agent installed and started.",
+                "endlocal");
+        }
+
+        /// <summary>Self-elevating silent uninstaller: deregister the service, remove the installed exe.</summary>
+        public static string BuildUninstallScript()
+        {
+            return Join(
+                "@echo off",
+                "setlocal",
+                "net session >nul 2>&1",
+                "if %errorlevel% neq 0 (",
+                "  echo Requesting administrator privileges...",
+                "  powershell -NoProfile -Command \"Start-Process -FilePath '%~f0' -Verb RunAs\"",
+                "  exit /b",
+                ")",
+                "set \"INSTALL_DIR=%ProgramFiles%\\HSM Agent\"",
+                "if exist \"%INSTALL_DIR%\\" + ExeName + "\" \"%INSTALL_DIR%\\" + ExeName + "\" --uninstall",
+                "if exist \"%INSTALL_DIR%\\" + ExeName + "\" del /Q \"%INSTALL_DIR%\\" + ExeName + "\"",
+                "echo HSM Agent uninstalled.",
+                "endlocal");
+        }
+
+        /// <summary>Assemble the zip in memory: the unmodified exe + generated config + install scripts.</summary>
+        public static byte[] BuildZip(byte[] agentExe, AgentBundleOptions options)
+        {
+            using var memory = new MemoryStream();
+            using (var archive = new ZipArchive(memory, ZipArchiveMode.Create, leaveOpen: true))
+            {
+                AddEntry(archive, ExeName, agentExe);
+                AddEntry(archive, ConfigName, Encoding.UTF8.GetBytes(BuildConfigJson(options)));
+                AddEntry(archive, InstallScript, Encoding.ASCII.GetBytes(BuildInstallScript()));
+                AddEntry(archive, UninstallScript, Encoding.ASCII.GetBytes(BuildUninstallScript()));
+            }
+
+            return memory.ToArray();
+        }
+
+        private static void AddEntry(ZipArchive archive, string name, byte[] content)
+        {
+            var entry = archive.CreateEntry(name, CompressionLevel.Optimal);
+            using var stream = entry.Open();
+            stream.Write(content, 0, content.Length);
+        }
+
+        // Batch scripts want CRLF line endings.
+        private static string Join(params string[] lines) => string.Join("\r\n", lines) + "\r\n";
+    }
+}

--- a/src/server/HSMServer/Model/Configuration/AgentSettingsViewModel.cs
+++ b/src/server/HSMServer/Model/Configuration/AgentSettingsViewModel.cs
@@ -1,0 +1,18 @@
+using HSMServer.ServerConfiguration;
+using System.ComponentModel.DataAnnotations;
+
+namespace HSMServer.Model.Configuration
+{
+    public class AgentSettingsViewModel
+    {
+        [Display(Name = "Agent connection URL")]
+        public string ExternalConnectionUrl { get; set; }
+
+        public AgentSettingsViewModel() { }
+
+        public AgentSettingsViewModel(IServerConfig config)
+        {
+            ExternalConnectionUrl = config.Agent.ExternalConnectionUrl;
+        }
+    }
+}

--- a/src/server/HSMServer/Model/Configuration/ConfigurationViewModel.cs
+++ b/src/server/HSMServer/Model/Configuration/ConfigurationViewModel.cs
@@ -16,6 +16,8 @@ namespace HSMServer.Model.Configuration
 
         public MonitoringSettingsViewModel Monitoring { get; } = new(config);
 
+        public AgentSettingsViewModel Agent { get; } = new(config);
+
         public double TotalDbSize => Math.Round(database.TotalDbSize / (double)(1<<20), 2, MidpointRounding.AwayFromZero);
 
         public bool IsCompactRunning => database.IsCompactRunning;

--- a/src/server/HSMServer/ServerConfiguration/IServerConfig.cs
+++ b/src/server/HSMServer/ServerConfiguration/IServerConfig.cs
@@ -12,6 +12,8 @@
 
         ServerCertificateConfig ServerCertificate { get; }
 
+        AgentConfig Agent { get; }
+
 
         void ResaveSettings();
     }

--- a/src/server/HSMServer/ServerConfiguration/Sections/AgentConfig.cs
+++ b/src/server/HSMServer/ServerConfiguration/Sections/AgentConfig.cs
@@ -1,0 +1,12 @@
+namespace HSMServer.ServerConfiguration;
+
+/// <summary>
+/// Settings for the downloadable HSM Agent (epic #1167). The externally-reachable Sensor-API base URL
+/// is baked into each per-product agent bundle so the client connects with zero configuration. The
+/// server cannot infer this behind Docker/NAT, so an admin sets it; when blank, the download endpoint
+/// falls back to the request host + the configured Sensor port.
+/// </summary>
+public class AgentConfig
+{
+    public string ExternalConnectionUrl { get; set; } = string.Empty;
+}

--- a/src/server/HSMServer/ServerConfiguration/ServerConfig.cs
+++ b/src/server/HSMServer/ServerConfiguration/ServerConfig.cs
@@ -54,6 +54,8 @@ namespace HSMServer.ServerConfiguration
 
         public MonitoringOptions MonitoringOptions { get; }
 
+        public AgentConfig Agent { get; }
+
 
         static ServerConfig()
         {
@@ -86,6 +88,7 @@ namespace HSMServer.ServerConfiguration
             Telegram = Register<TelegramConfig>(nameof(Telegram));
             Kestrel = Register<KestrelConfig>(nameof(Kestrel));
             MonitoringOptions = Register<MonitoringOptions>(nameof(MonitoringOptions));
+            Agent = Register<AgentConfig>(nameof(Agent));
 
             ResaveSettings();
         }

--- a/src/server/HSMServer/Views/AccessKeys/_ProductAccessKeys.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/_ProductAccessKeys.cshtml
@@ -26,6 +26,10 @@
 
     <div class="container-fluid d-flex flex-row-reverse align-items-center flex-shrink-0 ">
         <div class="row flex-nowrap">
+            @if (user is not null && user.IsAdmin)
+            {
+                <button id="downloadAgentButton" class="btn btn-secondary mx-1" type="button" onclick="downloadAgentClick()" title="Download a ready-to-run Windows agent for this product (server address + key pre-configured)">Download agent</button>
+            }
             @if (Model.IsChangingAccessKeysAvailable(User as User))
             {
                 <button id="addButton" class="btn btn-secondary col-2 w-50 mx-1" type="button" onclick="addButtonClick()">Add</button>
@@ -42,6 +46,11 @@
         let newAccessKeyURL = "@Html.Raw(Url.Action(nameof(AccessKeysController.NewAccessKey), ViewConstants.AccessKeysController))";
 
         showNewAccessKeyModal(`${newAccessKeyURL}?selectedId=${productId}`, false);
+    }
+
+    function downloadAgentClick() {
+        // Attachment response → the browser downloads without navigating away from the modal.
+        window.location.href = '/api/Agent/installer?productId=@Model.Id';
     }
     
     $(document).ready(() => {

--- a/src/server/HSMServer/Views/Configuration/Index.cshtml
+++ b/src/server/HSMServer/Views/Configuration/Index.cshtml
@@ -30,6 +30,9 @@
             <li class="nav-item" role="presentation">
                 <button class="nav-link" id="database-tab" data-bs-toggle="tab" data-bs-target="#database" type="button" role="tab" aria-controls="database" aria-selected="false">Database</button>
             </li>
+            <li class="nav-item" role="presentation">
+                <button class="nav-link" id="agent-tab" data-bs-toggle="tab" data-bs-target="#agent" type="button" role="tab" aria-controls="agent" aria-selected="false">Agent</button>
+            </li>
         </ul>
         <div class="tab-content w-100">
             <div class="tab-pane fade show active" id="server" role="tabpanel" aria-labelledby="server-tab">
@@ -58,6 +61,12 @@
 
             <div class="tab-pane fade" id="database" role="tabpanel" aria-labelledby="database-tab">
                     @await Html.PartialAsync("_Database", Model)
+            </div>
+
+            <div class="tab-pane fade" id="agent" role="tabpanel" aria-labelledby="agent-tab">
+                <form id="agentSettings_form" method="post" asp-action="@nameof(ConfigurationController.SaveAgentSettings)">
+                    @await Html.PartialAsync("_Agent", Model.Agent)
+                </form>
             </div>
         </div>
     </div>
@@ -89,6 +98,7 @@
         obs["backupSettings_form"] = createFormObserver("backupSettings_form");
         obs["selfMonitoringSettings_form"] = createFormObserver("selfMonitoringSettings_form");
         obs["telegramSettings_form"] = createFormObserver("telegramSettings_form");
+        obs["agentSettings_form"] = createFormObserver("agentSettings_form");
     });
     
     function savingFormSubscribe(formId, successMessage) {

--- a/src/server/HSMServer/Views/Configuration/_Agent.cshtml
+++ b/src/server/HSMServer/Views/Configuration/_Agent.cshtml
@@ -1,0 +1,29 @@
+@using HSMServer.Model.Configuration
+
+@model AgentSettingsViewModel
+
+
+<div class="row mt-3">
+    <div class="col-3">
+        <label class="col-form-label" asp-for="ExternalConnectionUrl"></label>
+    </div>
+    <div class="col">
+        <input class="form-control" asp-for="ExternalConnectionUrl" placeholder="https://hsm.company.com:44330">
+    </div>
+</div>
+<div class="row">
+    <div class="offset-3 col-9">
+        <label class="note">The externally-reachable Sensor-API URL baked into downloaded agent bundles so a client connects with zero configuration. Behind Docker/NAT the server cannot infer this. When blank, the download falls back to the request host and the configured Sensors API port.</label>
+    </div>
+</div>
+
+<div class="d-flex justify-content-end mt-2">
+    <button type="submit" class="btn btn-primary independentSizeButton mt-1">Save</button>
+</div>
+
+
+<script>
+    $(document).ready(function () {
+        savingFormSubscribe("agentSettings_form", "Agent settings have been successfully saved!");
+    });
+</script>

--- a/src/server/HSMServer/wwwroot/agent/README.md
+++ b/src/server/HSMServer/wwwroot/agent/README.md
@@ -1,0 +1,12 @@
+# Agent binary drop-point
+
+The per-product download endpoint (`GET /api/agent/installer?productId=…`, epic #1167 W6/W7) serves a
+zip containing the prebuilt **`hsm-agent.exe`** from this directory, plus a generated `config.json` and
+install scripts.
+
+Publish the signed release `hsm-agent.exe` here as `wwwroot/agent/hsm-agent.exe`. CI packaging wires this
+up (W8). Until the binary is present the endpoint returns HTTP 503 with a clear message — the rest of the
+download flow (config + scripts) is exercised by unit tests.
+
+The exe is served **byte-identical** to the published, signed binary; only `config.json` is generated
+per product (Authenticode invariant).

--- a/src/tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs
+++ b/src/tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs
@@ -1,0 +1,93 @@
+using HSMServer.Model.Agent;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace HSMServer.Core.Tests
+{
+    public class AgentInstallerBundleTests
+    {
+        private static readonly AgentBundleOptions _options =
+            new("https://hsm.example.com", 44330, "11111111-2222-3333-4444-555555555555", AllowUntrustedCertificate: false);
+
+        [Fact]
+        public void ConfigJson_CarriesServerAddressPortAndKey()
+        {
+            var json = AgentInstallerBundle.BuildConfigJson(_options);
+
+            using var doc = JsonDocument.Parse(json);
+            var server = doc.RootElement.GetProperty("server");
+
+            Assert.Equal("https://hsm.example.com", server.GetProperty("address").GetString());
+            Assert.Equal(44330, server.GetProperty("port").GetInt32());
+            Assert.Equal(_options.AccessKey, server.GetProperty("accessKey").GetString());
+            Assert.False(server.GetProperty("allowUntrustedCertificate").GetBoolean());
+            Assert.Equal("auto", doc.RootElement.GetProperty("identity").GetProperty("computerName").GetString());
+        }
+
+        [Fact]
+        public void Zip_ContainsExeConfigAndScripts()
+        {
+            var exeBytes = Encoding.ASCII.GetBytes("MZ-fake-signed-agent-binary");
+
+            var zipBytes = AgentInstallerBundle.BuildZip(exeBytes, _options);
+
+            using var memory = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(memory, ZipArchiveMode.Read);
+
+            var names = archive.Entries.Select(e => e.FullName).ToList();
+            Assert.Contains(AgentInstallerBundle.ExeName, names);
+            Assert.Contains(AgentInstallerBundle.ConfigName, names);
+            Assert.Contains(AgentInstallerBundle.InstallScript, names);
+            Assert.Contains(AgentInstallerBundle.UninstallScript, names);
+        }
+
+        [Fact]
+        public void Zip_KeepsExeByteIdentical()
+        {
+            var exeBytes = Encoding.ASCII.GetBytes("MZ-fake-signed-agent-binary-\0\x01\x02");
+
+            var zipBytes = AgentInstallerBundle.BuildZip(exeBytes, _options);
+
+            using var memory = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(memory, ZipArchiveMode.Read);
+
+            using var entryStream = archive.GetEntry(AgentInstallerBundle.ExeName).Open();
+            using var copy = new MemoryStream();
+            entryStream.CopyTo(copy);
+
+            Assert.Equal(exeBytes, copy.ToArray());
+        }
+
+        [Fact]
+        public void Zip_ConfigEntryCarriesAddressAndKey()
+        {
+            var zipBytes = AgentInstallerBundle.BuildZip(new byte[] { 0x4D, 0x5A }, _options);
+
+            using var memory = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(memory, ZipArchiveMode.Read);
+            using var reader = new StreamReader(archive.GetEntry(AgentInstallerBundle.ConfigName).Open());
+
+            var json = reader.ReadToEnd();
+            Assert.Contains(_options.AccessKey, json);
+            Assert.Contains("https://hsm.example.com", json);
+        }
+
+        [Fact]
+        public void InstallScript_RegistersAndStartsTheService()
+        {
+            var zipBytes = AgentInstallerBundle.BuildZip(new byte[] { 0x4D, 0x5A }, _options);
+
+            using var memory = new MemoryStream(zipBytes);
+            using var archive = new ZipArchive(memory, ZipArchiveMode.Read);
+            using var reader = new StreamReader(archive.GetEntry(AgentInstallerBundle.InstallScript).Open());
+
+            var script = reader.ReadToEnd();
+            Assert.Contains("--install", script);
+            Assert.Contains("HSMAgent", script);
+        }
+    }
+}


### PR DESCRIPTION
## What

Epic #1167, **W6/W7** — the zero-config delivery half. An admin opens a product's access-keys view, clicks **Download agent**, and the server streams a zip with the **byte-identical signed `hsm-agent.exe`** + a generated `config.json` (this server's address + the product's access key) + silent `install.cmd`/`uninstall.cmd`. The client runs `install.cmd`; the **C++ exe self-installs** as an auto-start Windows service and connects — zero client configuration.

> Pure-native install: the server **only generates + serves the zip** — it is not an installer. The client-side install is the exe's own `--install`. No .NET runtime, no C#/MSI installer on the client (per the epic's direction). The exe is served byte-identical to the signed binary; only `config.json` is generated per product (Authenticode invariant).

Independent of the agent C++ PR (#1168) — this is pure C# in `src/server`; the two merge in any order.

## Changes

- **W6 setting — `AgentConfig.ExternalConnectionUrl`** (`ServerConfiguration/Sections/AgentConfig.cs`, registered via `ServerConfig.Register<T>`), with an admin **Agent** settings tab (`Views/Configuration/_Agent.cshtml` + `AgentSettingsViewModel` + `ConfigurationController.SaveAgentSettings`). Behind Docker/NAT the server can't infer its external address; when blank, the download falls back to the request host + the configured Sensor port.
- **W6/W7 endpoint — `GET /api/agent/installer?productId=…`** (`Controllers/AgentController.cs`, `[AuthorizeIsAdmin]`): resolves the product → its **DefaultKey** (full perms, never expires; else any valid send-data/add-sensor key) → `AgentInstallerBundle` builds `config.json` + `install.cmd`/`uninstall.cmd` and zips them with the exe from `wwwroot/agent/`. Returns **503** with a clear message if the exe asset isn't published yet (W8).
- **W6 UI** — admin-only **Download agent** button on the product access-keys view (`Views/AccessKeys/_ProductAccessKeys.cshtml`).
- **Bundle builder** — `Model/Agent/AgentInstallerBundle.cs`: pure, side-effect-free (config.json + scripts + zip), unit-tested without a web host.

The baked access key is the product's access-key **GUID** (the `Key` header value the agent authenticates with). The generated `config.json` matches the agent's config schema (only `server.address` + `server.accessKey` required; the rest defaults).

## Tests / verification

- `tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs` (5 cases): config carries address/port/key; zip contains exe+config+install+uninstall; **exe byte-identical** (signed-exe invariant); config entry carries address+key; `install.cmd` registers + starts the service.
- ✅ `dotnet build HSMServer` clean (0 errors; Razor views compile on build). ✅ 5/5 bundle tests pass.

## Out of scope (follow-up)

- **W8** — publish the signed `hsm-agent.exe` into `wwwroot/agent/` from CI (until then the endpoint 503s; the rest is tested).
- A dedicated, separately-revocable per-download "agent key" (currently reuses the product DefaultKey).
- **W9** — full download→install→data E2E CI lane.

## Docs

`aicontext/features/server/agent-download/feature.md`.

Part of #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)