### PR TITLE
Remove dead node-level alert remnants from _Alerts.cshtml

### DIFF
--- a/aicontext/features/server/alerts/feature.md
+++ b/aicontext/features/server/alerts/feature.md
@@ -1,6 +1,6 @@
 # Feature: Alerts
 
-> Owner: server | Last reviewed: 2026-06-23 | Canonical: yes
+> Owner: server | Last reviewed: 2026-06-24 | Canonical: yes
 > Scope: Server-side alert ownership, creation paths, and the boundary between global (template) and per-sensor alerts.
 
 ---
@@ -120,7 +120,6 @@ Condition view model guards live in `src/tests/HSMServer.Core.Tests/ConditionVie
 
 ## Known Issues / Limitations
 
-- `_Alerts.cshtml` still contains an unreachable `FolderInfoViewModel` branch. Removing it is a cleanup for a future PR.
 - `ProductInfoViewModel.DataAlerts` is still populated but never posted from the form; cleanup deferred to avoid rippling into import/export.
 - Switching a template's sensor type after adding alerts empties the unified alerts container (existing behavior for regular alerts; as of #1159 this also clears any TTL rows mixed in). Type changes are rare in practice; preserving TTL across type changes would require splitting the container.
 - Demoting a TTL alert (loaded from storage) to a regular alert via the property dropdown does not restore the schedule's "starting at" / "instant send" fields. Those fields are gated server-side by `Model.IsTtl` in `_ActionBlock.cshtml` and never render for TTL rows, so the client cannot show them after demote. Regular-to-TTL-to-regular works correctly because the fields exist in the DOM and are only hidden+disabled by the `.ttlAction` class on `.fullAction`. Workaround: save and reopen the editor.

--- a/src/server/HSMServer/Views/Home/Alerts/_Alerts.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_Alerts.cshtml
@@ -19,88 +19,36 @@
     // For a sensor, DataAlerts contains exactly one non-TTL entry keyed by (byte)Type (see
     // SensorNodeViewModel), plus the TTL entry keyed by ttlType. FirstOrDefault therefore
     // picks the sensor's concrete type unambiguously — used by both the Add button and the
-    // unified alerts container below. Unused for folder/product branches.
+    // unified alerts container below.
     var sensorType = Model.DataAlerts.FirstOrDefault(a => a.Key != ttlType).Key;
 }
 
 
-@if (Model is FolderInfoViewModel)
-{
-    <label class="col-form-label fw-bold">Alerts:</label>
+<div id="metaInfo_alerts" class="@(hasAlerts ? string.Empty : "d-none")">
+    <div class="d-flex justify-content-between align-items-center">
+        <div class="d-flex align-items-center">
+            <label class="col-form-label fw-bold">Alerts:</label>
 
-    <div class="d-flex flex-row text-nowrap align-items-center ms-3">
-        <span class="meta-info-label">Time to sensor(s) live</span>
-
-        <span id="folder_ttlLabel" class="meta-info-value">@Model.ExpectedUpdateInterval.DisplayValue</span>
-        <div id="folder_ttl" class="d-none meta-info-interval">
-            <partial name="_TimeIntervalSelect" for="ExpectedUpdateInterval" />
-        </div>
-
-        <i class='fas fa-question-circle mx-2' title='Time format: dd.hh:mm:ss min value 00:01:00. If the sensor doesn`t receive new data within the specified time interval, a notification sends'></i>
-        <span asp-validation-for="ExpectedUpdateInterval"></span>
-    </div>
-}
-else
-{
-    <div id="metaInfo_alerts" class="@(hasAlerts ? string.Empty : "d-none")">
-        <div class="d-flex justify-content-between align-items-center">
-            <div class="d-flex align-items-center">
-                <label class="col-form-label fw-bold">Alerts:</label>
-
-                @if (Model is SensorInfoViewModel)
-                {
-                    <a id="addDataAlert" href="javascript:addDataAlert('@sensorType', '@Model.EncodedId');" class="d-none btn btn-link p-0 m-0 ms-2">
-                        <i class="fa-solid fa-plus"></i> Add
-                    </a>
-                }
-            </div>
-
-            <a id="commentHelp" data-bs-toggle="popover" title="Custom comment variables" data-bs-html="true" data-bs-content="@DataAlertCommentHelper.CreateCommentHelp()" class="d-none help-popover">
-                Comment help
+            <a id="addDataAlert" href="javascript:addDataAlert('@sensorType', '@Model.EncodedId');" class="d-none btn btn-link p-0 m-0 ms-2">
+                <i class="fa-solid fa-plus"></i> Add
             </a>
         </div>
 
-        @if (Model is SensorInfoViewModel sensorInfo)
-        {
-            // Unified list: regular + TTL alerts in one container. Each row's data-alert-type
-            // attribute (set in _DataAlert.cshtml) tells form collection whether to route to
-            // TTL (255) or sensor-type storage.
-            <div id="dataAlertsList_@sensorType">
-                @foreach (var (_, alerts) in sensorInfo.DataAlerts)
-                {
-                    @foreach (var alert in alerts)
-                    {
-                        @await Html.PartialAsync("~/Views/Home/Alerts/_DataAlert.cshtml", alert)
-                    }
-                }
-            </div>
-        }
-        else
-        {
-            @foreach (var (type, alerts) in Model.DataAlerts)
-            {
-                <div id="dataAlertsList_@type" class="@(alerts.Count == 0 ? "d-none" : string.Empty)">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <div>
-                            <label class="col-form-label fw-bold">@type alerts:</label>
-                            <a id="addDataAlert" href="javascript:addDataAlert('@type', '@Model.EncodedId');" class="d-none mx-2">
-                                <i class="fa-solid fa-plus"></i> Add
-                            </a>
-                        </div>
-                        <a id="commentHelp" data-bs-toggle="popover" title="Custom comment variables" data-bs-html="true" data-bs-content="@DataAlertCommentHelper.CreateCommentHelp()" class="d-none help-popover">
-                            Comment help
-                        </a>
-                    </div>
+        <a id="commentHelp" data-bs-toggle="popover" title="Custom comment variables" data-bs-html="true" data-bs-content="@DataAlertCommentHelper.CreateCommentHelp()" class="d-none help-popover">
+            Comment help
+        </a>
+    </div>
 
-                    @foreach (var alert in alerts)
-                    {
-                        @await Html.PartialAsync("~/Views/Home/Alerts/_DataAlert.cshtml", alert)
-                    }
-                </div>
+    <div id="dataAlertsList_@sensorType">
+        @foreach (var (_, alerts) in Model.DataAlerts)
+        {
+            @foreach (var alert in alerts)
+            {
+                @await Html.PartialAsync("~/Views/Home/Alerts/_DataAlert.cshtml", alert)
             }
         }
     </div>
-}
+</div>
 
 
 <script>
@@ -109,12 +57,6 @@ else
         var popoverList = popoverTriggerList.map(function(popoverTriggerEl) {
             return new bootstrap.Popover(popoverTriggerEl);
         });
-
-        if ('@(Model is SensorInfoViewModel)' !== "True") {
-            $("a.showMessage").each(function () {
-                $(this).addClass("d-none");
-            });
-        }
     });
 
     $('#commentHelp').on('show.bs.popover', () => {

--- a/src/server/HSMServer/wwwroot/src/js/metaInfo.js
+++ b/src/server/HSMServer/wwwroot/src/js/metaInfo.js
@@ -27,14 +27,12 @@ window.editInfoButtonClick = function () {
     $('#emaStatisticsSwitch').attr("disabled", false);
     $('#singletonSwitch').attr("disabled", false);
 
-    $('#folder_ttl').removeClass('d-none');
     $('#node_ttl').removeClass('d-none');
     $('#partialSavedHistorySelect').removeClass('d-none');
     $('#partialSelfDestroySelect').removeClass('d-none');
     $('#defaultChatControl').removeClass('d-none');
     $('[id^="alertConstructor_"]').removeClass('d-none');
 
-    $('#folder_ttlLabel').addClass('d-none');
     $('#node_ttlLabel').addClass('d-none');
     $('#labelSavedHistory').addClass('d-none');
     $('#labelSelfDestroy').addClass('d-none');


### PR DESCRIPTION
## Summary

- Epic #1141's acceptance criteria were already met by #1142 / PR #1158, but the epic stayed open while `_Alerts.cshtml` still carried the dead code that #1142 left behind. This PR removes it and closes the epic.
- `_Alerts.cshtml` is gated to `SensorInfoViewModel` (`_MetaInfo.cshtml:126`), so the `FolderInfoViewModel` TTL branch, the generic per-type `else`, the `SensorInfoViewModel` guards, and the `showMessage` JS block were all unreachable. Removed.
- The `#folder_ttl` / `#folder_ttlLabel` selectors in `metaInfo.js` referenced ids that only existed in the removed folder branch and were already no-ops — the canonical TTL editor is `#node_ttl` in `_GeneralInfo.cshtml:35-36`. Removed.
- `feature.md` Known Issues: dropped the now-resolved "unreachable `FolderInfoViewModel` branch" entry. Kept the deferred `ProductInfoViewModel.DataAlerts` item (ripples into import/export, intentionally out of scope).

Net: 3 files, −61 lines of dead code. No behavior change.

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.csproj` — 0 errors (Razor views compile; webpack rebuilt the frontend bundle cleanly).
- [x] `dotnet test src/tests/HSMServer.Core.Tests/HSMServer.Core.Tests.csproj --filter "FullyQualifiedName~ConditionViewModelPropertiesTests|FullyQualifiedName~ProductOwnedPolicyCleanupTests"` — 19/19 pass.
- [ ] Manual smoke (operator): Sensor page renders the Add button + unified alert list and new rows still default to TTL; Folder/Product pages show no `_Alerts.cshtml` output and TTL is still editable under "Inactivity Period" via `#node_ttl` in `_GeneralInfo.cshtml`.

Closes #1141

🤖 Generated with [Claude Code](https://claude.com/claude-code)