### PR TITLE
feat(#1174): agent self-update — server manifest, poll, binary swap, rollback

### DIFF
--- a/.github/workflows/agent-windows-build.yml
+++ b/.github/workflows/agent-windows-build.yml
@@ -96,6 +96,10 @@ jobs:
           cp src/agent/config.template.json staging/config.json
           cp src/agent/packaging/install-hsmagent-service.cmd staging/install-hsmagent-service.cmd
           cp src/agent/packaging/uninstall-hsmagent-service.cmd staging/uninstall-hsmagent-service.cmd
+          # version.txt consumed by GET /api/agent/version on the server (epic #1174).
+          grep 'project(HsmAgent VERSION' src/agent/CMakeLists.txt \
+            | sed 's/.*VERSION \([0-9][^ ]*\).*/\1/' > staging/version.txt
+          cat staging/version.txt
           ls -l staging
 
       - name: Upload agent bundle

--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -134,6 +134,9 @@ before `Stop()`, waits on the same `cv_` so it exits the moment stop is requeste
 2. `SelectTopN` (portable, unit-tested) keeps names `>= minPercent` and returns the busiest `count`.
 3. Each survivor's % is posted to a lazily-created `Top CPU processes/<exe>` Double sensor (cached by
    name). Names not in the top list that tick get **no value** → natural gaps in their series.
+   The distinct-name set is **capped at `max(count * 8, 64)`** in both collectors (the server sensor
+   registry is permanent, with no delete API): once the cap is reached, newly seen process names are
+   skipped so a churn-heavy host can't grow the namespace without bound or exhaust the global MaxSensors.
 
 Aggregating by exe name (not PID, not PDH `#n` suffix) keeps a stable sensor identity over time.
 **Out of scope:** browser tab/site attribution (needs browser-level instrumentation; tracked separately).

--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -1,6 +1,6 @@
 # Feature: HSM Agent (Windows service)
 
-> Owner: agent | Last reviewed: 2026-06-23 | Canonical: yes
+> Owner: agent | Last reviewed: 2026-06-25 | Canonical: yes
 > Scope: The standalone **HSM Agent** product (`src/agent/`) — an always-on Windows service that hosts the native collector and streams this computer's metrics to an HSM server with zero client-side configuration. This feature owns the service host, config, and logging; it owns NO wire behavior (that all lives in `collector/` + `integrations/native-collector`).
 
 ---
@@ -86,6 +86,42 @@ defaults. Maps onto `CollectorOptions` + runtime group gates:
 - `periods.collectMs` → `package_collect_period_ms`. `productVersion` → module-sensor version.
 - `topCpu.{enabled=false,periodMs=60000,minPercent=1.0,count=10}` — opt-in "top processes by CPU"
   (issue #1175). Validated only when enabled (period/count > 0, minPercent ≥ 0).
+- `update.{enabled=true,checkPeriodHours=24}` — self-update channel (epic #1174). When enabled the
+  agent periodically polls `GET <server>/api/agent/version` and self-updates when the server advertises
+  a newer version AND its global `AutoUpdateEnabled` flag is true. `enabled=false` opts this machine out
+  regardless of the server's flag. Validated: `checkPeriodHours ≥ 1`.
+
+## Self-update (epic #1174)
+
+Server-driven auto-upgrade of the running Windows service. The server exposes:
+- `GET /api/agent/version` — public, returns `{ version, sha256, updateEnabled }`. Version is read from
+  `wwwroot/agent/version.txt` (staged by CI). SHA-256 is computed from the staged exe at request time.
+  `updateEnabled` mirrors `ServerConfig.Agent.AutoUpdateEnabled` (admin toggle, default false).
+- `GET /api/agent/exe` — Key-header auth (agent's own access key), returns the binary stream with
+  `X-Agent-Sha256` response header.
+
+`UpdateChecker` (`src/agent/src/update_checker.cpp`, Windows-only) runs on a background thread after
+`collector.Start()`. Flow per poll:
+1. Fetch version manifest (WinHTTP, TLS enforced; `allow_untrusted_certificate` honoured for eval setups).
+2. Parse version string into `(major, minor, patch)`; skip if `remote ≤ current` (downgrade protection).
+3. Skip if `updateEnabled == false` (server kill-switch).
+4. Download exe (`Key` header), verify SHA-256 against manifest value.
+5. Write to `%ProgramFiles%\HSM Agent\hsm-agent.new.exe`.
+6. Spawn `hsm-agent.exe --apply-update` as a detached process.
+7. Call `RequestStop()` → graceful service shutdown begins.
+
+`--apply-update` (`src/agent/src/apply_update.cpp`) is the detached binary-swap helper:
+1. Wait up to 60 s for `HSMAgent` service to reach `STOPPED`.
+2. Rename dance: `hsm-agent.exe → hsm-agent.old.exe`; `hsm-agent.new.exe → hsm-agent.exe`.
+3. `StartService(HSMAgent)`.
+4. Health gate: wait 30 s for `SERVICE_RUNNING`; on failure, roll back (`hsm-agent.old.exe →
+   hsm-agent.exe`), restart old version, log error to Event Log.
+
+On next startup, `AgentRuntime::Run()` deletes `hsm-agent.old.exe` to confirm the new version is live.
+
+**Admin kill-switch:** `Agent.AutoUpdateEnabled: false` in `appsettings.json` (default). Flip to true
+when ready to roll out; flip back to halt. Per-machine opt-out: set `update.enabled: false` in the
+machine's `config.json`.
 
 ## Top processes by CPU (issue #1175)
 
@@ -115,7 +151,7 @@ stderr. The collector's own dedup window keeps a flapping server from spamming t
 
 ## Verification
 
-- Portable unit tests (`tests/agent_tests.cpp`, name-dispatched, 12 cases — config parser + topCpu config + `SelectTopN`) — run on every
+- Portable unit tests (`tests/agent_tests.cpp`, name-dispatched, 13 cases — config parser + topCpu config + update config) — run on every
   platform, registered in `ctest`.
 - **CI build lane (W8):** `.github/workflows/agent-windows-build.yml` — windows-latest, vcpkg curl,
   configures + builds `src/agent` Release with warnings-as-errors, runs the config `ctest`, and uploads

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -68,7 +68,9 @@ if(HSM_AGENT_BUILD_TESTS)
             agent_config_ignores_unknown_fields
             agent_config_decodes_string_escapes
             agent_topcpu_config_parses_and_defaults
-            agent_topcpu_rejects_bad_config)
+            agent_topcpu_rejects_bad_config
+            agent_update_config_parses_and_defaults
+            agent_update_config_rejects_bad_period)
         add_test(NAME ${name} COMMAND hsm_agent_tests ${name})
     endforeach()
 endif()
@@ -99,7 +101,9 @@ if(WIN32)
     add_executable(hsm-agent
         src/main.cpp
         src/agent_runtime.cpp
+        src/apply_update.cpp
         src/paths.cpp
+        src/update_checker.cpp
         src/logging/file_logger.cpp
         src/logging/agent_logger.cpp
         src/service/event_log.cpp
@@ -108,7 +112,8 @@ if(WIN32)
         "${TIMESTAMP_CPP}"
     )
     add_dependencies(hsm-agent hsm_agent_timestamp)
-    target_link_libraries(hsm-agent PRIVATE hsm_agent_config hsm_collector_cpp advapi32)
+    # winhttp: WinHTTP for self-update HTTP (epic #1174); bcrypt: SHA-256 via Windows CNG
+    target_link_libraries(hsm-agent PRIVATE hsm_agent_config hsm_collector_cpp advapi32 winhttp bcrypt)
     target_compile_features(hsm-agent PRIVATE cxx_std_17)
     target_compile_definitions(hsm-agent PRIVATE HSM_AGENT_VERSION="${PROJECT_VERSION}")
     hsm_agent_set_warnings(hsm-agent)

--- a/src/agent/config.template.json
+++ b/src/agent/config.template.json
@@ -27,5 +27,10 @@
     "collectMs": 15000
   },
 
-  "productVersion": "1.0.0.0"
+  "productVersion": "1.0.0.0",
+
+  "update": {
+    "enabled": true,
+    "checkPeriodHours": 24
+  }
 }

--- a/src/agent/include/agent/apply_update.hpp
+++ b/src/agent/include/agent/apply_update.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+/// @file
+/// @brief `--apply-update` CLI mode for hsm-agent (epic #1174).
+///
+/// RunApplyUpdate() is called when the agent is launched as a detached helper process with the
+/// --apply-update argument. It waits for the HSMAgent service to reach STOPPED, performs the
+/// binary swap dance (hsm-agent.exe → hsm-agent.old.exe, hsm-agent.new.exe → hsm-agent.exe),
+/// starts the service, and validates the health gate. On failure it rolls back and restores the
+/// old binary.
+
+namespace hsm::agent
+{
+    /// Entry point for the --apply-update detached helper. Returns 0 on success, non-zero on any
+    /// failure (rename error, start failure, health gate failure after rollback).
+    int RunApplyUpdate();
+} // namespace hsm::agent

--- a/src/agent/include/agent/config.hpp
+++ b/src/agent/include/agent/config.hpp
@@ -54,6 +54,13 @@ namespace hsm::agent
         // module-sensor product version
         std::string product_version = "1.0.0.0";
 
