### PR TITLE
Slack destination registry (PR2 of #1144)

### DIFF
--- a/aicontext/features/server/notifications/feature.md
+++ b/aicontext/features/server/notifications/feature.md
@@ -1,0 +1,70 @@
+# Feature: Notifications
+
+> Owner: server | Last reviewed: 2026-06-24 | Canonical: yes
+> Scope: Outbound alert delivery destinations (Telegram today, Slack registry in progress) and the managers that own their lifecycle.
+
+---
+
+## Overview
+
+HSM notifications are the delivery side of alerts: when a policy fires, a destination receives the rendered alert message. Today the only wired channel is Telegram (bot-driven, per-chat). The Slack support epic (#1144) adds Slack as a second channel using the **Incoming Webhook per channel** model — each Slack destination is one webhook URL, no bot token or OAuth.
+
+Delivery is staged across multiple PRs:
+- **PR1** introduces an `INotificationChannel` abstraction and refactors Telegram behind it (behavior-preserving).
+- **PR2** (this doc, as of last review) adds the Slack destination **registry only**: storage, domain model, and a manager. No delivery, no policy wiring, no UI yet.
+- **PR3** will add `SlackNotificationChannel` delivery + diagnostics.
+- **PR4** will add the management UI and the alert-action destination-kind selector.
+
+## Slack destination registry (PR2 scope)
+
+### Invariants
+
+- A Slack destination = `(Id, Name, WebhookUrl, SendMessages, AuthorId, AddedAt)`. One webhook URL per destination; one Slack channel per webhook.
+- `SlackDestination.SendMessages` defaults to `true` on construction via `SlackAddRequest`. A destination can be disabled without being removed by setting `SendMessages = false`.
+- Storage is **additive and independent** of the existing Telegram `Chats` dictionary on `PolicyDestination`. PR2 introduces no changes to `PolicyDestination`, `PolicyEntity`, or alert routing — those land in PR3/PR4.
+- `ISlackDestinationsManager` follows the same `ConcurrentStorage<Model, Entity, Update>` lifecycle as `ITelegramChatsManager`: `Initialize()` loads all rows from LevelDB into memory; `TryAdd` / `TryUpdate` / `TryRemove` persist synchronously and update the in-memory cache.
+- The LevelDB id-list key is `"SlackDestinations"` (UTF-8 bytes), paralleling the `"TelegramChats"` key. Per-destination entities are keyed by `byte[]` Guid under their own LevelDB family.
+
+### API / Public Contracts
+
+| Contract | Location | Notes |
+|---|---|---|
+| `ISlackDestinationsManager` | `src/server/HSMServer/Notifications/Slack/ISlackDestinationsManager.cs` | Empty marker interface over `IConcurrentStorage<SlackDestination, SlackDestinationEntity, SlackDestinationUpdate>`. |
+| `SlackDestinationsManager` | `src/server/HSMServer/Notifications/Slack/SlackDestinationsManager.cs` | Sealed `ConcurrentStorage<...>` impl; ctor takes `IDatabaseCore`. |
+| `SlackDestination` | `src/server/HSMServer/Notifications/Slack/SlackDestination.cs` | `BaseServerModel<SlackDestinationEntity, SlackDestinationUpdate>`. Public ctor from `SlackAddRequest`; internal ctor from entity. |
+| `SlackAddRequest` | `src/server/HSMServer/Notifications/Slack/SlackAddRequest.cs` | `BaseAddRequest` (required `AuthorId`) + required `WebhookUrl`. |
+| `SlackDestinationUpdate` | `src/server/HSMServer/Notifications/Slack/SlackDestinationUpdate.cs` | `BaseUpdateRequest` (required `Id`) + nullable `WebhookUrl`, nullable `SendMessages`. |
+| `IDatabaseCore` Slack methods | `src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs` | `AddSlackDestination`, `UpdateSlackDestination`, `RemoveSlackDestination`, `GetSlackDestination`, `GetSlackDestinations`. Mirror of the Telegram chat block. |
+
+### Key Files
+
+| File | Purpose |
+|---|---|
+| `src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/SlackDestinationEntity.cs` | Persisted record: `WebhookUrl`, `SendMessages` (+ `BaseServerEntity` fields). Mutable setters (mirrors `TelegramChatEntity`). |
+| `src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs` | `"SlackDestinations"` id-list key + JSON-serialized entity read/write. Mirrors Telegram chats. |
+| `src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs` | `IDatabaseCore` Slack impl: add = list + entity; update = re-add entity; remove = entity + list. |
+| `src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs` | Registers `ISlackDestinationsManager` via `AddAsyncStorage<...>` so `InitStorages` calls `Initialize()`. |
+
+### Storage / Persistence
+
+- **LevelDB family**: per-destination entities keyed by `byte[]` Guid.
+- **Id-list**: a single JSON array of Guids under the `"SlackDestinations"` key in the environment database. Read once on `Initialize()`, mutated on add/remove.
+- **Round-trip**: `SlackDestination.ToEntity()` ↔ `SlackDestination(SlackDestinationEntity)`. The DB-backed test (`SlackDestinationsManagerTests.Add_Update_Remove_PersistsThroughLevelDB`) reloads via a second manager instance to verify the entity→model mapping path that runs on real server startup.
+
+### Tests
+
+- `src/tests/HSMServer.Core.Tests/Notifications/SlackDestinationRoundTripTests.cs` — `ToEntity()` field mapping + default `SendMessages = true`.
+- `src/tests/HSMServer.Core.Tests/MonitoringCoreTests/SlackDestinationsManagerTests.cs` — DB-backed add/update/remove with reload-from-LevelDB to verify `FromEntity` persistence.
+
+## Out of scope for PR2
+
+- No `SlackNotificationChannel` / HTTP delivery (PR3).
+- No `PolicyDestination.Kind = Slack` wiring, no alert routing (PR3).
+- No management UI, no `_ActionBlock.cshtml` destination-kind selector (PR4).
+- No import/export of Slack destinations (PR4).
+- No diagnostics node (PR3).
+
+## Dependencies
+
+- Depends on: `ConcurrentStorage<...>` base, `IDatabaseCore` + `EnvironmentDatabaseWorker` (LevelDB), `BaseServerModel<...>` / `BaseServerEntity` / `BaseAddRequest` / `BaseUpdateRequest`.
+- Used by: (none yet at runtime — manager is registered but has no consumers until PR3).

--- a/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/SlackDestinationEntity.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/SlackDestinationEntity.cs
@@ -1,0 +1,11 @@
+using HSMDatabase.AccessManager.DatabaseEntities.VisualEntity;
+
+namespace HSMDatabase.AccessManager.DatabaseEntities
+{
+    public sealed record SlackDestinationEntity : BaseServerEntity
+    {
+        public string WebhookUrl { get; set; }
+
+        public bool SendMessages { get; set; }
+    }
+}

--- a/src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs
@@ -126,6 +126,16 @@ namespace HSMServer.Core.DataLayer
 
         #endregion
 
+        #region Slack destination
+
+        void AddSlackDestination(SlackDestinationEntity destination);
+        void UpdateSlackDestination(SlackDestinationEntity destination);
+        void RemoveSlackDestination(byte[] id);
+        SlackDestinationEntity GetSlackDestination(byte[] id);
+        List<SlackDestinationEntity> GetSlackDestinations();
+
+        #endregion
+
         #region Alert Templates
         List<AlertTemplateEntity> GetAllAlertTemplates();
         void AddAlertTemplate(AlertTemplateEntity policy);

--- a/src/database/HSMDatabase.AccessManager/IEnvironmentDatabase.cs
+++ b/src/database/HSMDatabase.AccessManager/IEnvironmentDatabase.cs
@@ -84,6 +84,17 @@ namespace HSMDatabase.AccessManager
 
         #endregion
 
+        #region Slack destinations
+
+        List<byte[]> GetSlackDestinationsList();
+        SlackDestinationEntity GetSlackDestination(byte[] id);
+        void AddSlackDestination(SlackDestinationEntity destination);
+        void RemoveSlackDestination(byte[] id);
+        void AddSlackDestinationToList(byte[] id);
+        void RemoveSlackDestinationFromList(byte[] id);
+
+        #endregion
+
         #region Alert templates
 
         List<byte[]> GetAllAlertTemplatesIds();

--- a/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
+++ b/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
@@ -25,6 +25,7 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
         private readonly byte[] _policyIdsKey = "NewPolicyIds"u8.ToArray();
         private readonly byte[] _folderIdsKey = "FolderIds"u8.ToArray();
         private readonly byte[] _telegramChatIdsKey = "TelegramChats"u8.ToArray();
+        private readonly byte[] _slackDestinationIdsKey = "SlackDestinations"u8.ToArray();
         private readonly byte[] _alertTemplatesIdsKey = "AlertTemplates"u8.ToArray();
         private readonly byte[] _alertScheduleIdsKey = "AlertSchedule"u8.ToArray();
 
@@ -658,6 +659,85 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
             catch (Exception e)
             {
                 _logger.Error(e, $"Failed to remove telegram chat id {chatId} from list");
+            }
+        }
+
+        #endregion
+
+        #region Slack destinations
+
+        public List<byte[]> GetSlackDestinationsList() => GetListOfBytes(_slackDestinationIdsKey, "Failed to get slack destinations ids list");
+
+        public SlackDestinationEntity GetSlackDestination(byte[] id)
+        {
+            try
+            {
+                return _database.TryRead(id, out byte[] value)
+                    ? JsonSerializer.Deserialize<SlackDestinationEntity>(Encoding.UTF8.GetString(value))
+                    : null;
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to read info for slack destination {new Guid(id)}");
+            }
+
+            return null;
+        }
+
+        public void AddSlackDestination(SlackDestinationEntity destination)
+        {
+            try
+            {
+                _database.Put(destination.Id, JsonSerializer.SerializeToUtf8Bytes(destination));
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to add slack destination info for {destination.Id}");
+            }
+        }
+
+        public void RemoveSlackDestination(byte[] id)
+        {
+            try
+            {
+                _database.Delete(id);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to remove info for slack destination {new Guid(id)}");
+            }
+        }
+
+        public void AddSlackDestinationToList(byte[] id)
+        {
+            try
+            {
+                var currentList = GetSlackDestinationsList();
+
+                if (!currentList.Contains(id))
+                    currentList.Add(id);
+
+                _database.Put(_slackDestinationIdsKey, JsonSerializer.SerializeToUtf8Bytes(currentList));
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to add slack destination id to list");
+            }
+        }
+
+        public void RemoveSlackDestinationFromList(byte[] id)
+        {
+            try
+            {
+                var currentList = GetSlackDestinationsList();
+
+                currentList.Remove(id);
+
+                _database.Put(_slackDestinationIdsKey, JsonSerializer.SerializeToUtf8Bytes(currentList));
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to remove slack destination id {id} from list");
             }
         }
 

--- a/src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs
+++ b/src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs
@@ -549,6 +549,41 @@ namespace HSMDatabase.DatabaseWorkCore
 
         #endregion
 
+        #region Environment database : Slack destination
+
+        public void AddSlackDestination(SlackDestinationEntity destination)
+        {
+            _environmentDatabase.AddSlackDestinationToList(destination.Id);
+            _environmentDatabase.AddSlackDestination(destination);
+        }
+
+        public void UpdateSlackDestination(SlackDestinationEntity destination) => _environmentDatabase.AddSlackDestination(destination);
+
+        public void RemoveSlackDestination(byte[] id)
+        {
+            _environmentDatabase.RemoveSlackDestination(id);
+            _environmentDatabase.RemoveSlackDestinationFromList(id);
+        }
+
+        public SlackDestinationEntity GetSlackDestination(byte[] id) => _environmentDatabase.GetSlackDestination(id);
+
+        public List<SlackDestinationEntity> GetSlackDestinations()
+        {
+            var destinations = new List<SlackDestinationEntity>(1 << 4);
+            var ids = _environmentDatabase.GetSlackDestinationsList();
+
+            foreach (var id in ids)
+            {
+                var entity = _environmentDatabase.GetSlackDestination(id);
+                if (entity != null)
+                    destinations.Add(entity);
+            }
+
+            return destinations;
+        }
+
+        #endregion
+
         #region Journal
 
         public void AddJournalValue(JournalKey journalKey, JournalRecordEntity value)

--- a/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
+++ b/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
@@ -51,6 +51,7 @@ namespace HSMServer.ServiceExtensions
             services.AddAsyncStorage<IUserManager, UserManager>()
                     .AddAsyncStorage<IFolderManager, FolderManager>()
                     .AddAsyncStorage<ITelegramChatsManager, TelegramChatsManager>()
+                    .AddAsyncStorage<ISlackDestinationsManager, SlackDestinationsManager>()
                     .AddAsyncStorage<IDashboardManager, DashboardManager>();
 
             services.AddSingleton<DataCollectorWrapper>()

--- a/src/server/HSMServer/Notifications/Slack/ISlackDestinationsManager.cs
+++ b/src/server/HSMServer/Notifications/Slack/ISlackDestinationsManager.cs
@@ -1,0 +1,9 @@
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.ConcurrentStorage;
+
+namespace HSMServer.Notifications
+{
+    public interface ISlackDestinationsManager : IConcurrentStorage<SlackDestination, SlackDestinationEntity, SlackDestinationUpdate>
+    {
+    }
+}

--- a/src/server/HSMServer/Notifications/Slack/SlackAddRequest.cs
+++ b/src/server/HSMServer/Notifications/Slack/SlackAddRequest.cs
@@ -1,0 +1,9 @@
+using HSMServer.ConcurrentStorage;
+
+namespace HSMServer.Notifications
+{
+    public record SlackAddRequest : BaseAddRequest
+    {
+        public required string WebhookUrl { get; init; }
+    }
+}

--- a/src/server/HSMServer/Notifications/Slack/SlackDestination.cs
+++ b/src/server/HSMServer/Notifications/Slack/SlackDestination.cs
@@ -1,0 +1,45 @@
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.ConcurrentStorage;
+
+namespace HSMServer.Notifications
+{
+    public sealed class SlackDestination : BaseServerModel<SlackDestinationEntity, SlackDestinationUpdate>
+    {
+        private const bool DefaultSendMessages = true;
+
+
+        public string WebhookUrl { get; private set; }
+
+        public bool SendMessages { get; private set; }
+
+
+        public SlackDestination(SlackAddRequest add) : base(add)
+        {
+            WebhookUrl = add.WebhookUrl;
+            SendMessages = DefaultSendMessages;
+        }
+
+        internal SlackDestination(SlackDestinationEntity entity) : base(entity)
+        {
+            WebhookUrl = entity.WebhookUrl;
+            SendMessages = entity.SendMessages;
+        }
+
+
+        protected override void ApplyUpdate(SlackDestinationUpdate update)
+        {
+            WebhookUrl = update.WebhookUrl ?? WebhookUrl;
+            SendMessages = update.SendMessages ?? SendMessages;
+        }
+
+        public override SlackDestinationEntity ToEntity()
+        {
+            var entity = base.ToEntity();
+
+            entity.WebhookUrl = WebhookUrl;
+            entity.SendMessages = SendMessages;
+
+            return entity;
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/Slack/SlackDestinationUpdate.cs
+++ b/src/server/HSMServer/Notifications/Slack/SlackDestinationUpdate.cs
@@ -1,0 +1,11 @@
+using HSMServer.ConcurrentStorage;
+
+namespace HSMServer.Notifications
+{
+    public record SlackDestinationUpdate : BaseUpdateRequest
+    {
+        public string WebhookUrl { get; init; }
+
+        public bool? SendMessages { get; init; }
+    }
+}

--- a/src/server/HSMServer/Notifications/Slack/SlackDestinationsManager.cs
+++ b/src/server/HSMServer/Notifications/Slack/SlackDestinationsManager.cs
@@ -1,0 +1,28 @@
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.ConcurrentStorage;
+using HSMServer.Core.DataLayer;
+using System;
+using System.Collections.Generic;
+
+namespace HSMServer.Notifications
+{
+    public sealed class SlackDestinationsManager : ConcurrentStorage<SlackDestination, SlackDestinationEntity, SlackDestinationUpdate>, ISlackDestinationsManager
+    {
+        private readonly IDatabaseCore _database;
+
+
+        protected override Action<SlackDestinationEntity> AddToDb => _database.AddSlackDestination;
+
+        protected override Action<SlackDestinationEntity> UpdateInDb => _database.UpdateSlackDestination;
+
+        protected override Action<SlackDestination> RemoveFromDb => destination => _database.RemoveSlackDestination(destination.Id.ToByteArray());
+
+        protected override Func<List<SlackDestinationEntity>> GetFromDb => _database.GetSlackDestinations;
+
+
+        public SlackDestinationsManager(IDatabaseCore database) => _database = database;
+
+
+        protected override SlackDestination FromEntity(SlackDestinationEntity entity) => new(entity);
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
+++ b/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
@@ -111,6 +111,12 @@ namespace HSMServer.Core.Tests.Infrastructure
         public TelegramChatEntity GetTelegramChat(byte[] chatId) => _inner.GetTelegramChat(chatId);
         public List<TelegramChatEntity> GetTelegramChats() => _inner.GetTelegramChats();
 
+        public void AddSlackDestination(SlackDestinationEntity destination) => _inner.AddSlackDestination(destination);
+        public void UpdateSlackDestination(SlackDestinationEntity destination) => _inner.UpdateSlackDestination(destination);
+        public void RemoveSlackDestination(byte[] id) => _inner.RemoveSlackDestination(id);
+        public SlackDestinationEntity GetSlackDestination(byte[] id) => _inner.GetSlackDestination(id);
+        public List<SlackDestinationEntity> GetSlackDestinations() => _inner.GetSlackDestinations();
+
         public List<AlertTemplateEntity> GetAllAlertTemplates() => _inner.GetAllAlertTemplates();
         public void AddAlertTemplate(AlertTemplateEntity policy) => _inner.AddAlertTemplate(policy);
         public void RemoveAlertTemplate(Guid id) => _inner.RemoveAlertTemplate(id);

--- a/src/tests/HSMServer.Core.Tests/MonitoringCoreTests/Fixture/SlackDestinationsFixture.cs
+++ b/src/tests/HSMServer.Core.Tests/MonitoringCoreTests/Fixture/SlackDestinationsFixture.cs
@@ -1,0 +1,7 @@
+namespace HSMServer.Core.Tests.MonitoringCoreTests.Fixture
+{
+    public class SlackDestinationsFixture : DatabaseFixture
+    {
+        protected override string DatabaseFolder => "SlackDestinations";
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/MonitoringCoreTests/SlackDestinationsManagerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/MonitoringCoreTests/SlackDestinationsManagerTests.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Linq;
+using HSMServer.ConcurrentStorage;
+using HSMServer.Core.TableOfChanges;
+using HSMServer.Core.Tests.MonitoringCoreTests.Fixture;
+using HSMServer.Notifications;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace HSMServer.Core.Tests.MonitoringCoreTests
+{
+    [Collection("Database collection")]
+    public class SlackDestinationsManagerTests : MonitoringCoreTestsBase<SlackDestinationsFixture>
+    {
+        public SlackDestinationsManagerTests(SlackDestinationsFixture fixture, DatabaseRegisterFixture registerFixture)
+            : base(fixture, registerFixture) { }
+
+
+        [Fact]
+        public async Task Add_Update_Remove_PersistsThroughLevelDB()
+        {
+            var db = _databaseCoreManager.DatabaseCore;
+
+            var manager = new SlackDestinationsManager(db);
+            await manager.Initialize();
+            Assert.Empty(manager.GetValues());
+
+            var destination = new SlackDestination(new SlackAddRequest
+            {
+                AuthorId = Guid.NewGuid(),
+                Name = "alerts",
+                WebhookUrl = "https://hooks.slack.com/services/X",
+            });
+
+            Assert.True(await manager.TryAdd(destination));
+            Assert.Single(manager.GetValues());
+
+            Assert.True(await manager.TryUpdate(new SlackDestinationUpdate
+            {
+                Id = destination.Id,
+                Name = "alerts-renamed",
+                WebhookUrl = "https://hooks.slack.com/services/Y",
+                SendMessages = false,
+            }));
+
+            // Reload from LevelDB -> verifies entity<->model mapping (FromEntity) + persistence.
+            var reloaded = new SlackDestinationsManager(db);
+            await reloaded.Initialize();
+
+            var loaded = Assert.Single(reloaded.GetValues());
+            Assert.Equal("alerts-renamed", loaded.Name);
+            Assert.Equal("https://hooks.slack.com/services/Y", loaded.WebhookUrl);
+            Assert.False(loaded.SendMessages);
+
+            Assert.True(await reloaded.TryRemove(new RemoveRequest(destination.Id, InitiatorInfo.System)));
+            Assert.Empty(reloaded.GetValues());
+
+            var afterRemove = new SlackDestinationsManager(db);
+            await afterRemove.Initialize();
+            Assert.Empty(afterRemove.GetValues());
+        }
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/Notifications/SlackDestinationRoundTripTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/SlackDestinationRoundTripTests.cs
@@ -1,0 +1,40 @@
+using System;
+using HSMServer.Notifications;
+using Xunit;
+
+namespace HSMServer.Core.Tests.Notifications
+{
+    public class SlackDestinationRoundTripTests
+    {
+        [Fact]
+        public void ToEntity_MapsModelFieldsToEntity()
+        {
+            var destination = new SlackDestination(new SlackAddRequest
+            {
+                AuthorId = Guid.NewGuid(),
+                Name = "alerts",
+                WebhookUrl = "https://hooks.slack.com/services/X",
+            });
+
+            var entity = destination.ToEntity();
+
+            Assert.Equal("alerts", entity.Name);
+            Assert.Equal("https://hooks.slack.com/services/X", entity.WebhookUrl);
+            Assert.True(entity.SendMessages);
+            Assert.Equal(destination.Id, new Guid(entity.Id));
+        }
+
+        [Fact]
+        public void NewDestination_DefaultsSendMessagesTrue()
+        {
+            var destination = new SlackDestination(new SlackAddRequest
+            {
+                AuthorId = Guid.NewGuid(),
+                Name = "alerts",
+                WebhookUrl = "https://hooks.slack.com/services/X",
+            });
+
+            Assert.True(destination.SendMessages);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second PR of the Slack support epic (#1144). Adds the **storage, domain, and manager** for Slack alert destinations using the Incoming-Webhook-per-channel model. No delivery, policy wiring, or UI yet — those land in PR3/PR4.

- New `SlackDestinationEntity` + `IDatabaseCore` Slack CRUD methods + `EnvironmentDatabaseWorker` `"SlackDestinations"` id-list (mirrors the Telegram chat block).
- `SlackDestination` model + `SlackAddRequest` / `SlackDestinationUpdate` DTOs + `ISlackDestinationsManager` / `SlackDestinationsManager` (uses the `ConcurrentStorage<...>` base).
- `ISlackDestinationsManager` registered via `AddAsyncStorage` so `InitStorages` calls `Initialize()`.
- DB-backed CRUD test reloads via a second manager instance to verify the `FromEntity` round-trip on real LevelDB.
- `aicontext/features/server/notifications/feature.md` scoped to the registry.

Closes #1183.

## Storage compatibility

Additive only. No changes to `PolicyDestination`, `PolicyEntity`, `PolicyDestinationEntity`, or alert routing. The existing Telegram `Chats` dictionary is untouched. The new `"SlackDestinations"` LevelDB key is independent of every existing key.

## Out of scope (deferred)

- `SlackNotificationChannel` HTTP delivery + retry/backoff (PR3).
- `PolicyDestination.Kind = Slack` wiring and `NotificationsCenter` channel-list integration (PR3).
- Slack diagnostics node (PR3).
- Management UI + `_ActionBlock.cshtml` destination-kind selector + import/export (PR4).

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.csproj` — 0 errors.
- [x] `dotnet build src/tests/HSMServer.Core.Tests/HSMServer.Core.Tests.csproj` — 0 errors.
- [x] `SlackDestinationRoundTripTests` (2 tests) — ToEntity mapping + default `SendMessages = true`.
- [x] `SlackDestinationsManagerTests.Add_Update_Remove_PersistsThroughLevelDB` — DB-backed add/update/remove with reload-from-LevelDB.
- [x] Regression: `TemplateConcurrencyTests` + `AlertTemplatePartialFailureTests` + `HomeControllerAddDataPolicyTests` (8 tests) — green.
- [ ] Manual smoke: server boots, `ISlackDestinationsManager.Initialize()` runs cleanly against an empty LevelDB.

## Related

- Epic: #1144
- PR1 (channel abstraction): #1182
- Child issue: #1183