### PR TITLE
Slack webhook delivery channel + diagnostics (PR3 of #1144)

### DIFF
--- a/aicontext/features/server/notifications/feature.md
+++ b/aicontext/features/server/notifications/feature.md
@@ -68,7 +68,38 @@ NotificationsBackgroundService (timer) -> NotificationsCenter.SendAllMessagesAsy
 - `src/tests/HSMServer.Core.Tests/Notifications/PolicyDestinationKindTests.cs` — `Kind` round-trips through `ToEntity()` -> ctor; missing/empty `Kind` deserializes to `Telegram`; `Slack` and `Telegram` values survive the round-trip.
 - Existing destination/policy tests stay green with no assertion changes: `TreeValuesCacheTests/TemplateConcurrencyTests.cs`, `TreeValuesCacheTests/AlertTemplatePartialFailureTests.cs`, `Controllers/HomeControllerAddDataPolicyTests.cs`.
 
-## Notes
+## Slack delivery (PR3 scope)
 
-- This seam is the behavior-preserving foundation (PR 1 of 4) for adding Slack as a notification destination under epic #1144. No Slack code is introduced here.
-- Planned follow-ups (separate PRs): Slack destination storage + config (PR2), Slack webhook delivery channel + diagnostics (PR3), Slack management UI + alert-action destination selector + docs (PR4).
+`SlackNotificationChannel : INotificationChannel` (`src/server/HSMServer/Notifications/Slack/SlackNotificationChannel.cs`) is wired into `NotificationsCenter._channels` alongside the Telegram channel. Each channel filters by `Kind` so Telegram and Slack do not cross-fire.
+
+### Destination filtering
+
+`AlertDestination` gained a `NotificationKind Kind` property, populated from `policy.Destination.Kind` in the `AlertDestination(Policy)` ctor. `TelegramBot.DeliverAsync` skips alerts whose `Kind != Telegram`; `SlackNotificationChannel.DeliverAsync` skips alerts whose `Kind != Slack`. This is the only behavior change to the Telegram path: previously Telegram delivered every alert regardless of `Kind`, but since pre-PR3 policies are all `Telegram`, no observable behavior regresses.
+
+### HTTP delivery contract
+
+- One `HttpClient` per channel instance, registered via `services.AddHttpClient<SlackNotificationChannel>()` in `ApplicationServiceExtensions`. Default request timeout: 30 s.
+- One POST per `(alert, destination)` pair. No aggregation — Slack webhooks take one payload per call, so the Telegram-style per-chat aggregation is not applicable.
+- Payload shape: `SlackMessageBuilder.BuildPayload(alert)` produces `{"text":"<alert.ToString()>"}` (System.Text.Json, camelCase). Rich blocks are explicitly out of scope for v1.
+- Retry policy: up to 3 attempts (1 initial + 2 retries). Transient failures (HTTP 5xx and `RequestTimeout`) are retried with exponential backoff (initial 2 s, doubled per retry). 4xx responses are terminal — Slack returns 200 on success and various 4xx for malformed payloads or revoked webhooks, so retrying would not help. Network errors (`HttpRequestException`) and timeouts (`TaskCanceledException`) are retried like 5xx.
+- `DeliverAsync` does not throw — every terminal failure is funneled through `ErrorHandled` and logged, matching the Telegram channel's contract.
+
+### Events (mirroring TelegramBot)
+
+- `event Action MessageSending` — raised once per POST attempt.
+- `event Action<string, string> MessageSended` — `(destinationName, payload)` on HTTP 200.
+- `event Action<string> ErrorHandled` — `(message)` on terminal failure or per-retry warning.
+
+### Diagnostics
+
+`SlackChannelStatistics` (`src/server/HSMServer/BackgroundServices/DatacollectorService/Nodes/SlackChannelStatistics.cs`) mirrors `TelegramBotStatistics` under NodeName `"Slack"`:
+
+- `Slack/Errors` — string sensor aggregating error messages.
+- `Slack/Total` — per-minute rate of POST attempts.
+- `Slack/Messages/<destinationName>` — per-destination string sensor with the last delivered payload.
+
+`DataCollectorWrapper` instantiates `SlackChannelStatistics` alongside `TelegramBotStatistics` and subscribes/unsubscribes the three channel events symmetrically to the Telegram wiring.
+
+### Storage
+
+Unchanged from PR2. `SlackDestinationEntity` rows under the `"SlackDestinations"` LevelDB key, accessed via `ISlackDestinationsManager`. The channel resolves webhook URLs from this registry at delivery time.

--- a/src/server/HSMServer.Core/Model/Policies/Alerts/AlertResult.cs
+++ b/src/server/HSMServer.Core/Model/Policies/Alerts/AlertResult.cs
@@ -1,4 +1,5 @@
 ﻿using HSMServer.Core.Extensions;
+using HSMServer.Core.Notifications;
 using HSMServer.Core.TreeStateSnapshot.States;
 using System;
 using System.Collections.Generic;
@@ -13,12 +14,17 @@ namespace HSMServer.Core.Model.Policies
 
         public bool AllChats { get; init; }
 
+        public NotificationKind Kind { get; init; }
+
         public AlertDestination(Policy policy)
         {
             var target = policy.TargetChats;
             Chats = new HashSet<Guid>(target.Chats.Keys);
             AllChats = target.IsAllChats;
+            Kind = policy.Destination.Kind;
         }
+
+        internal AlertDestination() { }
 
 
         internal bool HasChats => AllChats || Chats.Count > 0;
@@ -73,7 +79,7 @@ namespace HSMServer.Core.Model.Policies
         internal AlertResult(Policy policy, bool isReplace = false)
         {
             Destination = new(policy);
-            
+
             ConfirmationPeriod = policy.ConfirmationPeriod;
             SendTime = policy.Schedule.GetSendTime();
             BuildDate = DateTime.UtcNow;
@@ -94,6 +100,16 @@ namespace HSMServer.Core.Model.Policies
                 RetryCount = ttlPolicy.RetryCount;
 
             AddPolicyResult(policy);
+        }
+
+        internal AlertResult(AlertDestination destination, string icon, string comment, Guid policyId)
+        {
+            Destination = destination;
+            Icon = icon;
+            LastComment = comment;
+            PolicyId = policyId;
+            BuildDate = DateTime.UtcNow;
+            SendTime = DateTime.UtcNow;
         }
 
 

--- a/src/server/HSMServer/BackgroundServices/DatacollectorService/DataCollectorWrapper.cs
+++ b/src/server/HSMServer/BackgroundServices/DatacollectorService/DataCollectorWrapper.cs
@@ -56,6 +56,8 @@ namespace HSMServer.BackgroundServices
 
         internal TelegramBotStatistics TelegramBotStatistics { get; }
 
+        internal SlackChannelStatistics SlackChannelStatistics { get; }
+
 
         public DataCollectorWrapper(ITreeValuesCache cache, IDatabaseCore db, IServerConfig config, IOptionsMonitor<MonitoringOptions> optionsMonitor, NotificationsCenter notificationCenter)
         {
@@ -92,6 +94,7 @@ namespace HSMServer.BackgroundServices
             BackupSensors = new BackupSensors(_collector);
             TreeValueCacheStatistics = new TreeValueChacheStatistics(_collector);
             TelegramBotStatistics = new TelegramBotStatistics(_collector);
+            SlackChannelStatistics = new SlackChannelStatistics(_collector);
 
             _cache.RequestProcessed += OnRequestProcessed;
 
@@ -99,6 +102,10 @@ namespace HSMServer.BackgroundServices
             _notificationsCenter.TelegramBot.MessageSended += OnMessageSended;
             _notificationsCenter.TelegramBot.ErrorHandled += OnErrorHandled;
             _notificationsCenter.TelegramBot.MessageSending += OnMesageSending;
+
+            _notificationsCenter.SlackChannel.MessageSended += OnSlackMessageSended;
+            _notificationsCenter.SlackChannel.ErrorHandled += OnSlackErrorHandled;
+            _notificationsCenter.SlackChannel.MessageSending += OnSlackMessageSending;
 
 
         }
@@ -111,6 +118,12 @@ namespace HSMServer.BackgroundServices
 
         private void OnErrorHandled(string message) => TelegramBotStatistics.RegisterError(message);
 
+        private void OnSlackMessageSended(string destination, string message) => SlackChannelStatistics.RegisterMessageSended(destination, message);
+
+        private void OnSlackMessageSending() => SlackChannelStatistics.RegisterMessageSending();
+
+        private void OnSlackErrorHandled(string message) => SlackChannelStatistics.RegisterError(message);
+
 
         public void Dispose()
         {
@@ -118,6 +131,9 @@ namespace HSMServer.BackgroundServices
             _notificationsCenter.TelegramBot.MessageSended -= OnMessageSended;
             _notificationsCenter.TelegramBot.ErrorHandled -= OnErrorHandled;
             _notificationsCenter.TelegramBot.MessageSending -= OnMesageSending;
+            _notificationsCenter.SlackChannel.MessageSended -= OnSlackMessageSended;
+            _notificationsCenter.SlackChannel.ErrorHandled -= OnSlackErrorHandled;
+            _notificationsCenter.SlackChannel.MessageSending -= OnSlackMessageSending;
             _collector?.Dispose();
         }
 

--- a/src/server/HSMServer/BackgroundServices/DatacollectorService/Nodes/SlackChannelStatistics.cs
+++ b/src/server/HSMServer/BackgroundServices/DatacollectorService/Nodes/SlackChannelStatistics.cs
@@ -1,0 +1,69 @@
+using HSMDataCollector.Core;
+using HSMDataCollector.Options;
+using HSMDataCollector.PublicInterface;
+using HSMSensorDataObjects.SensorRequests;
+using System;
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace HSMServer.BackgroundServices
+{
+    public class SlackChannelStatistics
+    {
+        private const string MessagesNode = "Messages";
+        private const string Errors = "Errors";
+        private const string NodeName = "Slack";
+        private const string Rate = "Total";
+
+        private readonly IDataCollector _collector;
+
+        private readonly ConcurrentDictionary<string, IInstantValueSensor<string>> _notifications = new();
+        private readonly IInstantValueSensor<string> _errors;
+        private readonly IMonitoringRateSensor _messagesRate;
+
+        private static readonly Regex LineBreakRegex = new(@"\r\n|\n|\r", RegexOptions.Compiled);
+
+
+        public SlackChannelStatistics(IDataCollector collector)
+        {
+            _collector = collector;
+
+            _errors = collector.CreateStringSensor($"{NodeName}/{Errors}", new InstantSensorOptions
+            {
+                Alerts = [],
+                TTL = TimeSpan.MaxValue,
+                EnableForGrafana = false,
+                AggregateData = true,
+                Description = $"The sensor sends information about {NodeName} errors."
+            });
+
+            _messagesRate = collector.CreateRateSensor($"{NodeName}/{Rate}", new RateSensorOptions()
+            {
+                Alerts = [],
+                TTL = TimeSpan.MaxValue,
+                EnableForGrafana = false,
+                DisplayUnit = RateDisplayUnit.PerMinute,
+                PostDataPeriod = TimeSpan.FromMinutes(1),
+                Description = $"The sensor sends information about sent notifications to {NodeName}.",
+            });
+        }
+
+
+        public void RegisterMessageSended(string destination, string message)
+        {
+            var sensor = _notifications.GetOrAdd(destination, id => _collector.CreateStringSensor($"{NodeName}/{MessagesNode}/{id}", new InstantSensorOptions
+            {
+                Alerts = [],
+                TTL = TimeSpan.MaxValue,
+                EnableForGrafana = false,
+                Description = $"The sensor sends information about {NodeName} notifications messages sended."
+            }));
+
+            sensor.AddValue(LineBreakRegex.Replace(message, "<br>"));
+        }
+
+        public void RegisterMessageSending() => _messagesRate.AddValue(1);
+
+        public void RegisterError(string message) => _errors.AddValue(message);
+    }
+}

--- a/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
+++ b/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
@@ -60,6 +60,8 @@ namespace HSMServer.ServiceExtensions
                     .AddSingleton<BackupDatabaseService>()
                     .AddSingleton<NotificationsCenter>();
 
+            services.AddHttpClient<SlackNotificationChannel>();
+
             services.AddHostedService<TreeSnapshotService>()
                     .AddHostedService<ClearDatabaseService>()
                     //                .AddHostedService<MonitoringBackgroundService>()

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -36,6 +36,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="HSMServer.Core.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
     <PackageReference Include="HSMDataCollector.HSMDataCollector" Version="3.4.12" />
     <ProjectReference Include="..\..\api\HSMSensorDataObjects\HSMSensorDataObjects.csproj" />

--- a/src/server/HSMServer/HSMSwaggerComments.xml
+++ b/src/server/HSMServer/HSMSwaggerComments.xml
@@ -17,6 +17,15 @@
             </summary>
             <param name="user">User object (password field must be password hash).</param>
         </member>
+        <member name="T:HSMServer.Controllers.AgentController">
+            <summary>
+            Per-product HSM Agent download (epic #1167, W6/W7). The admin opens a product, clicks "Download
+            Windows agent", and gets a zip with the byte-identical signed exe + a generated config.json
+            (this server's address + the product's access key) + silent install scripts. The server ONLY
+            generates + serves the zip — it is not an installer; the client install is the C++ exe's own
+            <c>--install</c> (no .NET/MSI on the client).
+            </summary>
+        </member>
         <member name="M:HSMServer.Controllers.GrafanaDatasources.JsonSource.JsonDatasourceController.TestConnection">
             <summary>
             with 200 status code response. Used for "Test connection" on the datasource config page.
@@ -181,6 +190,66 @@
             The attribute denies access to some actions for a user who is neither admin or has role from _roles
             </summary>
         </member>
+        <member name="T:HSMServer.Model.Agent.AgentConnectionResolver">
+            <summary>
+            Resolves the (address, port) the agent bundle's config.json points at. Prefers the admin-set
+            external URL (the externally-reachable Sensor-API base; the server can't infer it behind
+            Docker/NAT); when blank, falls back to the request host + the configured Sensor port. Pure
+            (primitives only) so it is unit-tested without a web host.
+            </summary>
+        </member>
+        <member name="T:HSMServer.Model.Agent.AgentBundleOptions">
+            <summary>
+            Parameters baked into one per-product agent bundle. <see cref="P:HSMServer.Model.Agent.AgentBundleOptions.AccessKey"/> is the product's
+            access-key GUID (string) the agent sends in the <c>Key</c> header. <see cref="P:HSMServer.Model.Agent.AgentBundleOptions.EnableTopCpu"/>
+            adds a <c>topCpu</c> block so the installed agent also reports the top processes by CPU (#1175).
+            </summary>
+        </member>
+        <member name="M:HSMServer.Model.Agent.AgentBundleOptions.#ctor(System.String,System.Int32,System.String,System.Boolean,System.Boolean)">
+            <summary>
+            Parameters baked into one per-product agent bundle. <see cref="P:HSMServer.Model.Agent.AgentBundleOptions.AccessKey"/> is the product's
+            access-key GUID (string) the agent sends in the <c>Key</c> header. <see cref="P:HSMServer.Model.Agent.AgentBundleOptions.EnableTopCpu"/>
+            adds a <c>topCpu</c> block so the installed agent also reports the top processes by CPU (#1175).
+            </summary>
+        </member>
+        <member name="T:HSMServer.Model.Agent.AgentInstallerBundle">
+            <summary>
+            Builds the downloadable HSM Agent bundle (epic #1167, W7): a zip of the byte-identical signed
+            <c>hsm-agent.exe</c> + a generated <c>config.json</c> (server address + key) + silent
+            install/uninstall scripts. The exe is NEVER modified — all per-product data lives in
+            <c>config.json</c> (Authenticode invariant). Install is 100% native C++ (the exe self-installs);
+            no .NET/MSI on the client. Pure + side-effect-free so it is unit-tested without a web host.
+            </summary>
+        </member>
+        <member name="M:HSMServer.Model.Agent.AgentInstallerBundle.BuildConfigJson(HSMServer.Model.Agent.AgentBundleOptions)">
+            <summary>The generated config.json — matches the agent's config schema (only address + key required).</summary>
+        </member>
+        <member name="M:HSMServer.Model.Agent.AgentInstallerBundle.BuildInstallScript">
+            <summary>Self-elevating silent installer: copy exe + config, register the service, start it.</summary>
+        </member>
+        <member name="M:HSMServer.Model.Agent.AgentInstallerBundle.BuildUninstallScript">
+            <summary>Self-elevating silent uninstaller: deregister the service, remove the installed exe.</summary>
+        </member>
+        <member name="M:HSMServer.Model.Agent.AgentInstallerBundle.BuildZip(System.Byte[],HSMServer.Model.Agent.AgentBundleOptions)">
+            <summary>Assemble the zip in memory: the unmodified exe + generated config + install scripts.</summary>
+        </member>
+        <member name="T:HSMServer.Model.Agent.AgentKeySelector">
+            <summary>
+            Picks the access key baked into a product's agent bundle. The agent registers its default
+            sensors at start and streams values, so it needs add-node/add-sensor + send-data permissions —
+            the product DefaultKey has all of them and never expires. Pure (Core types only) so it is
+            unit-tested without a web host.
+            </summary>
+        </member>
+        <member name="M:HSMServer.Model.Agent.AgentKeySelector.Select(HSMServer.Core.Model.ProductModel)">
+            <summary>
+            Returns the best agent key for the product, or null when none actually satisfies
+            <see cref="F:HSMServer.Model.Agent.AgentKeySelector.AgentPermissions"/>. We never hand back an expired/under-permissioned key as a
+            "last resort": it would bake a credential that fails to authenticate at runtime into the
+            bundle with no signal to the admin. Null instead lets the caller refuse the download
+            (BadRequest) so the admin fixes the key first.
+            </summary>
+        </member>
         <member name="M:HSMServer.Model.History.BarHistoryProcessor`1.AddValueFromLists(HSMServer.Model.History.SummaryBarItem{`0})">
             <summary>
             Set fields, for which collecting lists of values is required
@@ -201,6 +270,27 @@
             </summary>
             <param name="means"></param>
             <returns></returns>
+        </member>
+        <member name="T:HSMServer.ServerConfiguration.AgentConfig">
+            <summary>
+            Settings for the downloadable HSM Agent (epic #1167). The externally-reachable Sensor-API base URL
+            is baked into each per-product agent bundle so the client connects with zero configuration. The
+            server cannot infer this behind Docker/NAT, so an admin sets it; when blank, the download endpoint
+            falls back to the request host + the configured Sensor port.
+            </summary>
+        </member>
+        <member name="P:HSMServer.ServerConfiguration.AgentConfig.AllowUntrustedCertificate">
+            <summary>
+            Baked into downloaded bundles as <c>server.allowUntrustedCertificate</c> so an agent accepts a
+            self-signed server certificate (the typical self-hosted / Docker eval case). Default false.
+            </summary>
+        </member>
+        <member name="P:HSMServer.ServerConfiguration.AgentConfig.EnableTopCpuProcesses">
+            <summary>
+            When true, downloaded bundles carry a <c>topCpu</c> block (issue #1175) so the installed agent
+            also reports the top processes by CPU once a minute. The admin opts in here (server-side); the
+            client agent has no UI and simply runs whatever config.json the bundle ships. Default false.
+            </summary>
         </member>
     </members>
 </doc>

--- a/src/server/HSMServer/Notifications/NotificationsCenter.cs
+++ b/src/server/HSMServer/Notifications/NotificationsCenter.cs
@@ -19,8 +19,11 @@ namespace HSMServer.Notifications
 
         public TelegramBot TelegramBot { get; }
 
+        public SlackNotificationChannel SlackChannel { get; }
 
-        public NotificationsCenter(ITelegramChatsManager telegramChats, IFolderManager folderManager, ITreeValuesCache cache, IServerConfig config)
+
+        public NotificationsCenter(ITelegramChatsManager telegramChats, IFolderManager folderManager, ITreeValuesCache cache, IServerConfig config,
+                                   SlackNotificationChannel slackChannel)
         {
             _telegramChatsManager = telegramChats;
             _folderManager = folderManager;
@@ -29,7 +32,8 @@ namespace HSMServer.Notifications
             ConnectFoldersAndChats();
 
             TelegramBot = new(telegramChats, folderManager, config.Telegram);
-            _channels = [new TelegramNotificationChannel(TelegramBot)];
+            SlackChannel = slackChannel;
+            _channels = [new TelegramNotificationChannel(TelegramBot), SlackChannel];
 
             _cache.NewAlertMessageEvent += DispatchAlertMessage;
         }

--- a/src/server/HSMServer/Notifications/Slack/SlackMessageBuilder.cs
+++ b/src/server/HSMServer/Notifications/Slack/SlackMessageBuilder.cs
@@ -1,0 +1,25 @@
+using HSMServer.Core.Managers;
+using HSMServer.Core.Model.Policies;
+using System.Text.Json;
+
+namespace HSMServer.Notifications
+{
+    internal static class SlackMessageBuilder
+    {
+        private static readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
+
+        public static string BuildPayload(AlertResult alert)
+        {
+            var text = alert.ToString();
+
+            var payload = new SlackWebhookPayload { Text = text };
+
+            return JsonSerializer.Serialize(payload, _options);
+        }
+
+        private sealed record SlackWebhookPayload
+        {
+            public string Text { get; init; }
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/Slack/SlackNotificationChannel.cs
+++ b/src/server/HSMServer/Notifications/Slack/SlackNotificationChannel.cs
@@ -1,0 +1,144 @@
+using HSMServer.Core.Managers;
+using HSMServer.Core.Model.Policies;
+using HSMServer.Core.Notifications;
+using HSMServer.Notifications.Channels;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HSMServer.Notifications
+{
+    public sealed class SlackNotificationChannel : INotificationChannel
+    {
+        internal const int DefaultMaxRetryAttempts = 3;
+        internal static readonly TimeSpan DefaultInitialBackoff = TimeSpan.FromSeconds(2);
+        internal static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(30);
+
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetLogger(nameof(SlackNotificationChannel));
+
+        private readonly ISlackDestinationsManager _destinations;
+        private readonly HttpClient _httpClient;
+        private readonly int _maxRetryAttempts;
+        private readonly TimeSpan _initialBackoff;
+
+        public NotificationKind Kind => NotificationKind.Slack;
+
+        public event Action MessageSending;
+        public event Action<string, string> MessageSended;
+        public event Action<string> ErrorHandled;
+
+
+        public SlackNotificationChannel(ISlackDestinationsManager destinations, HttpClient httpClient)
+            : this(destinations, httpClient, DefaultMaxRetryAttempts, DefaultInitialBackoff, DefaultRequestTimeout)
+        {
+        }
+
+        internal SlackNotificationChannel(ISlackDestinationsManager destinations, HttpClient httpClient,
+            int maxRetryAttempts, TimeSpan initialBackoff, TimeSpan requestTimeout)
+        {
+            _destinations = destinations;
+            _httpClient = httpClient;
+            _httpClient.Timeout = requestTimeout;
+            _maxRetryAttempts = maxRetryAttempts;
+            _initialBackoff = initialBackoff;
+        }
+
+
+        public async Task DeliverAsync(AlertMessage message)
+        {
+            try
+            {
+                foreach (var alert in message)
+                {
+                    if (alert.Destination.Kind != NotificationKind.Slack)
+                        continue;
+
+                    var payload = SlackMessageBuilder.BuildPayload(alert);
+
+                    foreach (var destinationId in alert.Destination.Chats)
+                    {
+                        if (!_destinations.TryGetValue(destinationId, out var destination))
+                        {
+                            _logger.Warn($"Slack destination {destinationId} not found for alert {alert.PolicyId}");
+                            continue;
+                        }
+
+                        if (!destination.SendMessages)
+                            continue;
+
+                        await PostWithRetryAsync(destination.WebhookUrl, payload, destination.Name);
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Slack DeliverAsync failed");
+            }
+        }
+
+        public Task FlushAsync() => Task.CompletedTask;
+
+
+        private async Task PostWithRetryAsync(string webhookUrl, string payload, string destinationName)
+        {
+            var backoff = _initialBackoff;
+
+            for (var attempt = 1; attempt <= _maxRetryAttempts; attempt++)
+            {
+                try
+                {
+                    MessageSending?.Invoke();
+
+                    using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                    using var response = await _httpClient.PostAsync(webhookUrl, content);
+
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        MessageSended?.Invoke(destinationName, payload);
+                        return;
+                    }
+
+                    if (IsTransient(response.StatusCode) && attempt < _maxRetryAttempts)
+                    {
+                        OnError($"Slack POST to {destinationName} returned {response.StatusCode}; retrying (attempt {attempt}/{_maxRetryAttempts})");
+                        await Task.Delay(backoff);
+                        backoff *= 2;
+                        continue;
+                    }
+
+                    OnError($"Slack POST to {destinationName} returned terminal status {response.StatusCode}; giving up");
+                    return;
+                }
+                catch (HttpRequestException ex) when (attempt < _maxRetryAttempts)
+                {
+                    OnError($"Slack POST to {destinationName} failed (attempt {attempt}/{_maxRetryAttempts}): {ex.Message}");
+                    await Task.Delay(backoff);
+                    backoff *= 2;
+                }
+                catch (TaskCanceledException) when (attempt < _maxRetryAttempts)
+                {
+                    OnError($"Slack POST to {destinationName} timed out (attempt {attempt}/{_maxRetryAttempts})");
+                    await Task.Delay(backoff);
+                    backoff *= 2;
+                }
+                catch (Exception ex)
+                {
+                    OnError($"Slack POST to {destinationName} failed terminally: {ex.Message}");
+                    return;
+                }
+            }
+        }
+
+        private static bool IsTransient(HttpStatusCode statusCode) =>
+            statusCode >= HttpStatusCode.InternalServerError || statusCode == HttpStatusCode.RequestTimeout;
+
+        private void OnError(string message)
+        {
+            _logger.Error(message);
+            ErrorHandled?.Invoke(message);
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/Telegram/TelegramBot.cs
+++ b/src/server/HSMServer/Notifications/Telegram/TelegramBot.cs
@@ -7,6 +7,7 @@ using Telegram.Bot.Polling;
 using Telegram.Bot.Types;
 using Telegram.Bot.Exceptions;
 using HSMServer.Core.Managers;
+using HSMServer.Core.Notifications;
 using HSMServer.Core.TableOfChanges;
 using HSMServer.ConcurrentStorage;
 using HSMServer.Folders;
@@ -183,6 +184,9 @@ namespace HSMServer.Notifications
 
                 foreach (var alert in message)
                 {
+                    if (alert.Destination.Kind != NotificationKind.Telegram)
+                        continue;
+
                     var chatIds = alert.Destination.Chats;
 
                     foreach (var chatId in chatIds)

--- a/src/tests/HSMServer.Core.Tests/Notifications/SlackChannelTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/SlackChannelTests.cs
@@ -1,0 +1,245 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Core.DataLayer;
+using HSMServer.Core.Managers;
+using HSMServer.Core.Model.Policies;
+using HSMServer.Core.Notifications;
+using HSMServer.Notifications;
+using Moq;
+using Xunit;
+
+namespace HSMServer.Core.Tests.Notifications
+{
+    public class SlackChannelTests
+    {
+        private const string WebhookUrl = "https://hooks.slack.com/services/X";
+        private static readonly TimeSpan TestBackoff = TimeSpan.FromMilliseconds(1);
+
+
+        [Fact]
+        public async Task DeliverAsync_SlackPolicy_PostsToWebhookAndFiresEvents()
+        {
+            var (manager, destinationId) = SeedDestination(send: true);
+            var handler = new StubHandler(HttpStatusCode.OK);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 3, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            int sending = 0, sended = 0;
+            channel.MessageSending += () => sending++;
+            channel.MessageSended += (_, _) => sended++;
+
+            await channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Slack));
+
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(WebhookUrl, handler.LastRequestUri);
+            Assert.Equal(1, sending);
+            Assert.Equal(1, sended);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_TelegramPolicy_DoesNotPost()
+        {
+            var (manager, destinationId) = SeedDestination(send: true);
+            var handler = new StubHandler(HttpStatusCode.OK);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 1, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            await channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Telegram));
+
+            Assert.Equal(0, handler.Calls);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_DisabledDestination_Skipped()
+        {
+            var (manager, destinationId) = SeedDestination(send: false);
+            var handler = new StubHandler(HttpStatusCode.OK);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 1, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            await channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Slack));
+
+            Assert.Equal(0, handler.Calls);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_4xxResponse_TerminalNoRetry()
+        {
+            var (manager, destinationId) = SeedDestination(send: true);
+            var handler = new StubHandler(HttpStatusCode.BadRequest);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 3, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            int errors = 0;
+            channel.ErrorHandled += _ => errors++;
+
+            await channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Slack));
+
+            Assert.Equal(1, handler.Calls);
+            Assert.Equal(1, errors);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_5xxResponse_RetriesThenSucceeds()
+        {
+            var (manager, destinationId) = SeedDestination(send: true);
+            var handler = new StubHandler(HttpStatusCode.InternalServerError, HttpStatusCode.OK);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 3, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            int sended = 0;
+            channel.MessageSended += (_, _) => sended++;
+
+            await channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Slack));
+
+            Assert.Equal(2, handler.Calls);
+            Assert.Equal(1, sended);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_UnknownDestination_SkippedWithoutErrorEvent()
+        {
+            var manager = BuildManager();
+            var handler = new StubHandler(HttpStatusCode.OK);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 1, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            int errors = 0;
+            channel.ErrorHandled += _ => errors++;
+
+            await channel.DeliverAsync(BuildMessage(Guid.NewGuid(), NotificationKind.Slack));
+
+            Assert.Equal(0, handler.Calls);
+            Assert.Equal(0, errors);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_All5xx_RetriesUntilLimitThenErrors()
+        {
+            var (manager, destinationId) = SeedDestination(send: true);
+            var handler = new StubHandler(HttpStatusCode.ServiceUnavailable);
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 3, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            int errors = 0;
+            int sended = 0;
+            channel.ErrorHandled += _ => errors++;
+            channel.MessageSended += (_, _) => sended++;
+
+            await channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Slack));
+
+            Assert.Equal(3, handler.Calls);
+            Assert.Equal(0, sended);
+            Assert.True(errors >= 1);
+        }
+
+        [Fact]
+        public async Task DeliverAsync_ExceptionInSend_DoesNotPropagate()
+        {
+            var (manager, destinationId) = SeedDestination(send: true);
+            var handler = new ThrowingHandler();
+
+            var channel = new SlackNotificationChannel(manager, new HttpClient(handler),
+                maxRetryAttempts: 2, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            int errors = 0;
+            channel.ErrorHandled += _ => errors++;
+
+            var ex = await Record.ExceptionAsync(() => channel.DeliverAsync(BuildMessage(destinationId, NotificationKind.Slack)));
+
+            Assert.Null(ex);
+            Assert.True(errors >= 1);
+        }
+
+        [Fact]
+        public async Task FlushAsync_IsNoOp()
+        {
+            var manager = BuildManager();
+            var channel = new SlackNotificationChannel(manager, new HttpClient(),
+                maxRetryAttempts: 1, initialBackoff: TestBackoff, requestTimeout: TimeSpan.FromSeconds(5));
+
+            var ex = await Record.ExceptionAsync(() => channel.FlushAsync());
+
+            Assert.Null(ex);
+        }
+
+
+        private static SlackDestinationsManager BuildManager()
+            => new(new Mock<IDatabaseCore>().Object);
+
+        private static SlackDestination BuildDestination(bool send) =>
+            new(new SlackDestinationEntity
+            {
+                Id = Guid.NewGuid().ToByteArray(),
+                Author = Guid.NewGuid().ToByteArray(),
+                CreationDate = DateTime.UtcNow.Ticks,
+                Name = "alerts-channel",
+                WebhookUrl = WebhookUrl,
+                SendMessages = send,
+            });
+
+        private static (SlackDestinationsManager manager, Guid destinationId) SeedDestination(bool send)
+        {
+            var manager = BuildManager();
+            var dest = BuildDestination(send);
+            manager.TryAdd(dest.Id, dest);
+            return (manager, dest.Id);
+        }
+
+        private static AlertMessage BuildMessage(Guid destinationId, NotificationKind kind)
+        {
+            var dest = new AlertDestination
+            {
+                Chats = new HashSet<Guid> { destinationId },
+                AllChats = false,
+                Kind = kind,
+            };
+
+            var alert = new AlertResult(dest, icon: "⚠️", comment: "value changed", policyId: Guid.NewGuid());
+
+            return new AlertMessage(Guid.NewGuid(), new List<AlertResult> { alert });
+        }
+
+
+        private sealed class StubHandler : HttpMessageHandler
+        {
+            private readonly Queue<HttpStatusCode> _responses;
+
+            public int Calls { get; private set; }
+            public string LastRequestUri { get; private set; }
+
+            internal StubHandler(params HttpStatusCode[] responses)
+            {
+                _responses = new Queue<HttpStatusCode>(responses);
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                Calls++;
+                LastRequestUri = request.RequestUri?.ToString();
+
+                var status = _responses.Count > 1 ? _responses.Dequeue() : (_responses.Count == 1 ? _responses.Peek() : HttpStatusCode.OK);
+
+                return Task.FromResult(new HttpResponseMessage(status));
+            }
+        }
+
+        private sealed class ThrowingHandler : HttpMessageHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+                => throw new InvalidOperationException("simulated network failure");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Third PR of the Slack support epic (#1144). The destination registry from PR2 (#1184) now has a runtime consumer: a Slack channel that actually delivers alerts via webhook, plus a Slack diagnostics node under "HSM Server Monitoring".

- `SlackNotificationChannel : INotificationChannel` — one `HttpClient` POST per `(alert, destination)` pair. Retry policy: up to 3 attempts with exponential backoff for transient failures (5xx, network, timeout); 4xx is terminal (Slack returns 200 on success and 4xx for malformed payloads or revoked webhooks). Does not throw out of `DeliverAsync`.
- `AlertDestination` gained `NotificationKind Kind`, populated from `policy.Destination.Kind`. Each channel filters by `Kind` so Telegram and Slack don't cross-fire. `TelegramBot.DeliverAsync` skips non-Telegram alerts — no observable regression since pre-PR3 policies are all Telegram.
- `SlackChannelStatistics` mirrors `TelgramBotStatistics` under node `"Slack"`: `Slack/Errors`, `Slack/Total` rate, and per-destination `Slack/Messages/<name>` sensors.
- `DataCollectorWrapper` subscribes to the three Slack channel events symmetrically to the Telegram wiring.
- `HttpClient` registered via `AddHttpClient<SlackNotificationChannel>()` in `ApplicationServiceExtensions`.
- Added `InternalsVisibleTo("HSMServer.Core.Tests")` to HSMServer so tests can use the internal `SlackDestination(entity)` ctor and the test-friendly channel ctor.

Closes #1185.

## Channel design choices (per #1185 task list)

- **Options class**: skipped for v1. Constants live in the channel (`DefaultMaxRetryAttempts = 3`, `DefaultInitialBackoff = 2s`, `DefaultRequestTimeout = 30s`). An internal ctor accepts overrides for tests. If operator-tunability is needed later, lift into `SlackChannelOptions`.
- **Channel exposure**: `NotificationsCenter.SlackChannel` property mirrors the existing `TelegramBot` property so `DataCollectorWrapper` can subscribe directly. No event re-dispatch on `NotificationsCenter` itself.
- **Payload**: `SlackMessageBuilder.BuildPayload(alert)` -> `{"text":"<alert.ToString()>"}` (System.Text.Json, camelCase). Rich blocks deliberately out of scope for v1.

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.csproj` — 0 errors.
- [x] `dotnet build src/tests/HSMServer.Core.Tests/HSMServer.Core.Tests.csproj` — 0 errors.
- [x] `SlackChannelTests` (9 tests) with a stub `HttpMessageHandler`:
  - `DeliverAsync_SlackPolicy_PostsToWebhookAndFiresEvents` — happy path, POST URL and event counts verified.
  - `DeliverAsync_TelegramPolicy_DoesNotPost` — kind filter, no POST.
  - `DeliverAsync_DisabledDestination_Skipped` — `SendMessages == false` short-circuits.
  - `DeliverAsync_4xxResponse_TerminalNoRetry` — exactly one POST, one `ErrorHandled`.
  - `DeliverAsync_5xxResponse_RetriesThenSucceeds` — 500 then 200 -> 2 POSTs, `MessageSended` fires.
  - `DeliverAsync_UnknownDestination_SkippedWithoutErrorEvent` — destination not in registry, no POST, no error event (logged warning only).
  - `DeliverAsync_All5xx_RetriesUntilLimitThenErrors` — 3 POSTs, `MessageSended` never fires, `ErrorHandled` fires.
  - `DeliverAsync_ExceptionInSend_DoesNotPropagate` — throwing handler, `DeliverAsync` returns normally, `ErrorHandled` fires.
  - `FlushAsync_IsNoOp` — returns without throwing.
- [x] Regression (16 tests): `TemplateConcurrencyTests`, `AlertTemplatePartialFailureTests`, `HomeControllerAddDataPolicyTests`, `PolicyDestinationKindTests`, `SlackDestinationRoundTripTests`, `SlackDestinationsManagerTests` — all green.
- [ ] Manual smoke (deferred to reviewer): create a Slack destination, point a `Kind == Slack` policy at it (requires PR4 UI; can be done via direct DB write or REST), confirm the webhook fires and the Slack diagnostics sensors tick.

## Out of scope (PR4)

- Management UI for Slack destinations (`NotificationsController` CRUD).
- `_ActionBlock.cshtml` destination-kind selector and `ActionViewModel.NotificationKind`.
- Folder linkage and import/export of Slack destinations.
- Rich Slack block formatting.

## Related

- Epic: #1144
- PR1 (channel abstraction): #1181 / #1182
- PR2 (destination registry): #1183 / #1184
- Child issue: #1185
