### PR TITLE
Release HSMServer 3.40.33

### DIFF
--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,14 +1,25 @@
 # HSM Server
 
-## Server start up
+## Alerts
 
-* Now edit last value of sensor is included into snapshot
+* Inactivity Period is now a condition property inside the regular alert editor. The dedicated TTL section and "Add Inactivity Period" link are removed; every new alert defaults to Inactivity Period and the user can switch back to a regular property.
+* Per-node (Folder/Product) alert editor removed. Templates are the only supported path for non-leaf alerting.
+* TTL labels renamed to "Inactivity Period" across the UI.
+* Atomic AddPolicy / RemovePolicy serialized under the per-product lock — fixes a race on alert group creation.
+* TTL orphan-cleanup now gated on the batch initiator only, so mixed-initiator operations no longer drop TTL policies.
+* Alert template is preserved on partial DB failure during removal.
+* Template mutations are dispatched to each sensor's own queue.
+* Node-level TTL From-Parent is now bounded to the node's own Settings.TTL.
 
-## HSM Plots
+## Products
 
-* Label 'Restart' now is set ot 45 angle
+* Duplicate DisplayName rejected on AddProductAsync.
+* Rename collision surfaced as a TaskResult error; products are no longer orphaned when a rename target name is taken.
 
+## Sensors
 
-## Notifications
+* DB errors during AddSensor are surfaced and partial state is rolled back; a ChangeSensorEvent(Delete) is fired during rollback so the tree stays consistent.
 
-* Added deletion sync for group telegram chats
+## History API
+
+* History API now returns TimeSpan / Version values directly instead of stringly-typed payloads.

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.40.32</Version>
+    <Version>3.40.33</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Bumps `3.40.32` → `3.40.33` and regenerates `ReleaseNote.md` with server-side user-facing changes since `server-v3.40.31`.

## Highlights

- **Alerts**: Inactivity Period merged into the regular alert editor; per-node editor removed; atomic policy operations; TTL preservation fixes.
- **Products**: Duplicate DisplayName guard; rename collision surfaced as error.
- **Sensors**: AddSensor DB error rollback.
- **History API**: TimeSpan / Version return types.

After merge, `/release-server` will trigger `server-build.yml` with `isPreRelease=false` (Final release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)