### PR TITLE
hsm-agent: top-10 CPU processes — per-exe periodic sensors

### DIFF
--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -80,6 +80,23 @@ defaults. Maps onto `CollectorOptions` + runtime group gates:
   `system`/`disk`/`network` are finer subsets used **only when `computer` is false**; `module` =
   collector self-sensors; `process` is opt-in.
 - `periods.collectMs` → `package_collect_period_ms`. `productVersion` → module-sensor version.
+- `topCpu.{enabled=false,periodMs=60000,minPercent=1.0,count=10}` — opt-in "top processes by CPU"
+  (issue #1175). Validated only when enabled (period/count > 0, minPercent ≥ 0).
+
+## Top processes by CPU (issue #1175)
+
+Opt-in (`topCpu.enabled`). A dedicated thread in `AgentRuntime` (started after `Start()`, joined
+before `Stop()`, waits on the same `cv_` so it exits the moment stop is requested) runs every
+`periodMs`:
+1. `WindowsCpuSampler` (`src/cpu_top.cpp`, `#ifdef _WIN32`) enumerates processes (`CreateToolhelp32Snapshot`
+   + `GetProcessTimes`), diffs each PID's CPU time against the previous tick, and aggregates by exe name
+   into CPU% **of the whole machine** (÷ logical-core count).
+2. `SelectTopN` (portable, unit-tested) keeps names `>= minPercent` and returns the busiest `count`.
+3. Each survivor's % is posted to a lazily-created `Top CPU processes/<exe>` Double sensor (cached by
+   name). Names not in the top list that tick get **no value** → natural gaps in their series.
+
+Aggregating by exe name (not PID, not PDH `#n` suffix) keeps a stable sensor identity over time.
+**Out of scope:** browser tab/site attribution (needs browser-level instrumentation; tracked separately).
 
 ## Logging
 
@@ -94,7 +111,7 @@ stderr. The collector's own dedup window keeps a flapping server from spamming t
 
 ## Verification
 
-- Portable config-parser unit tests (`tests/agent_tests.cpp`, name-dispatched, 9 cases) — run on every
+- Portable unit tests (`tests/agent_tests.cpp`, name-dispatched, 12 cases — config parser + topCpu config + `SelectTopN`) — run on every
   platform, registered in `ctest`.
 - **CI build lane (W8):** `.github/workflows/agent-windows-build.yml` — windows-latest, vcpkg curl,
   configures + builds `src/agent` Release with warnings-as-errors, runs the config `ctest`, and uploads

--- a/aicontext/features/server/agent-download/feature.md
+++ b/aicontext/features/server/agent-download/feature.md
@@ -32,12 +32,17 @@ pure-native exe's own `--install`. No .NET runtime, no C#/MSI installer is produ
 |---|---|
 | Download endpoint `GET /api/agent/installer?productId=…` | `HSMServer/Controllers/AgentController.cs` |
 | Bundle builder (config.json + scripts + zip; pure/testable) | `HSMServer/Model/Agent/AgentInstallerBundle.cs` |
-| Server settings "Agent connection URL" + "Allow untrusted server certificate" | `HSMServer/ServerConfiguration/Sections/AgentConfig.cs` (`ExternalConnectionUrl`, `AllowUntrustedCertificate`) (+ `IServerConfig`/`ServerConfig`) |
+| Server settings "Agent connection URL" + "Allow untrusted server certificate" + "Report top processes by CPU" | `HSMServer/ServerConfiguration/Sections/AgentConfig.cs` (`ExternalConnectionUrl`, `AllowUntrustedCertificate`, `EnableTopCpuProcesses`) (+ `IServerConfig`/`ServerConfig`) |
 | Settings UI (Agent tab) | `Views/Configuration/_Agent.cshtml`, `Views/Configuration/Index.cshtml`, `AgentSettingsViewModel`, `ConfigurationController.SaveAgentSettings` |
 | Download button | `Views/AccessKeys/_ProductAccessKeys.cshtml` (admin-only) |
 | Exe drop-point | `HSMServer/wwwroot/agent/hsm-agent.exe` (staged by `server-build.yml` before publish, W9) |
 | Key selection / URL resolution (pure, testable) | `Model/Agent/AgentKeySelector.cs`, `Model/Agent/AgentConnectionResolver.cs` |
