### PR TITLE
Fix FileManager async-void crash on test cleanup

### DIFF
--- a/src/server/HSMCommon/FileManager.cs
+++ b/src/server/HSMCommon/FileManager.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Text;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace HSMCommon
 {
@@ -44,7 +44,13 @@ namespace HSMCommon
             DoActionWhileThereAreAttempts(RemoveFolder);
         }
 
-        private static async void DoActionWhileThereAreAttempts(Action action)
+        // Sync retry loop. Callers (test-fixture Dispose, static ctor) are synchronous and
+        // fire-and-forget — they cannot await. The previous `async void` form routed the
+        // terminal IOException through Task.ThrowAsync into the ThreadPool, which surfaces
+        // as an unhandled exception and crashes the test-host process even when every test
+        // has passed. Blocking the calling thread on Thread.Sleep is acceptable here: the
+        // callers run at fixture disposal / startup, off any hot path.
+        private static void DoActionWhileThereAreAttempts(Action action)
         {
             int attempts = 0;
 
@@ -60,7 +66,7 @@ namespace HSMCommon
                     if (++attempts == MaxAttemptsCount)
                         throw;
 
-                    await Task.Delay(WaitTime);
+                    Thread.Sleep(WaitTime);
                 }
             }
         }


### PR DESCRIPTION
## Summary

`FileManager.DoActionWhileThereAreAttempts` was declared `async void`, so when retries exhausted the terminal `IOException` was routed through `Task.ThrowAsync` into the ThreadPool and surfaced as an unhandled exception — crashing the test-host process even when every test had passed.

The 3.40.33 release workflow failed exactly this way:
- `HSMServer.Core.Tests`: 388/388 passed
- Test host aborted on `FileManager.SafeRemoveFolder` of a LevelDB WAL file (`000003.log`) still held by LightningDB disposal
- `dotnet test` exit code 1 → build job failed → no release

Callers (`DatabaseFixture` ctor, `DatabaseRegisterFixture.Dispose`, `ServerConfig` static ctor) are all synchronous fire-and-forget — none of them can `await`. Switching to a synchronous loop with `Thread.Sleep` preserves their contract and routes the exception through the normal caller stack instead of the thread pool.

## Why blocking Thread.Sleep is fine

Callers run at fixture disposal / server startup — off any hot path. Blocking the calling thread for up to 25 s (5 × 5 s) is acceptable; the previous `async void` was never actually giving them concurrency anyway since they didn't await.

## Test plan

- [ ] CI: `HSMServer.Core.Tests` passes without test-host abort on the LevelDB cleanup path
- [ ] Re-run `server-build.yml` workflow_dispatch on master after merge → release 3.40.33 completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)