### PR TITLE
Deterministic template dispatch order

### DIFF
--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -2455,7 +2455,13 @@ namespace HSMServer.Core.Cache
 
             ChangeSensorEvent?.Invoke(sensor, ActionType.Add);
 
-            foreach (var template in _alertTemplates.Values)
+            // OrderBy on the dispatch loop: _alertTemplates is a ConcurrentDictionary, whose
+            // .Values enumeration order is not insertion-stable, and ApplyTemplateToSensor
+            // dispatches per-template onto the per-sensor queue. Without ordering, two
+            // templates matching the same sensor could land in arbitrary order in
+            // sensor.Policies.TTLPolicies, which surfaces as non-deterministic list state for
+            // callers that read the policies list by index.
+            foreach (var template in _alertTemplates.Values.OrderBy(t => t.Id))
             {
                 if (template.IsMatch(sensor))
                     ApplyTemplateToSensor(new ApplyTemplateRequest(sensor.Id, template));

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateApplicationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateApplicationTests.cs
@@ -122,9 +122,18 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                 _fixture.ProductId, sensorPath, out var sensor);
             Assert.True(found, "Sensor was not found in cache");
 
+            // Positional order is not part of the contract: _alertTemplates is a
+            // ConcurrentDictionary (insertion order undefined), and the per-sensor queue
+            // applies matching templates in whatever order the dispatch loop sees them.
+            // Even with the OrderBy on the dispatch loop, asserting position here would
+            // couple the test to that implementation detail. Assert set membership instead.
             Assert.Equal(2, sensor.Policies.TTLPolicies.Count);
-            Assert.Equal(template1.Id, sensor.Policies.TTLPolicies[0].TemplateId);
-            Assert.Equal(template2.Id, sensor.Policies.TTLPolicies[1].TemplateId);
+            var templateIds = sensor.Policies.TTLPolicies
+                .Select(p => p.TemplateId!.Value)
+                .OrderBy(id => id)
+                .ToArray();
+            var expectedIds = new[] { template1.Id, template2.Id }.OrderBy(id => id).ToArray();
+            Assert.Equal(expectedIds, templateIds);
         }
 
         [Fact]


### PR DESCRIPTION
## Summary
- `TreeValuesCache.AddSensor` now sorts matching templates by `Id` before dispatching to the per-sensor queue. `ConcurrentDictionary.Values` enumeration order is not insertion-stable, so two templates matching the same sensor previously landed in arbitrary order in `sensor.Policies.TTLPolicies`. PR #1135 introduced this path; the surface was hidden until `NewSensor_MatchingMultipleTemplates_GetsAllPolicies` flaked under CI.
- `TemplateApplicationTests.NewSensor_MatchingMultipleTemplates_GetsAllPolicies` asserts set membership instead of positional order. `TTLPolicies` exposes no contract that makes index meaningful, and templates are unordered by spec — coupling the test to position was wrong regardless of the production fix.

## Why both
The `OrderBy` makes runtime behaviour deterministic; the test relaxation prevents this class of flake from re-appearing if a future refactor (e.g. switch to a different dispatch shape) changes the iteration source again.

## Test plan
- [ ] CI: server-build.yml `build` job passes
- [ ] Specifically: `NewSensor_MatchingMultipleTemplates_GetsAllPolicies` no longer flakes
- [ ] Other TemplateApplication tests unaffected (only the multi-template test changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)