-| Tests | `tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs` (5) + `AgentDownloadLogicTests.cs` (13: key selection + URL resolution) |
+| Tests | `tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs` (7: incl. topCpu on/off) + `AgentDownloadLogicTests.cs` (13: key selection + URL resolution) |
+
+`AgentConfig.EnableTopCpuProcesses` (admin toggle, Configuration → Agent) makes `BuildConfigJson` add a
+`topCpu` block (`enabled:true, periodMs:60000, minPercent:1.0, count:10`) to the generated `config.json`,
+so the downloaded agent also reports the top processes by CPU (issue #1175). Off by default; the client
+agent has no UI and just runs the baked config.
 
 ## Connection URL resolution
 

--- a/docs/hsm-agent.md
+++ b/docs/hsm-agent.md
@@ -75,7 +75,16 @@ are required; everything else has a default.
 | `sensors.module` | `true` | collector self-sensors (alive / version / queue) |
 | `sensors.process` | `false` | per-process sensors (opt-in) |
 | `periods.collectMs` | `15000` | package collect period (ms) |
+| `topCpu.enabled` | `false` | opt-in: periodic "top processes by CPU" sensors |
+| `topCpu.periodMs` | `60000` | how often to sample + post the top list (ms) |
+| `topCpu.minPercent` | `1.0` | skip processes below this %CPU (of the whole machine) |
+| `topCpu.count` | `10` | how many of the busiest exe names to post per tick |
 | `productVersion` | `"1.0.0.0"` | version reported by module sensors |
+
+When `topCpu.enabled` is `true`, every `periodMs` the agent samples CPU usage of all processes,
+aggregates by **executable name** (all `chrome.exe` instances summed), and posts the CPU% of the
+busiest `count` names (that are also `>= minPercent`) to `Top CPU processes/<exe name>` Double sensors.
+A name that isn't in the top list that tick gets no value — leaving a natural gap in its graph.
 
 Blank/missing `address` or `accessKey`, or an out-of-range `port`, make the agent refuse to start (the
 reason is logged to the Event Log and the file log).

--- a/docs/hsm-agent.md
+++ b/docs/hsm-agent.md
@@ -86,6 +86,10 @@ aggregates by **executable name** (all `chrome.exe` instances summed), and posts
 busiest `count` names (that are also `>= minPercent`) to `Top CPU processes/<exe name>` Double sensors.
 A name that isn't in the top list that tick gets no value — leaving a natural gap in its graph.
 
+> Note: a sensor is created the first time an exe name reaches the top list and kept afterwards, so on a
+> long-lived, busy host the number of `Top CPU processes/*` sensors grows with the number of distinct
+> programs that have ever been busy. Raise `minPercent` to limit churn from short-lived spikes.
+
 Blank/missing `address` or `accessKey`, or an out-of-range `port`, make the agent refuse to start (the
 reason is logged to the Event Log and the file log).
 

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -29,7 +29,9 @@ function(hsm_agent_set_warnings target)
 endfunction()
 
 # --- Portable config layer + tests (every platform) ----------------------------------------------
-add_library(hsm_agent_config STATIC src/config.cpp)
+# cpu_top.cpp is built here too: its SelectTopN logic is portable + unit-tested, while the Win32
+# process sampler inside it is #ifdef _WIN32 (compiled only into the agent on Windows).
+add_library(hsm_agent_config STATIC src/config.cpp src/cpu_top.cpp)
 target_include_directories(hsm_agent_config PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_compile_features(hsm_agent_config PUBLIC cxx_std_17)
 hsm_agent_set_warnings(hsm_agent_config)
@@ -49,7 +51,10 @@ if(HSM_AGENT_BUILD_TESTS)
             agent_config_rejects_malformed_json
             agent_config_rejects_wrong_typed_field
             agent_config_ignores_unknown_fields
-            agent_config_decodes_string_escapes)
+            agent_config_decodes_string_escapes
+            agent_topcpu_config_parses_and_defaults
+            agent_topcpu_rejects_bad_config
+            agent_topcpu_selects_busiest_above_threshold)
         add_test(NAME ${name} COMMAND hsm_agent_tests ${name})
     endforeach()
 endif()

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -21,6 +21,10 @@ With a minimal config it registers and streams the standard host catalog via
 PDH/Win32 metric sources (`InstallWindowsMetricSources()`). Computer sensors appear in the server
 tree under `<computer>/.computer/...` for the product the access key belongs to.
 