+        // update.* — agent self-update channel (epic #1174). The agent polls
+        // GET <server>/api/agent/version and self-updates when a newer build is available AND the
+        // server's global AutoUpdateEnabled flag is true. Set enabled=false in config to opt this
+        // machine out even when the server permits updates.
+        bool update_enabled = true;
+        int update_check_period_hours = 24; ///< poll interval; must be >= 1
+
         /// True once `computer_name` should be replaced by the resolved machine name.
         bool ComputerNameIsAuto() const;
     };

--- a/src/agent/include/agent/paths.hpp
+++ b/src/agent/include/agent/paths.hpp
@@ -1,12 +1,15 @@
 #pragma once
 
 /// @file
-/// @brief Well-known agent paths under %ProgramData% and a UTF-8 wide-path file reader.
+/// @brief Well-known agent paths under %ProgramData%/%ProgramFiles% and a UTF-8 wide-path file
+/// reader.
 
 #include <string>
 
 namespace hsm::agent
 {
+    // --- Data / config paths (%ProgramData%) -------------------------------------------------------
+
     /// `%ProgramData%\HSM Agent`.
     std::wstring ProgramDataAgentDir();
 
@@ -23,4 +26,18 @@ namespace hsm::agent
     /// Read a whole text file by wide path into `out` (raw bytes; the config is UTF-8). Returns false
     /// if the file cannot be opened.
     bool ReadTextFileWide(const std::wstring& path, std::string& out);
+
+    // --- Install paths (%ProgramFiles%) — used by self-update (epic #1174) -----------------------
+
+    /// `%ProgramFiles%\HSM Agent` — the directory the install script places the exe in.
+    std::wstring ProgramFilesAgentDir();
+
+    /// `%ProgramFiles%\HSM Agent\hsm-agent.exe` — the currently-installed (active) binary.
+    std::wstring InstallExePath();
+
+    /// `%ProgramFiles%\HSM Agent\hsm-agent.new.exe` — downloaded update staged here before swap.
+    std::wstring NewExePath();
+
+    /// `%ProgramFiles%\HSM Agent\hsm-agent.old.exe` — the previous binary kept until health gate.
+    std::wstring OldExePath();
 } // namespace hsm::agent

--- a/src/agent/include/agent/update_checker.hpp
+++ b/src/agent/include/agent/update_checker.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+/// @file
+/// @brief Background agent self-update checker (epic #1174).
+///
+/// UpdateChecker runs on a dedicated thread. It periodically polls GET /api/agent/version on the
+/// server. When a newer build is available AND the server's global switch (updateEnabled) is true,
+/// it downloads the exe, verifies its SHA-256, stages it as hsm-agent.new.exe, spawns itself with
+/// --apply-update, then requests a graceful stop of the current service run.
+
+#include "agent/config.hpp"
+
+#include <functional>
+#include <string>
+
+namespace hsm::agent
+{
+    /// Encapsulates the background update-check loop. Lifetime: construct after the runtime starts,
+    /// destroy (Stop()) before the runtime exits.
+    class UpdateChecker
+    {
+    public:
+        /// Log sink: void(int level, const std::string& message). Level values match
+        /// hsm::collector::LogLevel (Info=2, Warn=3, Error=4).
+        using LogFn = std::function<void(int, const std::string&)>;
+
+        /// `request_stop` is called once when an update is ready to apply (the checker has staged
+        /// hsm-agent.new.exe and spawned --apply-update). The runtime must then begin its shutdown
+        /// sequence so the service can be restarted by the apply-update helper.
+        UpdateChecker(const AgentConfig& config, LogFn log, std::function<void()> request_stop);
+        ~UpdateChecker();
+
+        UpdateChecker(const UpdateChecker&) = delete;
+        UpdateChecker& operator=(const UpdateChecker&) = delete;
+
+        /// Start the background polling thread.
+        void Start();
+
+        /// Signal the thread to exit and block until it does.
+        void Stop();
+
+    private:
+        void Run();
+        bool CheckAndUpdate();
+
+        const AgentConfig& config_;
+        LogFn log_;
+        std::function<void()> request_stop_;
+
+        void* thread_handle_ = nullptr; // HANDLE, void* to avoid Win32 headers in this header
+        void* stop_event_ = nullptr;    // HANDLE
+    };
+} // namespace hsm::agent

--- a/src/agent/include/agent/update_checker.hpp
+++ b/src/agent/include/agent/update_checker.hpp
@@ -39,9 +39,11 @@ namespace hsm::agent
         /// Signal the thread to exit and block until it does.
         void Stop();
 
-    private:
-        static DWORD WINAPI ThreadProc(LPVOID param);
+        // Called by the background thread only; public so the file-scope thread proc
+        // can invoke it without pulling Win32 types into this header.
         void Run();
+
+    private:
         bool CheckAndUpdate();
 
         const AgentConfig& config_;

--- a/src/agent/include/agent/update_checker.hpp
+++ b/src/agent/include/agent/update_checker.hpp
@@ -40,6 +40,7 @@ namespace hsm::agent
         void Stop();
 
     private:
+        static DWORD WINAPI ThreadProc(LPVOID param);
         void Run();
         bool CheckAndUpdate();
 

--- a/src/agent/src/agent_runtime.cpp
+++ b/src/agent/src/agent_runtime.cpp
@@ -1,5 +1,10 @@
 #include "agent/agent_runtime.hpp"
 
+#ifdef _WIN32
+#include "agent/paths.hpp"
+#include "agent/update_checker.hpp"
+#endif
+
 #include <chrono>
 #include <exception>
 #include <utility>
