### PR TITLE
hsm-agent: static-link into a self-contained exe (missed #1168 merge)

### DIFF
--- a/.github/workflows/agent-windows-build.yml
+++ b/.github/workflows/agent-windows-build.yml
@@ -41,10 +41,11 @@ jobs:
           vcpkgGitCommitId: 6f29f12e82a8293156836ad81cc9bf5af41fe836
 
       - name: Configure (Release, HTTP transport on)
-        # The agent CMake forces HSM_COLLECTOR_HTTP=ON on Windows; vcpkg manifest install (curl) runs
-        # at configure time. Override VCPKG_BINARY_SOURCES to "clear" so the GHA cache backend (whose
-        # tokens aren't reliably exported) is not used — curl builds from source. Same fix the
-        # collector http-transport lane uses.
+        # The agent CMake forces HSM_COLLECTOR_HTTP=ON on Windows AND the x64-windows-static triplet +
+        # static CRT, so the produced hsm-agent.exe is a self-contained single binary (no libcurl/zlib
+        # DLLs). vcpkg manifest install (static curl[ssl]=Schannel + zlib) runs at configure time.
+        # Override VCPKG_BINARY_SOURCES to "clear" so the GHA cache backend (whose tokens aren't
+        # reliably exported) is not used — curl builds from source. Same fix the collector lane uses.
         env:
           VCPKG_BINARY_SOURCES: clear
         run: >

--- a/.github/workflows/server-build.yml
+++ b/.github/workflows/server-build.yml
@@ -49,9 +49,10 @@ jobs:
 
       # HSM Agent (#1167): build the native Windows agent and stage it into wwwroot so the published
       # server image serves a real per-product download bundle (otherwise /api/agent/installer 503s).
-      # The agent links the collector with the libcurl HTTP transport, so it needs vcpkg (curl). This
-      # job is already windows-latest, so the agent's MSVC build fits here. wwwroot is included by the
-      # dotnet publish below.
+      # The agent links the collector with the libcurl HTTP transport, so it needs vcpkg (curl). It is
+      # statically linked (x64-windows-static, forced by src/agent/CMakeLists.txt) so the served exe is
+      # a self-contained single binary. This job is already windows-latest, so the agent's MSVC build
+      # fits here. wwwroot is included by the dotnet publish below.
       - name: Set up vcpkg (HSM Agent curl)
         uses: lukka/run-vcpkg@v11
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -139,3 +139,9 @@ src/module/HSMPingModule/Config/*
 
 # Conan/CMake user presets (generated, never committed)
 CMakeUserPresets.json
+
+# docker-compose.yml bind-mount volumes created at repo root by `docker compose up`
+/Logs/
+/Config/
+/Databases/
+/DatabasesBackups/

--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -40,6 +40,10 @@ server image + the install→data→stop run). A plugin system is **not** planne
   per-install/per-product data (server address, key, identity, sensor groups) lives in a separate
   `config.json`. The PE is never patched — preserving Authenticode (no SmartScreen/AV breakage). The
   agent enforces this structurally by reading config from a file, never from embedded bytes.
+- **Self-contained exe.** The Windows build is statically linked (`x64-windows-static` triplet +
+  static CRT, forced in `src/agent/CMakeLists.txt`): the bundle ships one `hsm-agent.exe` with no
+  libcurl/zlib DLLs or VC++ redistributable, so it runs on a clean machine. curl uses Schannel (no
+  OpenSSL). This is what keeps the single-exe bundle (above) actually runnable after download.
 - **No wire distortion.** The agent adds no payload behavior; it calls the collector's public API
   (`AddAllComputerSensors`/`AddAllModuleSensors`/`UseHttpTransport`/`InstallWindowsMetricSources`).
   All wire/parity contracts remain the collector's.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,19 @@
+# Single-container HSM Server. Everyone runs the same stack with `docker compose up -d`.
+# The image is published by CI (server-build.yml). To run a build from local sources instead,
+# publish it to this exact tag first:
+#   dotnet publish src/server/HSMServer/HSMServer.csproj -c Release --os linux --arch x64 \
+#     -p:PublishProfile=DefaultContainer -p:ContainerImageName=hsmonitoring/hierarchical_sensor_monitoring
 services:
   app:
     image: 'hsmonitoring/hierarchical_sensor_monitoring:latest'
+    container_name: hsm-server
     restart: unless-stopped
     user: '0'
     ports:
-      - '44330:44330'
-      - '44333:44333'
+      - '44330:44330'   # Sensor API — collectors/agents send values here (https, /api/sensors/*)
+      - '44333:44333'   # Web UI — browser dashboard, admin, agent download (https)
     volumes:
-      - ./Logs:/app/Logs
-      - ./Config:/app/Config
-      - ./Databases:/app/Databases
+      - ./Logs:/app/Logs                       # NLog output
+      - ./Config:/app/Config                   # server config (TLS cert, Telegram, Agent settings)
+      - ./Databases:/app/Databases             # embedded LevelDB (sensor history + metadata)
       - ./DatabasesBackups:/app/DatabasesBackups

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -9,7 +9,22 @@
 #                             the libcurl HTTP transport (HSM_COLLECTOR_HTTP).
 cmake_minimum_required(VERSION 3.21)
 
+# Self-contained Windows agent: the downloadable bundle ships a SINGLE hsm-agent.exe with no
+# redistributable DLLs, so build the curl HTTP transport against the STATIC vcpkg triplet
+# (static curl[ssl]=Schannel + zlib, no libcurl/zlib DLLs) and link the CRT statically below.
+# Set the triplet before project() so the vcpkg toolchain (included during project()) picks it up.
+# Gate on the host (the Win32 service only builds on Windows) and allow an explicit override.
+if(CMAKE_HOST_WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
+    set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "vcpkg triplet for the self-contained agent build")
+endif()
+
 project(HsmAgent VERSION 0.4.0 LANGUAGES CXX)
+
+if(MSVC)
+    # Static CRT (/MT) to match the static triplet — the exe must run on a clean machine with no VC++
+    # redistributable. Applies to the agent, the linked collector subdir, and the portable config lib.
+    set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+endif()
 
 option(HSM_AGENT_WERROR "Treat compiler warnings as errors" OFF)
 option(HSM_AGENT_BUILD_TESTS "Build the agent unit tests" ON)

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -26,6 +26,11 @@ tree under `<computer>/.computer/...` for the product the access key belongs to.
 The agent links the in-tree collector with the libcurl HTTP transport, so a vcpkg toolchain (for
 curl) is required for the `hsm-agent` executable.
 
+On Windows the build is **statically linked** (`x64-windows-static` triplet + static CRT, forced by
+`src/agent/CMakeLists.txt`): the downloadable bundle ships a single self-contained `hsm-agent.exe`
+that runs on a clean machine with no libcurl/zlib DLLs or VC++ redistributable (curl uses Schannel,
+so no OpenSSL). Don't pass `-DVCPKG_TARGET_TRIPLET` unless you intend to override this.
+
 ```sh
 cmake -S src/agent -B src/agent/build/debug \
       -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake \


### PR DESCRIPTION
## Summary

PR #1168 merged the HSM Agent foundation, but the **static-linking** commit didn't make it into that merge in time. As a result the agent in `master` links libcurl/zlib **dynamically**, so the downloadable bundle (which ships only `hsm-agent.exe`) would fail to start on a clean machine (missing `libcurl.dll`/`zlib1.dll`). This PR brings that fix to `master` so the single downloaded exe is self-contained.

- `src/agent/CMakeLists.txt`: force the `x64-windows-static` vcpkg triplet (set before `project()` so the toolchain picks it up) + static CRT (`/MT`) on MSVC. curl uses Schannel on Windows → no OpenSSL pulled.
- CI comments (`agent-windows-build.yml`, `server-build.yml`) note the static triplet (inherited automatically from CMake).
- Compose polish: `docker-compose.yml` gets `container_name` + port/volume comments + a local-build note; `.gitignore` ignores the bind-mount dirs created by `docker compose up`.
- Docs: `README.md`, `feature.md`.

Verified: the Release exe depends only on system DLLs (advapi32/pdh/ws2_32/bcrypt/crypt32/kernel32), runs isolated with no DLLs present, config ctest 9/9, and a console run registers + streams against a live Dockerized server.

## Test plan
- [ ] `cmake -S src/agent -B build/agent -DCMAKE_TOOLCHAIN_FILE=<vcpkg>` → `cmake --build --config Release`
- [ ] `dumpbin /dependents build/agent/Release/hsm-agent.exe` shows no libcurl/zlib/vcruntime DLLs
- [ ] `ctest -C Release` green

Relates to #1167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)