+Optionally (`topCpu.enabled` in the config) it also posts **top processes by CPU** every minute —
+per-exe-name `Top CPU processes/<exe>` Double sensors for the busiest apps (issue #1175). See the
+[config reference](../../docs/hsm-agent.md#configuration-reference).
+
 ## Build
 
 The agent links the in-tree collector with the libcurl HTTP transport, so a vcpkg toolchain (for

--- a/src/agent/include/agent/agent_runtime.hpp
+++ b/src/agent/include/agent/agent_runtime.hpp
@@ -44,6 +44,11 @@ namespace hsm::agent
         void Log(hsm::collector::LogLevel level, const std::string& message) const;
         void WaitForStop();
 
+        /// Periodic "top processes by CPU" loop (issue #1175). Runs on its own thread between Start and
+        /// stop when `topCpu.enabled`; posts the busiest exe names to `Top CPU processes/<exe>` Double
+        /// sensors each `topCpu.periodMs`. Returns promptly when stop is requested.
+        void RunTopCpuLoop(hsm::collector::Collector& collector);
+
         AgentConfig config_;
         LogFn log_;
 

--- a/src/agent/include/agent/config.hpp
+++ b/src/agent/include/agent/config.hpp
@@ -40,6 +40,15 @@ namespace hsm::agent
         // periods.*
         int collect_period_ms = 0; ///< 0 → collector default (15000)
 
+        // topCpu.* — periodic "top processes by CPU" sensors (issue #1175). Opt-in. Each tick the
+        // agent samples per-process CPU, aggregates by exe name, and posts the CPU% of the busiest
+        // names (in the top `count` AND >= `min_percent`) to `Top CPU processes/<exe>` Double sensors.
+        // Names that don't qualify a given tick get no value → natural gaps in their series.
+        bool top_cpu_enabled = false;
+        int top_cpu_period_ms = 60000;     ///< sampling/post interval; must be > 0
+        double top_cpu_min_percent = 1.0;  ///< skip anything below this %CPU (of the whole machine)
+        int top_cpu_count = 10;            ///< how many of the busiest names to post per tick
+
         // module-sensor product version
         std::string product_version = "1.0.0.0";
 

--- a/src/agent/include/agent/config.hpp
+++ b/src/agent/include/agent/config.hpp
@@ -44,6 +44,8 @@ namespace hsm::agent
         // agent samples per-process CPU, aggregates by exe name, and posts the CPU% of the busiest
         // names (in the top `count` AND >= `min_percent`) to `Top CPU processes/<exe>` Double sensors.
         // Names that don't qualify a given tick get no value → natural gaps in their series.
+        // NOTE: these defaults are mirrored server-side in AgentInstallerBundle.BuildConfigJson (the
+        // download bundle's topCpu block) — keep the two in sync when changing them.
         bool top_cpu_enabled = false;
         int top_cpu_period_ms = 60000;     ///< sampling/post interval; must be > 0
         double top_cpu_min_percent = 1.0;  ///< skip anything below this %CPU (of the whole machine)

--- a/src/agent/include/agent/cpu_top.hpp
+++ b/src/agent/include/agent/cpu_top.hpp
@@ -40,8 +40,14 @@ namespace hsm::agent
         std::map<std::string, double> Sample();
 
     private:
-        std::map<std::uint32_t, std::uint64_t> prev_cpu_100ns_; ///< pid -> cumulative (kernel+user) 100ns
-        std::uint64_t prev_wall_100ns_ = 0;
+        struct PrevSample
+        {
+            std::uint64_t creation_100ns; ///< process creation time — detects PID reuse between ticks
+            std::uint64_t cpu_100ns;      ///< cumulative (kernel+user) CPU time
+        };
+
+        std::map<std::uint32_t, PrevSample> prev_; ///< pid -> previous sample
+        std::uint64_t prev_wall_ms_ = 0;           ///< monotonic (GetTickCount64) wall ms at last sample
         unsigned int cores_ = 1;
         bool have_baseline_ = false;
     };

--- a/src/agent/include/agent/cpu_top.hpp
+++ b/src/agent/include/agent/cpu_top.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+/// @file
+/// @brief "Top processes by CPU" sampling for the agent (issue #1175).
+///
+/// Two layers, deliberately split so the selection logic is unit-tested without Win32:
+///   * `SelectTopN` — pure: given per-exe aggregated CPU%, filter by a minimum and return the
+///     busiest `count` names, descending (deterministic tie-break by name). Built on every platform.
+///   * `WindowsCpuSampler` — Win32 only: enumerates processes, diffs CPU time against the previous
+///     call, and returns CPU% (of the whole machine) aggregated by exe name.
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace hsm::agent
+{
+    struct CpuUsage
+    {
+        std::string name; ///< executable image name, e.g. "chrome.exe"
+        double percent;   ///< CPU% of the whole machine (0..100), summed over all instances
+    };
+
+    /// Filter out names below `min_percent`, then return the `count` busiest, descending by percent
+    /// (ties broken by name ascending so the result is deterministic). `count <= 0` returns empty.
+    std::vector<CpuUsage> SelectTopN(const std::map<std::string, double>& by_name, int count, double min_percent);
+
+#ifdef _WIN32
+    /// Samples per-process CPU between successive `Sample()` calls. Stateful: it remembers each PID's
+    /// cumulative CPU time and the wall-clock of the previous call, so a value is a true delta over the
+    /// elapsed interval. The FIRST call only seeds the baseline and returns an empty map.
+    class WindowsCpuSampler
+    {
+    public:
+        WindowsCpuSampler();
+
+        /// Per-exe-name aggregated CPU% (of the whole machine) since the previous call. Processes that
+        /// appeared or vanished between calls contribute nothing to this tick.
+        std::map<std::string, double> Sample();
+
+    private:
+        std::map<std::uint32_t, std::uint64_t> prev_cpu_100ns_; ///< pid -> cumulative (kernel+user) 100ns
+        std::uint64_t prev_wall_100ns_ = 0;
+        unsigned int cores_ = 1;
+        bool have_baseline_ = false;
+    };
+#endif
+} // namespace hsm::agent

--- a/src/agent/src/agent_runtime.cpp
+++ b/src/agent/src/agent_runtime.cpp
@@ -1,6 +1,11 @@
 #include "agent/agent_runtime.hpp"
 
+#include "agent/cpu_top.hpp"
+
+#include <chrono>
 #include <exception>
+#include <map>
+#include <thread>
 #include <utility>
 
 #ifdef _WIN32
@@ -78,6 +83,48 @@ namespace hsm::agent
         cv_.notify_all();
     }
 
+    void AgentRuntime::RunTopCpuLoop(hc::Collector& collector)
+    {
+#ifdef _WIN32
+        WindowsCpuSampler sampler;
+        // exe name -> its sensor, created lazily the first time the name reaches the top list.
+        std::map<std::string, hc::DoubleSensor> sensors;
+        const auto period = std::chrono::milliseconds(config_.top_cpu_period_ms);
+
+        // Seed the baseline now so the first posted tick is a true delta over one full period.
+        sampler.Sample();
+
+        while (true)
+        {
+            {
+                std::unique_lock<std::mutex> lock(mutex_);
+                if (cv_.wait_for(lock, period, [this] { return stop_requested_; }))
+                    return; // stop requested — leave before touching the collector again
+            }
+
+            try
+            {
+                const auto by_name = sampler.Sample();
+                const auto top = SelectTopN(by_name, config_.top_cpu_count, config_.top_cpu_min_percent);
+                for (const auto& usage : top)
+                {
+                    auto it = sensors.find(usage.name);
+                    if (it == sensors.end())
+                        it = sensors.emplace(usage.name, collector.CreateDoubleSensor("Top CPU processes/" + usage.name)).first;
+                    it->second.AddValue(usage.percent);
+                }
+            }
+            catch (const std::exception& ex)
+            {
+                // A bad tick must never kill the loop or the agent; log and try again next period.
+                Log(hc::LogLevel::Error, std::string{ "top-CPU sampling error: " } + ex.what());
+            }
+        }
+#else
+        (void)collector;
+#endif
+    }
+
     int AgentRuntime::Run(const std::function<void()>& on_started)
     {
         try
@@ -121,10 +168,20 @@ namespace hsm::agent
 
             collector.Start();
 
+            // Periodic "top processes by CPU" sensors (issue #1175). Own thread so the minute-cadence
+            // sampling never blocks the collector's pipeline; it waits on the same cv_ and returns the
+            // moment stop is requested. Joined before Stop() so no sensor op overlaps shutdown.
+            std::thread top_cpu_thread;
+            if (config_.top_cpu_enabled)
+                top_cpu_thread = std::thread(&AgentRuntime::RunTopCpuLoop, this, std::ref(collector));
+
             if (on_started)
                 on_started();
 
             WaitForStop();
+
+            if (top_cpu_thread.joinable())
+                top_cpu_thread.join();
 
             Log(hc::LogLevel::Info, "HSM Agent stopping...");
             collector.Stop(); // bounded graceful drain (capped internally)

--- a/src/agent/src/agent_runtime.cpp
+++ b/src/agent/src/agent_runtime.cpp
@@ -110,6 +110,11 @@ namespace hsm::agent
                 {
                     auto it = sensors.find(usage.name);
                     if (it == sensors.end())
+                        // Creating a sensor from this background thread (after Start) is safe: the C-ABI
+                        // CreateSensor serializes on the collector's mutex_, and the scheduler reads the
+                        // registry only via a snapshot taken under the same mutex. A plain instant-sensor
+                        // create touches no unsynchronized std::function callback storage (only SetLogger/
+                        // AddLifecycleListener/SetMetricSourceFactory do — all done pre-Start on one thread).
                         it = sensors.emplace(usage.name, collector.CreateDoubleSensor("Top CPU processes/" + usage.name)).first;
                     it->second.AddValue(usage.percent);
                 }
@@ -172,6 +177,24 @@ namespace hsm::agent
             // sampling never blocks the collector's pipeline; it waits on the same cv_ and returns the
             // moment stop is requested. Joined before Stop() so no sensor op overlaps shutdown.
             std::thread top_cpu_thread;
+
+            // RAII backstop: if on_started() or WaitForStop() throws, the stack unwinds through here and
+            // the worker must be joined before its std::thread is destroyed — otherwise the destructor
+            // calls std::terminate(), bypassing the catch below. Requests stop, then joins, on any exit.
+            struct ThreadGuard
+            {
+                AgentRuntime* self;
+                std::thread& thread;
+                ~ThreadGuard()
+                {
+                    if (thread.joinable())
+                    {
+                        self->RequestStop();
+                        thread.join();
+                    }
+                }
+            } top_cpu_guard{ this, top_cpu_thread };
+
             if (config_.top_cpu_enabled)
                 top_cpu_thread = std::thread(&AgentRuntime::RunTopCpuLoop, this, std::ref(collector));
 

--- a/src/agent/src/config.cpp
+++ b/src/agent/src/config.cpp
@@ -447,6 +447,20 @@ namespace hsm::agent
             return true;
         }
 
+        bool ReadDouble(const JsonValue& object, const std::string& key, double& out, std::string& error)
+        {
+            const JsonValue* value = object.Find(key);
+            if (value == nullptr)
+                return true;
+            if (value->type != JsonValue::Type::Number)
+            {
+                error = "field '" + key + "' must be a number";
+                return false;
+            }
+            out = value->number;
+            return true;
+        }
+
     } // namespace
 
     bool AgentConfig::ComputerNameIsAuto() const