@@ -83,6 +88,14 @@ namespace hsm::agent
     {
         try
         {
+#ifdef _WIN32
+            // If a previous self-update succeeded, clean up the old binary now that the new
+            // service is confirmed running (this is the first Run() call after the swap).
+            const std::wstring old_exe = OldExePath();
+            if (GetFileAttributesW(old_exe.c_str()) != INVALID_FILE_ATTRIBUTES)
+                DeleteFileW(old_exe.c_str());
+#endif
+
             hc::Collector collector(BuildOptions());
 
             // Install the log sink first so configuration/transport diagnostics are captured.
@@ -135,7 +148,23 @@ namespace hsm::agent
             if (on_started)
                 on_started();
 
+#ifdef _WIN32
+            // Start the self-update checker after the collector is running (it may call RequestStop
+            // to trigger a service restart when an update is applied).
+            UpdateChecker updater(
+                config_,
+                [this](int level, const std::string& msg) {
+                    Log(static_cast<hc::LogLevel>(level), msg);
+                },
+                [this] { RequestStop(); });
+            updater.Start();
+#endif
+
             WaitForStop();
+
+#ifdef _WIN32
+            updater.Stop();
+#endif
 
             Log(hc::LogLevel::Info, "HSM Agent stopping...");
             collector.Stop(); // bounded graceful drain (capped internally)

--- a/src/agent/src/apply_update.cpp
+++ b/src/agent/src/apply_update.cpp
@@ -1,0 +1,194 @@
+// HSM Agent — --apply-update detached helper (epic #1174).
+//
+// This process is spawned by the running service after it downloads and verifies a new exe.
+// It must be detached (DETACHED_PROCESS) so it survives when the service process exits.
+//
+// Binary swap dance:
+//   1. Wait up to 60 s for service HSMAgent to reach STOPPED.
+//   2. MoveFileEx: hsm-agent.exe → hsm-agent.old.exe   (rename, not delete; rollback target)
+//   3. MoveFileEx: hsm-agent.new.exe → hsm-agent.exe    (atomic rename)
+//   4. sc start HSMAgent (or StartService).
+//   5. Health gate: poll status for up to 30 s; if STOPPED/FAILED → rollback.
+//
+// Rollback:
+//   MoveFileEx: hsm-agent.exe → (delete or temp), hsm-agent.old.exe → hsm-agent.exe
+//   Attempt to restart the old version.
+//
+// On success the service cleans up hsm-agent.old.exe at next startup.
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <winsvc.h>
+
+#include "agent/apply_update.hpp"
+#include "agent/paths.hpp"
+
+#include <cstdio>
+#include <iostream>
+#include <string>
+
+static const wchar_t* kServiceName = L"HSMAgent";
+
+// ---- helpers ---------------------------------------------------------------------------------
+
+static void Log(const std::string& msg)
+{
+    // This runs as a detached console-less process. Write to stderr (may be lost) + Event Log.
+    std::cerr << "[apply-update] " << msg << '\n';
+
+    HANDLE hev = RegisterEventSourceW(nullptr, L"HSMAgent");
+    if (hev)
+    {
+        const std::wstring wmsg(msg.begin(), msg.end());
+        const wchar_t* strs[] = { wmsg.c_str() };
+        ReportEventW(hev, EVENTLOG_INFORMATION_TYPE, 0, 0, nullptr, 1, 0, strs, nullptr);
+        DeregisterEventSource(hev);
+    }
+}
+
+static void LogErr(const std::string& msg)
+{
+    std::cerr << "[apply-update] ERROR: " << msg << '\n';
+
+    HANDLE hev = RegisterEventSourceW(nullptr, L"HSMAgent");
+    if (hev)
+    {
+        const std::wstring wmsg(msg.begin(), msg.end());
+        const wchar_t* strs[] = { wmsg.c_str() };
+        ReportEventW(hev, EVENTLOG_ERROR_TYPE, 0, 0, nullptr, 1, 0, strs, nullptr);
+        DeregisterEventSource(hev);
+    }
+}
+
+// Wait until the service status matches `target_state` or timeout_ms elapses.
+static bool WaitForServiceState(SC_HANDLE svc, DWORD target_state, DWORD timeout_ms)
+{
+    const DWORD deadline = GetTickCount() + timeout_ms;
+    while (true)
+    {
+        SERVICE_STATUS ss = {};
+        if (!QueryServiceStatus(svc, &ss))
+            return false;
+        if (ss.dwCurrentState == target_state)
+            return true;
+        if (GetTickCount() >= deadline)
+            return false;
+        Sleep(500);
+    }
+}
+
+namespace hsm::agent
+{
+    int RunApplyUpdate()
+    {
+        const std::wstring install_exe = InstallExePath();
+        const std::wstring new_exe = NewExePath();
+        const std::wstring old_exe = OldExePath();
+
+        // Verify that the downloaded binary exists.
+        if (GetFileAttributesW(new_exe.c_str()) == INVALID_FILE_ATTRIBUTES)
+        {
+            LogErr("hsm-agent.new.exe not found — nothing to apply");
+            return 1;
+        }
+
+        // --- Step 1: wait for the service to stop -------------------------------------------
+        SC_HANDLE scm = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
+        if (!scm)
+        {
+            LogErr("cannot open SCM");
+            return 1;
+        }
+
+        SC_HANDLE svc = OpenServiceW(scm, kServiceName, SERVICE_QUERY_STATUS | SERVICE_START | SERVICE_STOP);
+        if (!svc)
+        {
+            CloseServiceHandle(scm);
+            LogErr("cannot open HSMAgent service");
+            return 1;
+        }
+
+        Log("waiting for HSMAgent to stop (up to 60 s)...");
+        if (!WaitForServiceState(svc, SERVICE_STOPPED, 60000))
+        {
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            LogErr("HSMAgent did not stop within 60 s — aborting update");
+            DeleteFileW(new_exe.c_str());
+            return 1;
+        }
+        Log("HSMAgent stopped");
+
+        // --- Step 2 + 3: rename dance -------------------------------------------------------
+        // Remove any stale .old.exe first.
+        DeleteFileW(old_exe.c_str());
+
+        if (!MoveFileExW(install_exe.c_str(), old_exe.c_str(), MOVEFILE_REPLACE_EXISTING))
+        {
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            LogErr("cannot rename hsm-agent.exe → hsm-agent.old.exe");
+            DeleteFileW(new_exe.c_str());
+            return 1;
+        }
+
+        if (!MoveFileExW(new_exe.c_str(), install_exe.c_str(), MOVEFILE_REPLACE_EXISTING))
+        {
+            // Try to restore the old binary.
+            MoveFileExW(old_exe.c_str(), install_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            LogErr("cannot rename hsm-agent.new.exe → hsm-agent.exe; rolled back");
+            return 1;
+        }
+
+        Log("binary swap complete");
+
+        // --- Step 4: start the service ------------------------------------------------------
+        if (!StartServiceW(svc, 0, nullptr))
+        {
+            const DWORD err = GetLastError();
+            if (err != ERROR_SERVICE_ALREADY_RUNNING)
+            {
+                // Rollback.
+                MoveFileExW(install_exe.c_str(), new_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
+                MoveFileExW(old_exe.c_str(), install_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
+                StartServiceW(svc, 0, nullptr);
+                CloseServiceHandle(svc);
+                CloseServiceHandle(scm);
+                LogErr("StartService failed (" + std::to_string(err) + "); rolled back");
+                return 1;
+            }
+        }
+
+        // --- Step 5: health gate (30 s) -----------------------------------------------------
+        Log("health gate: waiting 30 s for service to reach RUNNING...");
+        if (!WaitForServiceState(svc, SERVICE_RUNNING, 30000))
+        {
+            LogErr("new version did not reach RUNNING within 30 s — rolling back");
+
+            // Stop the new (presumably crashed) service.
+            SERVICE_STATUS ss = {};
+            ControlService(svc, SERVICE_CONTROL_STOP, &ss);
+            WaitForServiceState(svc, SERVICE_STOPPED, 15000);
+
+            // Restore the old binary.
+            MoveFileExW(install_exe.c_str(), new_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
+            MoveFileExW(old_exe.c_str(), install_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
+            StartServiceW(svc, 0, nullptr);
+
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            LogErr("rolled back to previous version");
+            return 1;
+        }
+
+        Log("HSMAgent running with new version — update successful");
+        CloseServiceHandle(svc);
+        CloseServiceHandle(scm);
+        return 0;
+    }
+
+} // namespace hsm::agent

--- a/src/agent/src/apply_update.cpp
+++ b/src/agent/src/apply_update.cpp
@@ -63,9 +63,10 @@ static void LogErr(const std::string& msg)
 }
 
 // Wait until the service status matches `target_state` or timeout_ms elapses.
+// Uses GetTickCount64() to avoid the 32-bit wrap every ~49 days.
 static bool WaitForServiceState(SC_HANDLE svc, DWORD target_state, DWORD timeout_ms)
 {
-    const DWORD deadline = GetTickCount() + timeout_ms;
+    const ULONGLONG deadline = GetTickCount64() + timeout_ms;
     while (true)
     {
         SERVICE_STATUS ss = {};
@@ -73,7 +74,7 @@ static bool WaitForServiceState(SC_HANDLE svc, DWORD target_state, DWORD timeout
             return false;
         if (ss.dwCurrentState == target_state)
             return true;
-        if (GetTickCount() >= deadline)
+        if (GetTickCount64() >= deadline)
             return false;
         Sleep(500);
     }
@@ -155,7 +156,8 @@ namespace hsm::agent
                 // Rollback.
                 MoveFileExW(install_exe.c_str(), new_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
                 MoveFileExW(old_exe.c_str(), install_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
-                StartServiceW(svc, 0, nullptr);
+                if (!StartServiceW(svc, 0, nullptr) && GetLastError() != ERROR_SERVICE_ALREADY_RUNNING)
+                    LogErr("rollback: StartService for old version also failed (" + std::to_string(GetLastError()) + ") — service is stopped");
                 CloseServiceHandle(svc);
                 CloseServiceHandle(scm);
                 LogErr("StartService failed (" + std::to_string(err) + "); rolled back");
@@ -177,7 +179,8 @@ namespace hsm::agent
             // Restore the old binary.
             MoveFileExW(install_exe.c_str(), new_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
             MoveFileExW(old_exe.c_str(), install_exe.c_str(), MOVEFILE_REPLACE_EXISTING);
-            StartServiceW(svc, 0, nullptr);
+            if (!StartServiceW(svc, 0, nullptr) && GetLastError() != ERROR_SERVICE_ALREADY_RUNNING)
+                LogErr("rollback: StartService for old version also failed (" + std::to_string(GetLastError()) + ") — service is stopped");
 
             CloseServiceHandle(svc);
             CloseServiceHandle(scm);

--- a/src/agent/src/config.cpp
+++ b/src/agent/src/config.cpp
@@ -591,6 +591,12 @@ namespace hsm::agent
             error = "config: 'update.checkPeriodHours' must be at least 1";
             return false;
         }
+        // 1193 h * 3600000 ms overflows DWORD; cap at 8760 h (1 year) for safe DWORD arithmetic.
+        if (out.update_check_period_hours > 8760)
+        {
+            error = "config: 'update.checkPeriodHours' must not exceed 8760 (1 year)";
+            return false;
+        }
 
         return true;
     }

--- a/src/agent/src/config.cpp
+++ b/src/agent/src/config.cpp
@@ -540,6 +540,17 @@ namespace hsm::agent
         if (!ReadString(root, "productVersion", out.product_version, error))
             return false;
 
+        if (const JsonValue* upd = root.Find("update"))
+        {
+            if (upd->type != JsonValue::Type::Object)
+            {
+                error = "'update' must be an object";
+                return false;
+            }
+            if (!ReadBool(*upd, "enabled", out.update_enabled, error) || !ReadInt(*upd, "checkPeriodHours", out.update_check_period_hours, error))
+                return false;
+        }
+
         // Required-field validation (epic: blank key/address must refuse to start).
         if (out.server_address.empty())
         {
@@ -573,6 +584,12 @@ namespace hsm::agent
                 error = "config: 'topCpu.minPercent' must not be negative";
                 return false;
             }
+        }
+
+        if (out.update_check_period_hours < 1)
+        {
+            error = "config: 'update.checkPeriodHours' must be at least 1";
+            return false;
         }
 
         return true;

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -2,6 +2,8 @@
 //   (no args) / --service   run as an SCM service (StartServiceCtrlDispatcher)
 //   --console               run AgentRuntime in the foreground (Ctrl-C to stop) for debugging
 //   --install / --uninstall register/remove the auto-start service (requires elevation)
+//   --apply-update          detached helper: waits for service to stop, swaps binaries, restarts
+//                           with health gate (epic #1174)
 //   --config <path>         override the config.json location (default %ProgramData%\HSM Agent)
 //
 // The single signed binary is identical across every product download; only the bundled config.json
@@ -10,6 +12,7 @@
 namespace hsm { namespace agent { const char* BuildTimestamp(); } }
 
 #include "agent/agent_runtime.hpp"
+#include "agent/apply_update.hpp"
 #include "agent/config.hpp"
 #include "agent/event_log.hpp"
 #include "agent/file_logger.hpp"
@@ -58,6 +61,7 @@ namespace
                      "  --console      run in the foreground for debugging (Ctrl-C to stop)\n"
                      "  --install      register the auto-start service (requires elevation)\n"
                      "  --uninstall    remove the service (requires elevation)\n"
+                     "  --apply-update apply a staged update (spawned automatically by the agent)\n"
                      "  --config <p>   use config file <p> (default: %ProgramData%\\HSM Agent\\config.json)\n"
                      "  --version      print version and exit\n";
     }
@@ -108,7 +112,7 @@ int wmain(int argc, wchar_t** argv)
     for (int i = 1; i < argc; ++i)
     {
         const std::wstring arg = argv[i];
-        if (arg == L"--install" || arg == L"--uninstall" || arg == L"--console" || arg == L"--service")
+        if (arg == L"--install" || arg == L"--uninstall" || arg == L"--console" || arg == L"--service" || arg == L"--apply-update")
         {
             mode = arg;
         }
@@ -139,6 +143,8 @@ int wmain(int argc, wchar_t** argv)
         return InstallService();
     if (mode == L"--uninstall")
         return UninstallService();
+    if (mode == L"--apply-update")
+        return RunApplyUpdate();
 
     // Console + service runs must be single-instance so they never double-send. A Global mutex may
     // fail for a non-elevated user (no SeCreateGlobalPrivilege); in that case skip the guard rather

--- a/src/agent/src/paths.cpp
+++ b/src/agent/src/paths.cpp
@@ -51,4 +51,26 @@ namespace hsm::agent
         out = buffer.str();
         return true;
     }
+
+    std::wstring ProgramFilesAgentDir()
+    {
+        const wchar_t* pf = _wgetenv(L"ProgramFiles");
+        std::wstring base = (pf != nullptr && pf[0] != L'\0') ? pf : L"C:\\Program Files";
+        return base + L"\\HSM Agent";
+    }
+
+    std::wstring InstallExePath()
+    {
+        return ProgramFilesAgentDir() + L"\\hsm-agent.exe";
+    }
+
+    std::wstring NewExePath()
+    {
+        return ProgramFilesAgentDir() + L"\\hsm-agent.new.exe";
+    }
+
+    std::wstring OldExePath()
+    {
+        return ProgramFilesAgentDir() + L"\\hsm-agent.old.exe";
+    }
 } // namespace hsm::agent

--- a/src/agent/src/update_checker.cpp
+++ b/src/agent/src/update_checker.cpp
@@ -1,0 +1,557 @@
+// HSM Agent — background self-update checker (epic #1174).
+//
+// Flow per poll:
+//   1. GET /api/agent/version  → { version, sha256, updateEnabled }
+//   2. Compare with HSM_AGENT_VERSION (compile-time constant).
+//   3. If server version > current AND updateEnabled: download exe with Key auth,
+//      verify SHA-256, write to hsm-agent.new.exe, spawn --apply-update, RequestStop.
+//
+// HTTP: WinHTTP (built into Windows, no extra dep). TLS enforced; allow_untrusted_certificate
+// mirrors the sensor-data setting so a self-signed server works in eval setups.
+// SHA-256: Windows BCrypt (CNG).
+
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <winhttp.h>
+#include <bcrypt.h>
+
+#include "agent/update_checker.hpp"
+#include "agent/paths.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// LogLevel values mirror hsm::collector::LogLevel (info=2, error=4) without pulling in the
+// collector header from this platform-specific translation unit.
+static constexpr int kLogInfo = 2;
+static constexpr int kLogWarn = 3;
+static constexpr int kLogError = 4;
+
+namespace hsm::agent
+{
+    // ---- Version comparison -----------------------------------------------------------------------
+
+    struct SemVer
+    {
+        int major = 0, minor = 0, patch = 0;
+        bool ok = false;
+    };
+
+    static SemVer ParseVersion(const std::string& s)
+    {
+        SemVer v;
+        if (std::sscanf(s.c_str(), "%d.%d.%d", &v.major, &v.minor, &v.patch) == 3)
+            v.ok = true;
+        return v;
+    }
+
+    static bool IsNewer(const SemVer& candidate, const SemVer& current)
+    {
+        if (!candidate.ok || !current.ok)
+            return false;
+        if (candidate.major != current.major)
+            return candidate.major > current.major;
+        if (candidate.minor != current.minor)
+            return candidate.minor > current.minor;
+        return candidate.patch > current.patch;
+    }
+
+    // ---- SHA-256 via BCrypt -----------------------------------------------------------------------
+
+    static std::string Sha256File(const std::wstring& path)
+    {
+        BCRYPT_ALG_HANDLE alg = nullptr;
+        BCRYPT_HASH_HANDLE hash = nullptr;
+        if (BCryptOpenAlgorithmProvider(&alg, BCRYPT_SHA256_ALGORITHM, nullptr, 0) != 0)
+            return {};
+
+        std::string result;
+        do
+        {
+            DWORD hash_len = 0, cb_data = 0;
+            if (BCryptGetProperty(alg, BCRYPT_HASH_LENGTH, reinterpret_cast<PUCHAR>(&hash_len), sizeof(DWORD), &cb_data, 0) != 0)
+                break;
+
+            if (BCryptCreateHash(alg, &hash, nullptr, 0, nullptr, 0, 0) != 0)
+                break;
+
+            // Read file in chunks and feed to the hash.
+            HANDLE hfile = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (hfile == INVALID_HANDLE_VALUE)
+                break;
+
+            bool file_ok = true;
+            std::array<BYTE, 65536> buf;
+            DWORD read = 0;
+            while (ReadFile(hfile, buf.data(), static_cast<DWORD>(buf.size()), &read, nullptr) && read > 0)
+            {
+                if (BCryptHashData(hash, buf.data(), read, 0) != 0)
+                {
+                    file_ok = false;
+                    break;
+                }
+            }
+            CloseHandle(hfile);
+            if (!file_ok)
+                break;
+
+            std::vector<BYTE> digest(hash_len);
+            if (BCryptFinishHash(hash, digest.data(), hash_len, 0) != 0)
+                break;
+
+            std::ostringstream ss;
+            for (BYTE b : digest)
+            {
+                char hex[3];
+                std::snprintf(hex, sizeof(hex), "%02x", b);
+                ss << hex;
+            }
+            result = ss.str();
+        } while (false);
+
+        if (hash)
+            BCryptDestroyHash(hash);
+        BCryptCloseAlgorithmProvider(alg, 0);
+        return result;
+    }
+
+    // ---- Tiny JSON reader — pull a single string field from a flat JSON object ------------------
+    // The version manifest is simple: { "version": "0.5.1", "sha256": "...", "updateEnabled": true }
+
+    static bool ExtractJsonString(const std::string& json, const std::string& key, std::string& out)
+    {
+        // Find "key": then the next quoted string.
+        std::string needle = "\"" + key + "\"";
+        auto pos = json.find(needle);
+        if (pos == std::string::npos)
+            return false;
+        pos += needle.size();
+        while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' || json[pos] == ':'))
+            ++pos;
+        if (pos >= json.size() || json[pos] != '"')
+            return false;
+        ++pos;
+        out.clear();
+        while (pos < json.size() && json[pos] != '"')
+            out += json[pos++];
+        return true;
+    }
+
+    static bool ExtractJsonBool(const std::string& json, const std::string& key, bool& out)
+    {
+        std::string needle = "\"" + key + "\"";
+        auto pos = json.find(needle);
+        if (pos == std::string::npos)
+            return false;
+        pos += needle.size();
+        while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' || json[pos] == ':'))
+            ++pos;
+        if (json.compare(pos, 4, "true") == 0)
+        {
+            out = true;
+            return true;
+        }
+        if (json.compare(pos, 5, "false") == 0)
+        {
+            out = false;
+            return true;
+        }
+        return false;
+    }
+
+    // ---- WinHTTP helpers --------------------------------------------------------------------------
+
+    static std::wstring Utf8ToWide(const std::string& s)
+    {
+        if (s.empty())
+            return {};
+        const int needed = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+        if (needed <= 0)
+            return {};
+        std::wstring w(static_cast<std::size_t>(needed - 1), L'\0');
+        MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, w.data(), needed);
+        return w;
+    }
+
+    struct WinHttpSession
+    {
+        HINTERNET session = nullptr;
+        HINTERNET connect = nullptr;
+
+        explicit WinHttpSession(const std::string& host, int port, bool https, bool allow_untrusted)
+        {
+            session = WinHttpOpen(L"HSMAgent/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+            if (!session)
+                return;
+
+            connect = WinHttpConnect(session, Utf8ToWide(host).c_str(), static_cast<INTERNET_PORT>(port), 0);
+
+            if (https && allow_untrusted)
+            {
+                DWORD flags = SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
+                              SECURITY_FLAG_IGNORE_CERT_CN_INVALID | SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
+                WinHttpSetOption(session, WINHTTP_OPTION_SECURITY_FLAGS, &flags, sizeof(flags));
+            }
+        }
+
+        ~WinHttpSession()
+        {
+            if (connect)
+                WinHttpCloseHandle(connect);
+            if (session)
+                WinHttpCloseHandle(session);
+        }
+
+        bool Valid() const { return session != nullptr && connect != nullptr; }
+    };
+
+    // Do a GET request; return the body in `body_out` and optionally read a named response header.
+    // Returns the HTTP status code, or 0 on transport failure.
+    static int HttpGet(const WinHttpSession& sess, const std::wstring& path, bool https,
+                       const std::wstring& extra_headers, std::vector<char>& body_out,
+                       std::wstring* resp_header_name = nullptr, std::string* resp_header_out = nullptr)
+    {
+        if (!sess.Valid())
+            return 0;
+
+        const DWORD flags = https ? WINHTTP_FLAG_SECURE : 0;
+        HINTERNET req = WinHttpOpenRequest(sess.connect, L"GET", path.c_str(), nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES, flags);
+        if (!req)
+            return 0;
+
+        if (!extra_headers.empty())
+            WinHttpAddRequestHeaders(req, extra_headers.c_str(), static_cast<DWORD>(-1L), WINHTTP_ADDREQ_FLAG_ADD);
+
+        bool sent = WinHttpSendRequest(req, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0) &&
+                    WinHttpReceiveResponse(req, nullptr);
+
+        int status = 0;
+        if (sent)
+        {
+            DWORD status_code = 0, cb = sizeof(DWORD);
+            if (WinHttpQueryHeaders(req, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX, &status_code, &cb, WINHTTP_NO_HEADER_INDEX))
+                status = static_cast<int>(status_code);
+
+            if (status == 200)
+            {
+                // Read optional named response header.
+                if (resp_header_name && resp_header_out)
+                {
+                    DWORD hdr_size = 0;
+                    WinHttpQueryHeaders(req, WINHTTP_QUERY_CUSTOM, resp_header_name->c_str(), WINHTTP_NO_OUTPUT_BUFFER, &hdr_size, WINHTTP_NO_HEADER_INDEX);
+                    if (GetLastError() == ERROR_INSUFFICIENT_BUFFER)
+                    {
+                        std::wstring wval(hdr_size / sizeof(wchar_t), L'\0');
+                        if (WinHttpQueryHeaders(req, WINHTTP_QUERY_CUSTOM, resp_header_name->c_str(), wval.data(), &hdr_size, WINHTTP_NO_HEADER_INDEX))
+                        {
+                            // strip null terminator that WinHttp appends
+                            while (!wval.empty() && wval.back() == L'\0')
+                                wval.pop_back();
+                            const int n = WideCharToMultiByte(CP_UTF8, 0, wval.c_str(), -1, nullptr, 0, nullptr, nullptr);
+                            if (n > 0)
+                            {
+                                std::string s(static_cast<std::size_t>(n - 1), '\0');
+                                WideCharToMultiByte(CP_UTF8, 0, wval.c_str(), -1, s.data(), n, nullptr, nullptr);
+                                *resp_header_out = std::move(s);
+                            }
+                        }
+                    }
+                }
+
+                // Stream the body.
+                DWORD avail = 0;
+                while (WinHttpQueryDataAvailable(req, &avail) && avail > 0)
+                {
+                    const std::size_t off = body_out.size();
+                    body_out.resize(off + avail);
+                    DWORD read = 0;
+                    if (!WinHttpReadData(req, body_out.data() + off, avail, &read))
+                    {
+                        body_out.resize(off);
+                        break;
+                    }
+                    body_out.resize(off + read);
+                }
+            }
+        }
+
+        WinHttpCloseHandle(req);
+        return status;
+    }
+
+    // ---- Parse server URL into (scheme, host, port) ----------------------------------------------
+
+    struct ServerUrl
+    {
+        bool https = true;
+        std::string host;
+        int port = 44330;
+        bool ok = false;
+    };
+
+    static ServerUrl ParseServerUrl(const std::string& address, int config_port)
+    {
+        ServerUrl u;
+        u.port = config_port;
+        std::string addr = address;
+        if (addr.compare(0, 8, "https://") == 0)
+        {
+            u.https = true;
+            addr = addr.substr(8);
+        }
+        else if (addr.compare(0, 7, "http://") == 0)
+        {
+            u.https = false;
+            addr = addr.substr(7);
+        }
+        else
+        {
+            u.https = true;
+        }
+        // strip trailing slash or path
+        const auto slash = addr.find('/');
+        if (slash != std::string::npos)
+            addr = addr.substr(0, slash);
+        // host:port
+        const auto colon = addr.rfind(':');
+        if (colon != std::string::npos)
+        {
+            try
+            {
+                u.port = std::stoi(addr.substr(colon + 1));
+                addr = addr.substr(0, colon);
+            }
+            catch (...)
+            {
+            }
+        }
+        u.host = addr;
+        u.ok = !u.host.empty();
+        return u;
+    }
+
+    // ---- Spawn --apply-update detached process ---------------------------------------------------
+
+    static bool SpawnApplyUpdate(const LogFn& log)
+    {
+        wchar_t exe_path[MAX_PATH] = {};
+        if (!GetModuleFileNameW(nullptr, exe_path, MAX_PATH))
+        {
+            log(kLogError, "update: GetModuleFileName failed");
+            return false;
+        }
+
+        std::wstring cmd_line = std::wstring(L"\"") + exe_path + L"\" --apply-update";
+        STARTUPINFOW si = {};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi = {};
+        if (!CreateProcessW(nullptr, cmd_line.data(), nullptr, nullptr, FALSE, DETACHED_PROCESS | CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+        {
+            log(kLogError, "update: failed to spawn --apply-update");
+            return false;
+        }
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+        log(kLogInfo, "update: --apply-update spawned");
+        return true;
+    }
+
+    // ---- UpdateChecker implementation ------------------------------------------------------------
+
+    static DWORD WINAPI UpdateThreadProc(LPVOID param)
+    {
+        static_cast<UpdateChecker*>(param)->Run();
+        return 0;
+    }
+
+    UpdateChecker::UpdateChecker(const AgentConfig& config, LogFn log, std::function<void()> request_stop)
+        : config_(config), log_(std::move(log)), request_stop_(std::move(request_stop))
+    {
+        stop_event_ = CreateEventW(nullptr, TRUE, FALSE, nullptr);
+    }
+
+    UpdateChecker::~UpdateChecker()
+    {
+        Stop();
+        if (stop_event_)
+            CloseHandle(static_cast<HANDLE>(stop_event_));
+    }
+
+    void UpdateChecker::Start()
+    {
+        if (!config_.update_enabled)
+            return;
+        if (stop_event_ == nullptr)
+            return;
+        ResetEvent(static_cast<HANDLE>(stop_event_));
+        thread_handle_ = CreateThread(nullptr, 0, UpdateThreadProc, this, 0, nullptr);
+    }
+
+    void UpdateChecker::Stop()
+    {
+        if (stop_event_)
+            SetEvent(static_cast<HANDLE>(stop_event_));
+        if (thread_handle_)
+        {
+            WaitForSingleObject(static_cast<HANDLE>(thread_handle_), 10000);
+            CloseHandle(static_cast<HANDLE>(thread_handle_));
+            thread_handle_ = nullptr;
+        }
+    }
+
+    void UpdateChecker::Run()
+    {
+        if (!config_.update_enabled)
+            return;
+
+        // Jitter: wait 0–10 min on first boot so a fleet doesn't all check at once.
+        const DWORD jitter_ms = static_cast<DWORD>(GetTickCount64() % 600000ULL);
+        const DWORD period_ms = static_cast<DWORD>(config_.update_check_period_hours) * 3600000UL;
+
+        HANDLE ev = static_cast<HANDLE>(stop_event_);
+
+        // Initial jitter wait.
+        if (WaitForSingleObject(ev, jitter_ms) == WAIT_OBJECT_0)
+            return;
+
+        while (true)
+        {
+            if (CheckAndUpdate())
+                return; // update triggered — the service will be restarted by --apply-update
+
+            if (WaitForSingleObject(ev, period_ms) == WAIT_OBJECT_0)
+                return;
+        }
+    }
+
+    bool UpdateChecker::CheckAndUpdate()
+    {
+        const ServerUrl url = ParseServerUrl(config_.server_address, config_.port);
+        if (!url.ok)
+        {
+            log_(kLogWarn, "update: cannot parse server address");
+            return false;
+        }
+
+        WinHttpSession sess(url.host, url.port, url.https, config_.allow_untrusted_certificate);
+        if (!sess.Valid())
+        {
+            log_(kLogWarn, "update: WinHttp session failed");
+            return false;
+        }
+
+        // Step 1: fetch version manifest.
+        std::vector<char> manifest_body;
+        const int status = HttpGet(sess, L"/api/agent/version", url.https, L"", manifest_body);
+        if (status != 200)
+        {
+            log_(kLogWarn, "update: version manifest returned HTTP " + std::to_string(status));
+            return false;
+        }
+
+        std::string manifest(manifest_body.begin(), manifest_body.end());
+
+        std::string remote_version_str, remote_sha256;
+        bool update_enabled = false;
+        if (!ExtractJsonString(manifest, "version", remote_version_str) ||
+            !ExtractJsonString(manifest, "sha256", remote_sha256) ||
+            !ExtractJsonBool(manifest, "updateEnabled", update_enabled))
+        {
+            log_(kLogWarn, "update: cannot parse version manifest");
+            return false;
+        }
+
+        if (!update_enabled)
+        {
+            log_(kLogInfo, "update: server has auto-update disabled");
+            return false;
+        }
+
+        const SemVer remote = ParseVersion(remote_version_str);
+        const SemVer current = ParseVersion(HSM_AGENT_VERSION);
+        if (!IsNewer(remote, current))
+        {
+            log_(kLogInfo, "update: already up to date (" HSM_AGENT_VERSION ")");
+            return false;
+        }
+
+        log_(kLogInfo, "update: new version available: " + remote_version_str + " (current: " HSM_AGENT_VERSION ")");
+
+        // Step 2: download the exe.
+        const std::wstring key_header = L"Key: " + Utf8ToWide(config_.access_key);
+        std::vector<char> exe_body;
+        std::wstring sha256_header_name = L"X-Agent-Sha256";
+        std::string header_sha256;
+        const int exe_status = HttpGet(sess, L"/api/agent/exe", url.https, key_header, exe_body, &sha256_header_name, &header_sha256);
+        if (exe_status != 200 || exe_body.empty())
+        {
+            log_(kLogError, "update: exe download failed (HTTP " + std::to_string(exe_status) + ")");
+            return false;
+        }
+
+        // Step 3: write to hsm-agent.new.exe.
+        const std::wstring new_path = NewExePath();
+        {
+            HANDLE hf = CreateFileW(new_path.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+            if (hf == INVALID_HANDLE_VALUE)
+            {
+                log_(kLogError, "update: cannot write hsm-agent.new.exe");
+                return false;
+            }
+            DWORD written = 0;
+            WriteFile(hf, exe_body.data(), static_cast<DWORD>(exe_body.size()), &written, nullptr);
+            CloseHandle(hf);
+            if (written != static_cast<DWORD>(exe_body.size()))
+            {
+                log_(kLogError, "update: partial write to hsm-agent.new.exe");
+                DeleteFileW(new_path.c_str());
+                return false;
+            }
+        }
+
+        // Step 4: verify SHA-256.
+        const std::string actual_sha256 = Sha256File(new_path);
+        if (actual_sha256.empty())
+        {
+            log_(kLogError, "update: SHA-256 computation failed");
+            DeleteFileW(new_path.c_str());
+            return false;
+        }
+
+        // Prefer manifest's sha256 (from /api/agent/version); fall back to response header.
+        const std::string& expected = !remote_sha256.empty() ? remote_sha256 : header_sha256;
+        if (actual_sha256 != expected)
+        {
+            log_(kLogError, "update: SHA-256 mismatch — expected " + expected + " got " + actual_sha256);
+            DeleteFileW(new_path.c_str());
+            return false;
+        }
+
+        log_(kLogInfo, "update: SHA-256 verified, staging update");
+
+        // Step 5: spawn --apply-update, then request stop of the current service run.
+        if (!SpawnApplyUpdate(log_))
+        {
+            DeleteFileW(new_path.c_str());
+            return false;
+        }
+
+        log_(kLogInfo, "update: requesting service stop for restart");
+        if (request_stop_)
+            request_stop_();
+
+        return true;
+    }
+
+} // namespace hsm::agent

--- a/src/agent/src/update_checker.cpp
+++ b/src/agent/src/update_checker.cpp
@@ -188,21 +188,16 @@ namespace hsm::agent
     {
         HINTERNET session = nullptr;
         HINTERNET connect = nullptr;
+        bool allow_untrusted = false; // forwarded to each request handle (session-level has no effect)
 
-        explicit WinHttpSession(const std::string& host, int port, bool https, bool allow_untrusted)
+        explicit WinHttpSession(const std::string& host, int port, bool /*https*/, bool allow_untr)
+            : allow_untrusted(allow_untr)
         {
             session = WinHttpOpen(L"HSMAgent/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY, WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
             if (!session)
                 return;
 
             connect = WinHttpConnect(session, Utf8ToWide(host).c_str(), static_cast<INTERNET_PORT>(port), 0);
-
-            if (https && allow_untrusted)
-            {
-                DWORD flags = SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
-                              SECURITY_FLAG_IGNORE_CERT_CN_INVALID | SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
-                WinHttpSetOption(session, WINHTTP_OPTION_SECURITY_FLAGS, &flags, sizeof(flags));
-            }
         }
 
         ~WinHttpSession()
@@ -232,6 +227,14 @@ namespace hsm::agent
 
         if (!extra_headers.empty())
             WinHttpAddRequestHeaders(req, extra_headers.c_str(), static_cast<DWORD>(-1L), WINHTTP_ADDREQ_FLAG_ADD);
+
+        // WINHTTP_OPTION_SECURITY_FLAGS must be set on the request handle, not the session.
+        if (https && sess.allow_untrusted)
+        {
+            DWORD sec_flags = SECURITY_FLAG_IGNORE_UNKNOWN_CA | SECURITY_FLAG_IGNORE_CERT_DATE_INVALID |
+                              SECURITY_FLAG_IGNORE_CERT_CN_INVALID | SECURITY_FLAG_IGNORE_CERT_WRONG_USAGE;
+            WinHttpSetOption(req, WINHTTP_OPTION_SECURITY_FLAGS, &sec_flags, sizeof(sec_flags));
+        }
 
         bool sent = WinHttpSendRequest(req, WINHTTP_NO_ADDITIONAL_HEADERS, 0, WINHTTP_NO_REQUEST_DATA, 0, 0, 0) &&
                     WinHttpReceiveResponse(req, nullptr);

--- a/src/agent/src/update_checker.cpp
+++ b/src/agent/src/update_checker.cpp
@@ -346,7 +346,7 @@ namespace hsm::agent
 
     // ---- Spawn --apply-update detached process ---------------------------------------------------
 
-    static bool SpawnApplyUpdate(const LogFn& log)
+    static bool SpawnApplyUpdate(const UpdateChecker::LogFn& log)
     {
         wchar_t exe_path[MAX_PATH] = {};
         if (!GetModuleFileNameW(nullptr, exe_path, MAX_PATH))
@@ -372,7 +372,7 @@ namespace hsm::agent
 
     // ---- UpdateChecker implementation ------------------------------------------------------------
 
-    static DWORD WINAPI UpdateThreadProc(LPVOID param)
+    DWORD WINAPI UpdateChecker::ThreadProc(LPVOID param)
     {
         static_cast<UpdateChecker*>(param)->Run();
         return 0;
@@ -398,7 +398,7 @@ namespace hsm::agent
         if (stop_event_ == nullptr)
             return;
         ResetEvent(static_cast<HANDLE>(stop_event_));
-        thread_handle_ = CreateThread(nullptr, 0, UpdateThreadProc, this, 0, nullptr);
+        thread_handle_ = CreateThread(nullptr, 0, ThreadProc, this, 0, nullptr);
     }
 
     void UpdateChecker::Stop()

--- a/src/agent/src/update_checker.cpp
+++ b/src/agent/src/update_checker.cpp
@@ -372,7 +372,7 @@ namespace hsm::agent
 
     // ---- UpdateChecker implementation ------------------------------------------------------------
 
-    DWORD WINAPI UpdateChecker::ThreadProc(LPVOID param)
+    static DWORD WINAPI UpdateThreadProc(LPVOID param)
     {
         static_cast<UpdateChecker*>(param)->Run();
         return 0;
@@ -398,7 +398,7 @@ namespace hsm::agent
         if (stop_event_ == nullptr)
             return;
         ResetEvent(static_cast<HANDLE>(stop_event_));
-        thread_handle_ = CreateThread(nullptr, 0, ThreadProc, this, 0, nullptr);
+        thread_handle_ = CreateThread(nullptr, 0, UpdateThreadProc, this, 0, nullptr);
     }
 
     void UpdateChecker::Stop()

--- a/src/agent/src/update_checker.cpp
+++ b/src/agent/src/update_checker.cpp
@@ -418,22 +418,20 @@ namespace hsm::agent
         if (!config_.update_enabled)
             return;
 
-        // Jitter: wait 0–10 min on first boot so a fleet doesn't all check at once.
-        const DWORD jitter_ms = static_cast<DWORD>(GetTickCount64() % 600000ULL);
         const DWORD period_ms = static_cast<DWORD>(config_.update_check_period_hours) * 3600000UL;
-
         HANDLE ev = static_cast<HANDLE>(stop_event_);
 
-        // Initial jitter wait.
-        if (WaitForSingleObject(ev, jitter_ms) == WAIT_OBJECT_0)
-            return;
+        // Check immediately on startup — restarting the Windows service is the admin's "check now"
+        // gesture; no need to wait the full period to pick up a freshly staged binary.
+        if (CheckAndUpdate())
+            return; // update triggered — the service will be restarted by --apply-update
 
         while (true)
         {
-            if (CheckAndUpdate())
-                return; // update triggered — the service will be restarted by --apply-update
-
             if (WaitForSingleObject(ev, period_ms) == WAIT_OBJECT_0)
+                return;
+
+            if (CheckAndUpdate())
                 return;
         }
     }

--- a/src/agent/tests/agent_tests.cpp
+++ b/src/agent/tests/agent_tests.cpp
@@ -88,7 +88,8 @@ namespace
             "identity": { "computerName": "BUILD01", "module": "Custom Module" },
             "sensors": { "computer": false, "system": true, "disk": false, "network": true, "module": false, "process": true },
             "periods": { "collectMs": 5000 },
-            "productVersion": "2.3.4.5"
+            "productVersion": "2.3.4.5",
+            "update": { "enabled": false, "checkPeriodHours": 48 }
         })");
         CheckEq(config.server_address, std::string{ "https://h:1" }, "address");
         CheckEq(config.port, 9999, "port");
@@ -104,6 +105,8 @@ namespace
         Check(config.sensors_process, "process on");
         CheckEq(config.collect_period_ms, 5000, "collect period");
         CheckEq(config.product_version, std::string{ "2.3.4.5" }, "version");
+        Check(!config.update_enabled, "update disabled");
+        CheckEq(config.update_check_period_hours, 48, "update period");
     }
 
     void BlankAccessKeyIsRejected()
@@ -204,6 +207,8 @@ namespace
     {
         ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": { "checkPeriodHours": 0 } })", "zero period");
         ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": { "checkPeriodHours": -1 } })", "negative period");
+        // 1194 h * 3600000 overflows DWORD — must be rejected.
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": { "checkPeriodHours": 9000 } })", "overflow period");
         ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": "on" })", "non-object update");
     }
 

--- a/src/agent/tests/agent_tests.cpp
+++ b/src/agent/tests/agent_tests.cpp
@@ -184,6 +184,29 @@ namespace
         ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "topCpu": { "enabled": "yes" } })", "non-bool enabled");
     }
 
+    void UpdateConfigParsesAndDefaults()
+    {
+        // Absent update section → enabled=true, 24 h default.
+        const auto def = ParseOk(R"({ "server": { "address": "h", "accessKey": "k" } })");
+        Check(def.update_enabled, "update enabled by default");
+        CheckEq(def.update_check_period_hours, 24, "default check period");
+
+        // Explicit values round-trip.
+        const auto cfg = ParseOk(R"({
+            "server": { "address": "h", "accessKey": "k" },
+            "update": { "enabled": false, "checkPeriodHours": 12 }
+        })");
+        Check(!cfg.update_enabled, "disabled");
+        CheckEq(cfg.update_check_period_hours, 12, "check period");
+    }
+
+    void UpdateConfigRejectsBadPeriod()
+    {
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": { "checkPeriodHours": 0 } })", "zero period");
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": { "checkPeriodHours": -1 } })", "negative period");
+        ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": "on" })", "non-object update");
+    }
+
     const std::map<std::string, std::function<void()>>& Tests()
     {
         static const std::map<std::string, std::function<void()>> tests = {
@@ -198,6 +221,8 @@ namespace
             { "agent_config_decodes_string_escapes", StringEscapesDecode },
             { "agent_topcpu_config_parses_and_defaults", TopCpuConfigParsesAndDefaults },
             { "agent_topcpu_rejects_bad_config", TopCpuRejectsBadConfig },
+            { "agent_update_config_parses_and_defaults", UpdateConfigParsesAndDefaults },
+            { "agent_update_config_rejects_bad_period", UpdateConfigRejectsBadPeriod },
         };
         return tests;
     }

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
@@ -51,6 +51,14 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
         private readonly TimeSpan _period;
         private readonly int _processorCount;
 