@@ -512,6 +526,17 @@ namespace hsm::agent
                 return false;
         }
 
+        if (const JsonValue* top_cpu = root.Find("topCpu"))
+        {
+            if (top_cpu->type != JsonValue::Type::Object)
+            {
+                error = "'topCpu' must be an object";
+                return false;
+            }
+            if (!ReadBool(*top_cpu, "enabled", out.top_cpu_enabled, error) || !ReadInt(*top_cpu, "periodMs", out.top_cpu_period_ms, error) || !ReadDouble(*top_cpu, "minPercent", out.top_cpu_min_percent, error) || !ReadInt(*top_cpu, "count", out.top_cpu_count, error))
+                return false;
+        }
+
         if (!ReadString(root, "productVersion", out.product_version, error))
             return false;
 
@@ -530,6 +555,24 @@ namespace hsm::agent
         {
             error = "config: 'server.port' must be between 1 and 65535";
             return false;
+        }
+        if (out.top_cpu_enabled)
+        {
+            if (out.top_cpu_period_ms <= 0)
+            {
+                error = "config: 'topCpu.periodMs' must be greater than 0";
+                return false;
+            }
+            if (out.top_cpu_count <= 0)
+            {
+                error = "config: 'topCpu.count' must be greater than 0";
+                return false;
+            }
+            if (out.top_cpu_min_percent < 0.0)
+            {
+                error = "config: 'topCpu.minPercent' must not be negative";
+                return false;
+            }
         }
 
         return true;

--- a/src/agent/src/cpu_top.cpp
+++ b/src/agent/src/cpu_top.cpp
@@ -1,0 +1,136 @@
+#include "agent/cpu_top.hpp"
+
+#include <algorithm>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+
+#include <tlhelp32.h>
+#endif
+
+namespace hsm::agent
+{
+    std::vector<CpuUsage> SelectTopN(const std::map<std::string, double>& by_name, int count, double min_percent)
+    {
+        std::vector<CpuUsage> result;
+        if (count <= 0)
+            return result;
+
+        for (const auto& entry : by_name)
+            if (entry.second >= min_percent)
+                result.push_back({ entry.first, entry.second });
+
+        // Busiest first; deterministic tie-break by name so equal-CPU processes order stably.
+        std::sort(result.begin(), result.end(), [](const CpuUsage& a, const CpuUsage& b) {
+            if (a.percent != b.percent)
+                return a.percent > b.percent;
+            return a.name < b.name;
+        });
+
+        if (result.size() > static_cast<std::size_t>(count))
+            result.resize(static_cast<std::size_t>(count));
+        return result;
+    }
+
+#ifdef _WIN32
+    namespace
+    {
+        std::uint64_t FileTimeTo100ns(const FILETIME& ft)
+        {
+            ULARGE_INTEGER v;
+            v.LowPart = ft.dwLowDateTime;
+            v.HighPart = ft.dwHighDateTime;
+            return v.QuadPart;
+        }
+
+        std::uint64_t NowWall100ns()
+        {
+            FILETIME ft;
+            GetSystemTimeAsFileTime(&ft); // 100-ns ticks; monotonic enough for a delta over ~1 min
+            return FileTimeTo100ns(ft);
+        }
+
+        std::string NarrowExeName(const wchar_t* wide)
+        {
+            const int needed = WideCharToMultiByte(CP_UTF8, 0, wide, -1, nullptr, 0, nullptr, nullptr);
+            if (needed <= 1)
+                return std::string{};
+            std::string out(static_cast<std::size_t>(needed - 1), '\0'); // drop the NUL
+            WideCharToMultiByte(CP_UTF8, 0, wide, -1, out.data(), needed, nullptr, nullptr);
+            return out;
+        }
+    } // namespace
+
+    WindowsCpuSampler::WindowsCpuSampler()
+    {
+        SYSTEM_INFO info{};
+        GetSystemInfo(&info);
+        cores_ = info.dwNumberOfProcessors > 0 ? info.dwNumberOfProcessors : 1;
+    }
+
+    std::map<std::string, double> WindowsCpuSampler::Sample()
+    {
+        const std::uint64_t wall = NowWall100ns();
+
+        // Snapshot: pid -> cumulative CPU 100ns, and pid -> exe name (for this tick).
+        std::map<std::uint32_t, std::uint64_t> cur_cpu;
+        std::map<std::uint32_t, std::string> cur_name;
+
+        HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+        if (snapshot != INVALID_HANDLE_VALUE)
+        {
+            PROCESSENTRY32W entry{};
+            entry.dwSize = sizeof(entry);
+            if (Process32FirstW(snapshot, &entry))
+            {
+                do
+                {
+                    const std::uint32_t pid = entry.th32ProcessID;
+                    if (pid == 0)
+                        continue; // System Idle Process — not a real app
+
+                    HANDLE process = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
+                    if (process == nullptr)
+                        continue; // protected/elevated process we can't query — skip silently
+
+                    FILETIME creation, exit, kernel, user;
+                    if (GetProcessTimes(process, &creation, &exit, &kernel, &user))
+                    {
+                        cur_cpu[pid] = FileTimeTo100ns(kernel) + FileTimeTo100ns(user);
+                        cur_name[pid] = NarrowExeName(entry.szExeFile);
+                    }
+                    CloseHandle(process);
+                } while (Process32NextW(snapshot, &entry));
+            }
+            CloseHandle(snapshot);
+        }
+
+        std::map<std::string, double> by_name;
+
+        const std::uint64_t wall_delta = wall > prev_wall_100ns_ ? wall - prev_wall_100ns_ : 0;
+        if (have_baseline_ && wall_delta > 0)
+        {
+            const double denom = static_cast<double>(wall_delta) * static_cast<double>(cores_);
+            for (const auto& [pid, cpu] : cur_cpu)
+            {
+                const auto prev = prev_cpu_100ns_.find(pid);
+                if (prev == prev_cpu_100ns_.end() || cpu < prev->second)
+                    continue; // new process this tick (or counter reset) — no delta to attribute
+
+                const double percent = static_cast<double>(cpu - prev->second) / denom * 100.0;
+                const auto name = cur_name.find(pid);
+                if (name != cur_name.end() && !name->second.empty())
+                    by_name[name->second] += percent;
+            }
+        }
+
+        prev_cpu_100ns_ = std::move(cur_cpu);
+        prev_wall_100ns_ = wall;
+        have_baseline_ = true;
+        return by_name; // empty on the first call (baseline only)
+    }
+#endif
+} // namespace hsm::agent

--- a/src/agent/src/cpu_top.cpp
+++ b/src/agent/src/cpu_top.cpp
@@ -46,13 +46,6 @@ namespace hsm::agent
             return v.QuadPart;
         }
 
-        std::uint64_t NowWall100ns()
-        {
-            FILETIME ft;
-            GetSystemTimeAsFileTime(&ft); // 100-ns ticks; monotonic enough for a delta over ~1 min
-            return FileTimeTo100ns(ft);
-        }
-
         std::string NarrowExeName(const wchar_t* wide)
         {
             const int needed = WideCharToMultiByte(CP_UTF8, 0, wide, -1, nullptr, 0, nullptr, nullptr);
@@ -66,17 +59,20 @@ namespace hsm::agent
 
     WindowsCpuSampler::WindowsCpuSampler()
     {
-        SYSTEM_INFO info{};
-        GetSystemInfo(&info);
-        cores_ = info.dwNumberOfProcessors > 0 ? info.dwNumberOfProcessors : 1;
+        // Group-aware count: GetSystemInfo().dwNumberOfProcessors only sees the current processor
+        // group (<= 64), which would over-report CPU% on large multi-group servers.
+        const DWORD cores = GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+        cores_ = cores > 0 ? cores : 1;
     }
 
     std::map<std::string, double> WindowsCpuSampler::Sample()
     {
-        const std::uint64_t wall = NowWall100ns();
+        // Monotonic elapsed time for the denominator — GetTickCount64 is immune to NTP/DST/manual
+        // wall-clock adjustments (which could zero or inflate the interval).
+        const std::uint64_t wall_ms = GetTickCount64();
 
-        // Snapshot: pid -> cumulative CPU 100ns, and pid -> exe name (for this tick).
-        std::map<std::uint32_t, std::uint64_t> cur_cpu;
+        // This tick: pid -> {creation, cpu} and pid -> exe name.
+        std::map<std::uint32_t, PrevSample> cur;
         std::map<std::uint32_t, std::string> cur_name;
 
         HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
@@ -99,7 +95,7 @@ namespace hsm::agent
                     FILETIME creation, exit, kernel, user;
                     if (GetProcessTimes(process, &creation, &exit, &kernel, &user))
                     {
-                        cur_cpu[pid] = FileTimeTo100ns(kernel) + FileTimeTo100ns(user);
+                        cur[pid] = { FileTimeTo100ns(creation), FileTimeTo100ns(kernel) + FileTimeTo100ns(user) };
                         cur_name[pid] = NarrowExeName(entry.szExeFile);
                     }
                     CloseHandle(process);
@@ -110,25 +106,28 @@ namespace hsm::agent
 
         std::map<std::string, double> by_name;
 
-        const std::uint64_t wall_delta = wall > prev_wall_100ns_ ? wall - prev_wall_100ns_ : 0;
-        if (have_baseline_ && wall_delta > 0)
+        const std::uint64_t wall_delta_ms = wall_ms > prev_wall_ms_ ? wall_ms - prev_wall_ms_ : 0;
+        if (have_baseline_ && wall_delta_ms > 0)
         {
-            const double denom = static_cast<double>(wall_delta) * static_cast<double>(cores_);
-            for (const auto& [pid, cpu] : cur_cpu)
+            // Total CPU capacity over the interval, in 100ns units: ms * 10000 per core.
+            const double denom = static_cast<double>(wall_delta_ms) * 10000.0 * static_cast<double>(cores_);
+            for (const auto& [pid, sample] : cur)
             {
-                const auto prev = prev_cpu_100ns_.find(pid);
-                if (prev == prev_cpu_100ns_.end() || cpu < prev->second)
-                    continue; // new process this tick (or counter reset) — no delta to attribute
+                const auto prev = prev_.find(pid);
+                // Skip a process new this tick, a PID reused by a different process (creation time
+                // changed), or a non-monotonic counter — none has a valid delta to attribute.
+                if (prev == prev_.end() || prev->second.creation_100ns != sample.creation_100ns || sample.cpu_100ns < prev->second.cpu_100ns)
+                    continue;
 
-                const double percent = static_cast<double>(cpu - prev->second) / denom * 100.0;
+                const double percent = static_cast<double>(sample.cpu_100ns - prev->second.cpu_100ns) / denom * 100.0;
                 const auto name = cur_name.find(pid);
                 if (name != cur_name.end() && !name->second.empty())
                     by_name[name->second] += percent;
             }
         }
 
-        prev_cpu_100ns_ = std::move(cur_cpu);
-        prev_wall_100ns_ = wall;
+        prev_ = std::move(cur);
+        prev_wall_ms_ = wall_ms;
         have_baseline_ = true;
         return by_name; // empty on the first call (baseline only)
     }

--- a/src/agent/tests/agent_tests.cpp
+++ b/src/agent/tests/agent_tests.cpp
@@ -2,6 +2,7 @@
 // exits 0 on pass, non-zero on failure. Portable (config parser only) so every CI lane can run it.
 
 #include "agent/config.hpp"
+#include "agent/cpu_top.hpp"
 
 #include <cstring>
 #include <functional>
@@ -157,6 +158,58 @@ namespace
         CheckEq(config.server_address, std::string{ "a\tb\xc3\xa9" }, "tab + unicode escape decode to UTF-8");
     }
 