+        // Dedicated cap on the number of distinct "Top CPU processes/<name>" sensors this feature
+        // may ever create. The server sensor registry is permanent, so without a bound a host that
+        // churns through distinctly named processes (CI/build agents, batch jobs) would grow the
+        // namespace without limit. 8x the per-tick count (min 64) leaves generous headroom for
+        // normal rotation; once reached, new names are skipped and already-tracked names keep
+        // updating. Mirrors the native collector's max_tracked_names bound.
+        private readonly int _maxTrackedNames;
+
         // name -> sensor handle (created lazily on first appearance)
         private readonly Dictionary<string, IInstantValueSensor<double>> _sensors =
             new Dictionary<string, IInstantValueSensor<double>>();
@@ -73,6 +81,7 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
             _minPercent = minPercent;
             _period = period;
             _processorCount = GetTotalProcessorCount();
+            _maxTrackedNames = Math.Max(count * 8, 64);
         }
 
         public ValueTask<bool> InitAsync()
@@ -155,7 +164,8 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                     curCpu[key] = cpuMs;
 
                     // Cache full path on first encounter — MainModule can throw for protected processes.
-                    if (!_fullPaths.ContainsKey(p.ProcessName))
+                    // Bounded by the same cap as the sensor map so this dictionary can't grow without limit.
+                    if (_fullPaths.Count < _maxTrackedNames && !_fullPaths.ContainsKey(p.ProcessName))
                     {
                         try { _fullPaths[p.ProcessName] = p.MainModule.FileName; }
                         catch { }
@@ -199,6 +209,11 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                 IInstantValueSensor<double> sensor;
                 if (!_sensors.TryGetValue(name, out sensor))
                 {
+                    // Dedicated namespace cap: stop creating new per-process sensors once the bound
+                    // is reached so transient processes can't grow the server namespace without limit.
+                    if (_sensors.Count >= _maxTrackedNames)
+                        continue;
+
                     string fullPath;
                     _fullPaths.TryGetValue(name, out fullPath);
                     var pathLine = string.IsNullOrEmpty(fullPath) ? "" : "\n\n**Path:** `" + fullPath + "`";

--- a/src/collector/HSMDataCollector/PublicAPI/IWindowsCollection.cs
+++ b/src/collector/HSMDataCollector/PublicAPI/IWindowsCollection.cs
@@ -128,6 +128,9 @@ namespace HSMDataCollector.PublicInterface
         /// <paramref name="period"/> (default 1 minute), posts Double sensors at
         /// "Top CPU processes/&lt;exe-name&gt;" for the <paramref name="count"/> busiest processes
         /// above <paramref name="minPercent"/>% of total machine CPU. Windows only.
+        /// The number of distinct per-process sensors is capped (max(<paramref name="count"/> * 8, 64))
+        /// so a host that churns through many distinctly named processes cannot grow the sensor
+        /// namespace without bound; once the cap is reached, newly seen process names are skipped.
         /// </summary>
         IWindowsCollection AddTopCpuProcessesSensors(int count = 10, double minPercent = 1.0, TimeSpan? period = null);
     }

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -798,6 +798,9 @@ const char* hsm_collector_last_error(const hsm_collector_t* collector);
    samples all processes at intervals of `period_ms` milliseconds, filters to the `count` busiest
    above `min_percent`% of total machine CPU, and posts a Double sensor for each at path
    "Top CPU processes/<exe-name>". Call BEFORE Start().
+   The number of distinct per-process sensors is capped (max(count * 8, 64)) so a host that churns
+   through many distinctly named processes cannot grow the sensor namespace without bound or exhaust
+   the global MaxSensors cap; once the cap is reached, newly seen process names are skipped.
    Returns HSM_RESULT_INVALID_ARGUMENT if count <= 0 or period_ms <= 0.
    Returns HSM_RESULT_INVALID_STATE if already started or not on Windows. */
 hsm_result_t hsm_collector_enable_top_cpu_sensors(

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -3263,6 +3263,18 @@ namespace
             std::map<std::string, std::shared_ptr<NativeSensor>> sensor_cache;
             const auto period = std::chrono::milliseconds(top_cpu_period_ms_);
 
+            // Dedicated cap on the number of distinct "Top CPU processes/<name>" sensors this
+            // feature may ever create. The server sensor registry (sensors_) is permanent — there
+            // is no delete-sensor API — so without a bound a host that churns through distinctly
+            // named processes (CI/build agents, batch jobs) would grow the namespace without limit
+            // and could silently consume the global MaxSensors cap, starving legitimately-busy
+            // processes. 8x the per-tick count (min 64) leaves generous headroom for normal
+            // rotation of busy processes while containing runaway churn. Once the cap is reached,
+            // new names are skipped; already-tracked names keep updating.
+            const size_t max_tracked_names =
+                std::max<size_t>(static_cast<size_t>(top_cpu_count_) * 8, 64);
+            bool cap_logged = false;
+
             sampler.Sample(); // seed baseline — first call returns empty map, so first post is a true delta
 
             while (true)
@@ -3282,6 +3294,21 @@ namespace
                         auto it = sensor_cache.find(usage.name);
                         if (it == sensor_cache.end())
                         {
+                            // Dedicated namespace cap: stop creating new per-process sensors once
+                            // the bound is reached so transient processes can't grow the registry
+                            // without limit or exhaust the global MaxSensors cap. Log once.
+                            if (sensor_cache.size() >= max_tracked_names)
+                            {
+                                if (!cap_logged)
+                                {
+                                    LogError("top-CPU: tracked-process cap (" +
+                                             std::to_string(max_tracked_names) +
+                                             ") reached; new process names will not get a sensor.");
+                                    cap_logged = true;
+                                }
+                                continue;
+                            }
+
                             // Creating a sensor from this background thread (after Start) is safe:
                             // CollectorImpl::CreateSensor serializes on mutex_, and the scheduler
                             // reads the registry only via a snapshot under the same lock.

--- a/src/server/HSMServer/Controllers/AgentController.cs
+++ b/src/server/HSMServer/Controllers/AgentController.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.IO;
+using System.Security.Cryptography;
 
 namespace HSMServer.Controllers
 {
@@ -18,6 +19,10 @@ namespace HSMServer.Controllers
     /// (this server's address + the product's access key) + silent install scripts. The server ONLY
     /// generates + serves the zip — it is not an installer; the client install is the C++ exe's own
     /// <c>--install</c> (no .NET/MSI on the client).
+    ///
+    /// Epic #1174 adds two unauthenticated / key-authenticated endpoints for the agent self-update
+    /// channel: <c>GET /api/agent/version</c> (version manifest) and <c>GET /api/agent/exe</c>
+    /// (binary download, Key-header auth).
     /// </summary>
     [Authorize]
     [Route("api/[controller]")]
@@ -82,6 +87,62 @@ namespace HSMServer.Controllers
         }
 
 
+        /// <summary>
+        /// Agent self-update manifest (epic #1174). Returns the version, SHA-256, and whether the
+        /// server permits auto-updates. No authentication — version info is not sensitive and agents
+        /// need to poll this before they have a user context. Returns 503 when no exe is staged.
+        /// </summary>
+        [HttpGet("version")]
+        [AllowAnonymous]
+        public IActionResult GetVersion()
+        {
+            if (string.IsNullOrEmpty(_environment.WebRootPath))
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
+
+            var exePath = Path.Combine(_environment.WebRootPath, "agent", AgentInstallerBundle.ExeName);
+            if (!System.IO.File.Exists(exePath))
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
+
+            var sha256 = ComputeSha256Hex(exePath);
+            var version = ReadStagedVersion(_environment.WebRootPath);
+
+            return Ok(new
+            {
+                version,
+                sha256,
+                updateEnabled = _config.Agent.AutoUpdateEnabled,
+            });
+        }
+
+
+        /// <summary>
+        /// Serve the staged agent binary for self-update (epic #1174). Requires a valid product access
+        /// key in the <c>Key</c> request header — the agent sends the same key it uses for sensor data.
+        /// Sets <c>X-Agent-Sha256</c> on the response so the caller can verify integrity without a
+        /// second round-trip.
+        /// </summary>
+        [HttpGet("exe")]
+        [AllowAnonymous]
+        public IActionResult GetExe()
+        {
+            // Validate the Key header — same GUID-based access-key the agent sends for sensor data.
+            var keyHeader = Request.Headers["Key"].ToString();
+            if (!Guid.TryParse(keyHeader, out var keyGuid) || !_cache.TryGetKey(keyGuid, out _, out _))
+                return Unauthorized("A valid product access key is required in the 'Key' header.");
+
+            if (string.IsNullOrEmpty(_environment.WebRootPath))
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
+
+            var exePath = Path.Combine(_environment.WebRootPath, "agent", AgentInstallerBundle.ExeName);
+            if (!System.IO.File.Exists(exePath))
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
+
+            var sha256 = ComputeSha256Hex(exePath);
+            Response.Headers["X-Agent-Sha256"] = sha256;
+            return PhysicalFile(exePath, "application/octet-stream", AgentInstallerBundle.ExeName);
+        }
+
+
         private static string Sanitize(string name)
         {
             if (string.IsNullOrWhiteSpace(name))
@@ -92,6 +153,30 @@ namespace HSMServer.Controllers
                 sanitized = sanitized.Replace(invalid, '_');
 
             return sanitized.Replace(' ', '_');
+        }
+
+        private static string ComputeSha256Hex(string filePath)
+        {
+            using var sha256 = SHA256.Create();
+            using var stream = System.IO.File.OpenRead(filePath);
+            var hash = sha256.ComputeHash(stream);
+            return BitConverter.ToString(hash).Replace("-", "").ToLowerInvariant();
+        }
+
+        /// Read `wwwroot/agent/version.txt` (one-line version string staged by CI). Falls back to
+        /// "0.0.0" so the manifest stays valid even when the version file was not staged yet.
+        private static string ReadStagedVersion(string webRootPath)
+        {
+            var versionPath = Path.Combine(webRootPath, "agent", "version.txt");
+            try
+            {
+                var text = System.IO.File.ReadAllText(versionPath).Trim();
+                return string.IsNullOrEmpty(text) ? "0.0.0" : text;
+            }
+            catch
+            {
+                return "0.0.0";
+            }
         }
     }
 }

--- a/src/server/HSMServer/Controllers/AgentController.cs
+++ b/src/server/HSMServer/Controllers/AgentController.cs
@@ -100,10 +100,18 @@ namespace HSMServer.Controllers
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
 
             var exePath = Path.Combine(_environment.WebRootPath, "agent", AgentInstallerBundle.ExeName);
-            if (!System.IO.File.Exists(exePath))
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
 
-            var sha256 = ComputeSha256Hex(exePath);
+            // Read + hash in one open call — no separate File.Exists to avoid TOCTOU.
+            string sha256;
+            try
+            {
+                sha256 = ComputeSha256Hex(exePath);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
+            }
+
             var version = ReadStagedVersion(_environment.WebRootPath);
 
             return Ok(new
@@ -134,10 +142,17 @@ namespace HSMServer.Controllers
                 return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
 
             var exePath = Path.Combine(_environment.WebRootPath, "agent", AgentInstallerBundle.ExeName);
-            if (!System.IO.File.Exists(exePath))
-                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
 
-            var sha256 = ComputeSha256Hex(exePath);
+            string sha256;
+            try
+            {
+                sha256 = ComputeSha256Hex(exePath);
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException or IOException)
+            {
+                return StatusCode(StatusCodes.Status503ServiceUnavailable, "Agent binary not staged.");
+            }
+
             Response.Headers["X-Agent-Sha256"] = sha256;
             return PhysicalFile(exePath, "application/octet-stream", AgentInstallerBundle.ExeName);
         }

--- a/src/server/HSMServer/HSMSwaggerComments.xml
+++ b/src/server/HSMServer/HSMSwaggerComments.xml
@@ -296,5 +296,24 @@
             client agent has no UI and simply runs whatever config.json the bundle ships. Default false.
             </summary>
         </member>
+        <member name="P:HSMServer.ServerConfiguration.AgentConfig.AutoUpdateEnabled">
+            <summary>
+            Global kill-switch for the agent self-update channel (epic #1174). When false the
+            <c>GET /api/agent/version</c> manifest returns <c>updateEnabled: false</c> and every agent
+            that polls it will stay on its current version. Default false (opt-in).
+            </summary>
+        </member>
+        <member name="M:HSMServer.Controllers.AgentController.GetVersion">
+            <summary>
+            Agent self-update manifest (epic #1174). Returns version, SHA-256 of the staged exe, and
+            whether the server permits auto-updates. No authentication. Returns 503 when no exe is staged.
+            </summary>
+        </member>
+        <member name="M:HSMServer.Controllers.AgentController.GetExe">
+            <summary>
+            Serve the staged agent binary for self-update (epic #1174). Requires a valid product access
+            key in the <c>Key</c> request header. Sets <c>X-Agent-Sha256</c> on the response.
+            </summary>
+        </member>
     </members>
 </doc>

--- a/src/server/HSMServer/ServerConfiguration/Sections/AgentConfig.cs
+++ b/src/server/HSMServer/ServerConfiguration/Sections/AgentConfig.cs
@@ -22,4 +22,12 @@ public class AgentConfig
     /// client agent has no UI and simply runs whatever config.json the bundle ships. Default false.
     /// </summary>
     public bool EnableTopCpuProcesses { get; set; }
+
+    /// <summary>
+    /// Global kill-switch for the agent self-update channel (epic #1174). When false the
+    /// <c>GET /api/agent/version</c> manifest returns <c>updateEnabled: false</c> and every agent
+    /// that polls it will stay on its current version regardless of its local config. Default false
+    /// (opt-in: enable when ready to roll out, disable to halt).
+    /// </summary>
+    public bool AutoUpdateEnabled { get; set; }
 }


### PR DESCRIPTION
## Summary

- **Server**: two new unauthenticated/key-auth endpoints on `AgentController` — `GET /api/agent/version` returns `{version, sha256, updateEnabled}` (reads `wwwroot/agent/version.txt` + computes SHA-256 of the staged exe at request time); `GET /api/agent/exe` requires the agent's own access key in the `Key` header and returns the binary stream with `X-Agent-Sha256`. New `AgentConfig.AutoUpdateEnabled` global kill-switch (default **false**; opt-in when ready to roll out). CI now also stages `version.txt` alongside the exe.
- **Agent** (`update_checker.cpp`): background WinHTTP polling thread — fetches the version manifest, compares semver (downgrade protection: rejects `remote ≤ current`), downloads and SHA-256 verifies (BCrypt/CNG) the new exe to `hsm-agent.new.exe`, spawns `--apply-update` detached, then calls `RequestStop` for a graceful service shutdown.
- **Agent** (`apply_update.cpp`): detached helper started by `--apply-update` — waits up to 60 s for the service to reach `STOPPED`, does the binary rename dance (`exe→old`, `new→exe`), starts the service, 30 s health gate; on failure rolls back (`old→exe`), restarts the old version, logs to Event Log.
- **Config schema**: new `update.{enabled, checkPeriodHours}` section (default: enabled=true, 24 h); 2 new unit tests.
- **aicontext** feature doc updated.

## Design notes

- Global kill-switch on server (`AutoUpdateEnabled: false` default) — enable when ready, flip back to pause.
- Per-machine opt-out: `update.enabled: false` in the machine's `config.json`.
- No per-product override (agreed: too many products, manual testing on one machine before enabling globally).
- No server-side forced rollback needed — rollback = re-stage old exe on server + disable flag.
- TLS + SHA-256 integrity model (no code-signing in v1, consistent with existing binary invariant).
- WinHTTP + BCrypt used directly in agent (Windows SDK only, no extra vcpkg dep).

## Test plan

- [ ] Config parser tests pass: `ctest` in `build/agent` — 13 cases including 2 new update config cases
- [ ] Agent build passes: `cmake --build build/agent --config Release`
- [ ] Server builds cleanly (new endpoints compile, `TryGetKey` usage correct)
- [ ] Manual smoke: `GET /api/agent/version` returns JSON with version/sha256/updateEnabled=false; `GET /api/agent/exe` with valid Key returns binary + X-Agent-Sha256 header; with invalid Key → 401
- [ ] End-to-end (manual): bump version in CMakeLists.txt, rebuild agent, stage new exe on server, set AutoUpdateEnabled=true — running agent picks up update, applies it, service restarts on new version, `hsm-agent.old.exe` deleted on next startup

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)