+    void TopCpuConfigParsesAndDefaults()
+    {
+        // Absent topCpu → feature off, sane defaults.
+        const auto def = ParseOk(R"({ "server": { "address": "h", "accessKey": "k" } })");
+        Check(!def.top_cpu_enabled, "topCpu off by default");
+        CheckEq(def.top_cpu_period_ms, 60000, "default period");
+        CheckEq(def.top_cpu_count, 10, "default count");
+
+        const auto cfg = ParseOk(R"({
+            "server": { "address": "h", "accessKey": "k" },
+            "topCpu": { "enabled": true, "periodMs": 30000, "minPercent": 2.5, "count": 5 }
+        })");
+        Check(cfg.top_cpu_enabled, "enabled");
+        CheckEq(cfg.top_cpu_period_ms, 30000, "periodMs");
+        CheckEq(cfg.top_cpu_count, 5, "count");
+        Check(cfg.top_cpu_min_percent > 2.49 && cfg.top_cpu_min_percent < 2.51, "minPercent");
+    }
+
+    void TopCpuRejectsBadConfig()
+    {
+        // Bad values only matter when the feature is on.
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "topCpu": { "enabled": true, "periodMs": 0 } })", "zero period");
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "topCpu": { "enabled": true, "count": 0 } })", "zero count");
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "topCpu": { "enabled": true, "minPercent": -1 } })", "negative minPercent");
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "topCpu": { "enabled": "yes" } })", "non-bool enabled");
+    }
+
+    void TopCpuSelectsBusiestAboveThreshold()
+    {
+        using hsm::agent::SelectTopN;
+        const std::map<std::string, double> by_name = {
+            { "chrome.exe", 40.0 }, { "idle.exe", 0.5 }, { "code.exe", 12.0 }, { "svchost.exe", 3.0 }
+        };
+
+        // count=2, min=1.0 → busiest two at or above 1% (idle.exe filtered out).
+        const auto top = SelectTopN(by_name, 2, 1.0);
+        CheckEq(top.size(), static_cast<std::size_t>(2), "top size capped to count");
+        CheckEq(top[0].name, std::string{ "chrome.exe" }, "busiest first");
+        CheckEq(top[1].name, std::string{ "code.exe" }, "second busiest");
+
+        // Threshold drops sub-1% names entirely.
+        const auto filtered = SelectTopN(by_name, 10, 1.0);
+        CheckEq(filtered.size(), static_cast<std::size_t>(3), "sub-threshold filtered");
+
+        // Deterministic tie-break by name when percentages are equal.
+        const std::map<std::string, double> ties = { { "b.exe", 5.0 }, { "a.exe", 5.0 } };
+        const auto tied = SelectTopN(ties, 10, 0.0);
+        CheckEq(tied[0].name, std::string{ "a.exe" }, "tie broken by name asc");
+
+        CheckEq(SelectTopN(by_name, 0, 0.0).size(), static_cast<std::size_t>(0), "count<=0 → empty");
+    }
+
     const std::map<std::string, std::function<void()>>& Tests()
     {
         static const std::map<std::string, std::function<void()>> tests = {
@@ -169,6 +222,9 @@ namespace
             { "agent_config_rejects_wrong_typed_field", WrongTypedFieldIsRejected },
             { "agent_config_ignores_unknown_fields", UnknownFieldsAreIgnored },
             { "agent_config_decodes_string_escapes", StringEscapesDecode },
+            { "agent_topcpu_config_parses_and_defaults", TopCpuConfigParsesAndDefaults },
+            { "agent_topcpu_rejects_bad_config", TopCpuRejectsBadConfig },
+            { "agent_topcpu_selects_busiest_above_threshold", TopCpuSelectsBusiestAboveThreshold },
         };
         return tests;
     }

--- a/src/native/collector/include/hsm_collector/collector.hpp
+++ b/src/native/collector/include/hsm_collector/collector.hpp
@@ -52,12 +52,19 @@ namespace hsm::collector
     /// underlying handle; std::function callbacks registered through this object are kept alive
     /// until after that happens.
     ///
-    /// Threading: sensor `AddValue` is safe from any thread, but sensor/observer/sink REGISTRATION
-    /// (the `Create*` factories, `AddLifecycleListener`, `SetLogger`, `SetMetricSourceFactory`) must
-    /// be driven from a single thread — the internal callback storage is not synchronized. In
-    /// particular, a callback running on the scheduler thread must not register from inside itself
-    /// while another thread also registers. The natural pattern is to configure the collector fully
-    /// before `Start()`.
+    /// Threading:
+    /// - `AddValue` is safe from any thread.
+    /// - Plain sensor `Create*` factories (`CreateBoolSensor`/`CreateIntSensor`/`CreateDoubleSensor`/
+    ///   `CreateStringSensor`/… and their option/last-value variants) are also safe from any thread,
+    ///   incl. after `Start()`: the underlying C-ABI serializes the sensor registry on the collector's
+    ///   internal mutex, and the scheduler thread reads it only via a snapshot taken under that mutex.
+    ///   They register no `std::function` callback, so they don't touch the unsynchronized storage below.
+    /// - The CALLBACK-registering setup — `SetLogger`, `AddLifecycleListener`, `SetMetricSourceFactory`,
+    ///   and `CreateMetricSensor` (binds a metric source) — stores `std::function`s that are NOT
+    ///   synchronized: drive these from a single thread, before `Start()`. A callback running on the
+    ///   scheduler thread must not register from inside itself while another thread also registers.
+    /// The natural pattern is still to configure the collector fully before `Start()`; lazily creating
+    /// plain sensors at runtime (e.g. the agent's top-CPU sensors) is the supported exception.
     class Collector
     {
     public:

--- a/src/server/HSMServer/Controllers/AgentController.cs
+++ b/src/server/HSMServer/Controllers/AgentController.cs
@@ -73,7 +73,7 @@ namespace HSMServer.Controllers
 
             var (address, port) = AgentConnectionResolver.Resolve(
                 _config.Agent.ExternalConnectionUrl, _config.Kestrel.SensorPort, Request.Scheme, Request.Host.Host);
-            var options = new AgentBundleOptions(address, port, key.Id.ToString(), _config.Agent.AllowUntrustedCertificate);
+            var options = new AgentBundleOptions(address, port, key.Id.ToString(), _config.Agent.AllowUntrustedCertificate, _config.Agent.EnableTopCpuProcesses);
             var zip = AgentInstallerBundle.BuildZip(exeBytes, options);
 
             _logger.Info($"{CurrentUser?.Name} downloaded the HSM Agent bundle for product '{product.DisplayName}' ({productId}).");

--- a/src/server/HSMServer/Controllers/ConfigurationController.cs
+++ b/src/server/HSMServer/Controllers/ConfigurationController.cs
@@ -59,12 +59,15 @@ namespace HSMServer.Controllers
             if (ModelState.IsValid)
             {
                 var newUrl = settings.ExternalConnectionUrl?.Trim() ?? string.Empty;
-                if (config.Agent.ExternalConnectionUrl != newUrl || config.Agent.AllowUntrustedCertificate != settings.AllowUntrustedCertificate)
+                if (config.Agent.ExternalConnectionUrl != newUrl
+                    || config.Agent.AllowUntrustedCertificate != settings.AllowUntrustedCertificate
+                    || config.Agent.EnableTopCpuProcesses != settings.EnableTopCpuProcesses)
                 {
-                    _logger.Info($"SaveAgentSettings: {GetUserName()} changed Agent settings (URL '{config.Agent.ExternalConnectionUrl}' -> '{newUrl}', allowUntrustedCertificate {config.Agent.AllowUntrustedCertificate} -> {settings.AllowUntrustedCertificate})");
+                    _logger.Info($"SaveAgentSettings: {GetUserName()} changed Agent settings (URL '{config.Agent.ExternalConnectionUrl}' -> '{newUrl}', allowUntrustedCertificate {config.Agent.AllowUntrustedCertificate} -> {settings.AllowUntrustedCertificate}, enableTopCpuProcesses {config.Agent.EnableTopCpuProcesses} -> {settings.EnableTopCpuProcesses})");
 
                     config.Agent.ExternalConnectionUrl = newUrl;
                     config.Agent.AllowUntrustedCertificate = settings.AllowUntrustedCertificate;
+                    config.Agent.EnableTopCpuProcesses = settings.EnableTopCpuProcesses;
                     config.ResaveSettings();
                 }
             }

--- a/src/server/HSMServer/Model/Agent/AgentInstallerBundle.cs
+++ b/src/server/HSMServer/Model/Agent/AgentInstallerBundle.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -7,9 +8,10 @@ namespace HSMServer.Model.Agent
 {
     /// <summary>
     /// Parameters baked into one per-product agent bundle. <see cref="AccessKey"/> is the product's
-    /// access-key GUID (string) the agent sends in the <c>Key</c> header.
+    /// access-key GUID (string) the agent sends in the <c>Key</c> header. <see cref="EnableTopCpu"/>
+    /// adds a <c>topCpu</c> block so the installed agent also reports the top processes by CPU (#1175).
     /// </summary>
-    public sealed record AgentBundleOptions(string ServerAddress, int Port, string AccessKey, bool AllowUntrustedCertificate);
+    public sealed record AgentBundleOptions(string ServerAddress, int Port, string AccessKey, bool AllowUntrustedCertificate, bool EnableTopCpu = false);
 
     /// <summary>
     /// Builds the downloadable HSM Agent bundle (epic #1167, W7): a zip of the byte-identical signed
@@ -30,20 +32,35 @@ namespace HSMServer.Model.Agent
         /// <summary>The generated config.json — matches the agent's config schema (only address + key required).</summary>
         public static string BuildConfigJson(AgentBundleOptions options)
         {
-            var config = new
+            // A Dictionary (not an anonymous type) so the optional topCpu block can be added
+            // conditionally; each value's own property names serialize verbatim (camelCase as written).
+            var config = new Dictionary<string, object>
             {
-                server = new
+                ["server"] = new
                 {
                     address = options.ServerAddress,
                     port = options.Port,
                     accessKey = options.AccessKey,
                     allowUntrustedCertificate = options.AllowUntrustedCertificate,
                 },
-                identity = new
+                ["identity"] = new
                 {
                     computerName = "auto",
                 },
             };
+
+            if (options.EnableTopCpu)
+            {
+                // Server-side opt-in (Configuration → Agent). Ship the agent's topCpu defaults so the
+                // installed service reports the top processes by CPU once a minute.
+                config["topCpu"] = new
+                {
+                    enabled = true,
+                    periodMs = 60000,
+                    minPercent = 1.0,
+                    count = 10,
+                };
+            }
 
             return JsonSerializer.Serialize(config, _jsonOptions);
         }

--- a/src/server/HSMServer/Model/Agent/AgentInstallerBundle.cs
+++ b/src/server/HSMServer/Model/Agent/AgentInstallerBundle.cs
@@ -52,7 +52,8 @@ namespace HSMServer.Model.Agent
             if (options.EnableTopCpu)
             {
                 // Server-side opt-in (Configuration → Agent). Ship the agent's topCpu defaults so the
-                // installed service reports the top processes by CPU once a minute.
+                // installed service reports the top processes by CPU once a minute. NOTE: these defaults
+                // mirror AgentConfig in the agent (src/agent/include/agent/config.hpp) — keep in sync.
                 config["topCpu"] = new
                 {
                     enabled = true,

--- a/src/server/HSMServer/Model/Configuration/AgentSettingsViewModel.cs
+++ b/src/server/HSMServer/Model/Configuration/AgentSettingsViewModel.cs
@@ -11,12 +11,16 @@ namespace HSMServer.Model.Configuration
         [Display(Name = "Allow untrusted server certificate")]
         public bool AllowUntrustedCertificate { get; set; }
 
+        [Display(Name = "Report top processes by CPU")]
+        public bool EnableTopCpuProcesses { get; set; }
+
         public AgentSettingsViewModel() { }
 
         public AgentSettingsViewModel(IServerConfig config)
         {
             ExternalConnectionUrl = config.Agent.ExternalConnectionUrl;
             AllowUntrustedCertificate = config.Agent.AllowUntrustedCertificate;
+            EnableTopCpuProcesses = config.Agent.EnableTopCpuProcesses;
         }
     }
 }

--- a/src/server/HSMServer/ServerConfiguration/Sections/AgentConfig.cs
+++ b/src/server/HSMServer/ServerConfiguration/Sections/AgentConfig.cs
@@ -15,4 +15,11 @@ public class AgentConfig
     /// self-signed server certificate (the typical self-hosted / Docker eval case). Default false.
     /// </summary>
     public bool AllowUntrustedCertificate { get; set; }
+
+    /// <summary>
+    /// When true, downloaded bundles carry a <c>topCpu</c> block (issue #1175) so the installed agent
+    /// also reports the top processes by CPU once a minute. The admin opts in here (server-side); the
+    /// client agent has no UI and simply runs whatever config.json the bundle ships. Default false.
+    /// </summary>
+    public bool EnableTopCpuProcesses { get; set; }
 }

--- a/src/server/HSMServer/Views/Configuration/_Agent.cshtml
+++ b/src/server/HSMServer/Views/Configuration/_Agent.cshtml
@@ -31,6 +31,20 @@
     </div>
 </div>
 
+<div class="row mt-3">
+    <div class="col-3">
+        <label class="col-form-label" asp-for="EnableTopCpuProcesses"></label>
+    </div>
+    <div class="col-auto form-check form-switch ms-3 mt-2">
+        <input class="form-check-input" type="checkbox" asp-for="EnableTopCpuProcesses">
+    </div>
+</div>
+<div class="row">
+    <div class="offset-3 col-9">
+        <label class="note">Bake a <code>topCpu</code> block into downloaded bundles so the agent also reports the top processes by CPU once a minute (one <code>Top CPU processes/&lt;exe&gt;</code> sensor per busy app). Off by default.</label>
+    </div>
+</div>
+
 <div class="d-flex justify-content-end mt-2">
     <button type="submit" class="btn btn-primary independentSizeButton mt-1">Save</button>
 </div>

--- a/src/tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs
+++ b/src/tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs
@@ -30,6 +30,30 @@ namespace HSMServer.Core.Tests
         }
 
         [Fact]
+        public void ConfigJson_OmitsTopCpu_WhenDisabled()
+        {
+            var json = AgentInstallerBundle.BuildConfigJson(_options); // EnableTopCpu defaults to false
+
+            using var doc = JsonDocument.Parse(json);
+            Assert.False(doc.RootElement.TryGetProperty("topCpu", out _));
+        }
+
+        [Fact]
+        public void ConfigJson_CarriesTopCpu_WhenEnabled()
+        {
+            var options = _options with { EnableTopCpu = true };
+
+            var json = AgentInstallerBundle.BuildConfigJson(options);
+
+            using var doc = JsonDocument.Parse(json);
+            var topCpu = doc.RootElement.GetProperty("topCpu");
+            Assert.True(topCpu.GetProperty("enabled").GetBoolean());
+            Assert.Equal(60000, topCpu.GetProperty("periodMs").GetInt32());
+            Assert.Equal(10, topCpu.GetProperty("count").GetInt32());
+            Assert.Equal(1.0, topCpu.GetProperty("minPercent").GetDouble());
+        }
+
+        [Fact]
         public void Zip_ContainsExeConfigAndScripts()
         {
             var exeBytes = Encoding.ASCII.GetBytes("MZ-fake-signed-agent-binary");


### PR DESCRIPTION
## Summary

Opt-in (`topCpu.enabled`) periodic "top processes by CPU" for the HSM Agent. Once per `topCpu.periodMs` (default 60s) the agent samples per-process CPU, aggregates by **exe name** (all `chrome.exe` instances summed), and posts the busiest `topCpu.count` (default 10) names that are `>= topCpu.minPercent` (default 1.0) to `Top CPU processes/<exe>` Double sensors. Names not in the top list a given tick get **no value** → natural gaps in their series. Sensors are created lazily and cached by name.

- `src/agent/cpu_top.{hpp,cpp}`: portable `SelectTopN` (filter + top-N, deterministic tie-break) — unit-tested; Win32 `WindowsCpuSampler` (`#ifdef _WIN32`) — Toolhelp enum + `GetProcessTimes` delta, normalized to %CPU of the whole machine (÷ logical cores).
- `agent_runtime`: `RunTopCpuLoop` on its own thread; waits on the shared `cv_` (exits immediately on stop); joined before `Stop()`. Off-thread sensor creation is safe (the C-ABI registry is mutex-guarded).
- `config`: `topCpu.{enabled,periodMs,minPercent,count}` + `ReadDouble` + validation (only when enabled).
- Tests (3 new) + docs (`feature.md`, `README.md`, `hsm-agent.md`).

Aggregating by exe name (not PID / not PDH `#n` suffix) keeps a stable sensor identity over time. **Out of scope:** browser tab/site attribution (needs browser-level instrumentation; separate issue).

> Pairs with #1176 (agent static-linking, which missed the #1168 merge). Independent change; touches `src/agent/CMakeLists.txt` in a different region.

## Test plan
- [x] Unit: `SelectTopN` (threshold/cap/tie-break/empty) + `topCpu` config parse/reject — `ctest` green (12/12)
- [x] E2E: ran against a live Dockerized server — `Top CPU processes/<exe>` sensors appear (chrome.exe, claude.exe, yes.exe load-gen, …), fresh values for in-top-10 names, gaps for names that dropped out
- [ ] Reviewer: confirm CPU% normalization (0–100% of whole machine) reads sensibly in the UI

Closes #1175

🤖 Generated with [Claude Code](https://claude.com/claude-code)