### PR TITLE
fix(#1179): cap distinct top-CPU sensor names in both collectors

### DIFF
--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -98,6 +98,9 @@ before `Stop()`, waits on the same `cv_` so it exits the moment stop is requeste
 2. `SelectTopN` (portable, unit-tested) keeps names `>= minPercent` and returns the busiest `count`.
 3. Each survivor's % is posted to a lazily-created `Top CPU processes/<exe>` Double sensor (cached by
    name). Names not in the top list that tick get **no value** → natural gaps in their series.
+   The distinct-name set is **capped at `max(count * 8, 64)`** in both collectors (the server sensor
+   registry is permanent, with no delete API): once the cap is reached, newly seen process names are
+   skipped so a churn-heavy host can't grow the namespace without bound or exhaust the global MaxSensors.
 
 Aggregating by exe name (not PID, not PDH `#n` suffix) keeps a stable sensor identity over time.
 **Out of scope:** browser tab/site attribution (needs browser-level instrumentation; tracked separately).

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
@@ -51,6 +51,14 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
         private readonly TimeSpan _period;
         private readonly int _processorCount;
 
+        // Dedicated cap on the number of distinct "Top CPU processes/<name>" sensors this feature
+        // may ever create. The server sensor registry is permanent, so without a bound a host that
+        // churns through distinctly named processes (CI/build agents, batch jobs) would grow the
+        // namespace without limit. 8x the per-tick count (min 64) leaves generous headroom for
+        // normal rotation; once reached, new names are skipped and already-tracked names keep
+        // updating. Mirrors the native collector's max_tracked_names bound.
+        private readonly int _maxTrackedNames;
+
         // name -> sensor handle (created lazily on first appearance)
         private readonly Dictionary<string, IInstantValueSensor<double>> _sensors =
             new Dictionary<string, IInstantValueSensor<double>>();
@@ -73,6 +81,7 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
             _minPercent = minPercent;
             _period = period;
             _processorCount = GetTotalProcessorCount();
+            _maxTrackedNames = Math.Max(count * 8, 64);
         }
 
         public ValueTask<bool> InitAsync()
@@ -155,7 +164,8 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                     curCpu[key] = cpuMs;
 
                     // Cache full path on first encounter — MainModule can throw for protected processes.
-                    if (!_fullPaths.ContainsKey(p.ProcessName))
+                    // Bounded by the same cap as the sensor map so this dictionary can't grow without limit.
+                    if (_fullPaths.Count < _maxTrackedNames && !_fullPaths.ContainsKey(p.ProcessName))
                     {
                         try { _fullPaths[p.ProcessName] = p.MainModule.FileName; }
                         catch { }
@@ -199,6 +209,11 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                 IInstantValueSensor<double> sensor;
                 if (!_sensors.TryGetValue(name, out sensor))
                 {
+                    // Dedicated namespace cap: stop creating new per-process sensors once the bound
+                    // is reached so transient processes can't grow the server namespace without limit.
+                    if (_sensors.Count >= _maxTrackedNames)
+                        continue;
+
                     string fullPath;
                     _fullPaths.TryGetValue(name, out fullPath);
                     var pathLine = string.IsNullOrEmpty(fullPath) ? "" : "\n\n**Path:** `" + fullPath + "`";

--- a/src/collector/HSMDataCollector/PublicAPI/IWindowsCollection.cs
+++ b/src/collector/HSMDataCollector/PublicAPI/IWindowsCollection.cs
@@ -128,6 +128,9 @@ namespace HSMDataCollector.PublicInterface
         /// <paramref name="period"/> (default 1 minute), posts Double sensors at
         /// "Top CPU processes/&lt;exe-name&gt;" for the <paramref name="count"/> busiest processes
         /// above <paramref name="minPercent"/>% of total machine CPU. Windows only.
+        /// The number of distinct per-process sensors is capped (max(<paramref name="count"/> * 8, 64))
+        /// so a host that churns through many distinctly named processes cannot grow the sensor
+        /// namespace without bound; once the cap is reached, newly seen process names are skipped.
         /// </summary>
         IWindowsCollection AddTopCpuProcessesSensors(int count = 10, double minPercent = 1.0, TimeSpan? period = null);
     }

--- a/src/native/collector/include/hsm_collector/hsm_collector.h
+++ b/src/native/collector/include/hsm_collector/hsm_collector.h
@@ -798,6 +798,9 @@ const char* hsm_collector_last_error(const hsm_collector_t* collector);
    samples all processes at intervals of `period_ms` milliseconds, filters to the `count` busiest
    above `min_percent`% of total machine CPU, and posts a Double sensor for each at path
    "Top CPU processes/<exe-name>". Call BEFORE Start().
+   The number of distinct per-process sensors is capped (max(count * 8, 64)) so a host that churns
+   through many distinctly named processes cannot grow the sensor namespace without bound or exhaust
+   the global MaxSensors cap; once the cap is reached, newly seen process names are skipped.
    Returns HSM_RESULT_INVALID_ARGUMENT if count <= 0 or period_ms <= 0.
    Returns HSM_RESULT_INVALID_STATE if already started or not on Windows. */
 hsm_result_t hsm_collector_enable_top_cpu_sensors(

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -3263,6 +3263,18 @@ namespace
             std::map<std::string, std::shared_ptr<NativeSensor>> sensor_cache;
             const auto period = std::chrono::milliseconds(top_cpu_period_ms_);
 
+            // Dedicated cap on the number of distinct "Top CPU processes/<name>" sensors this
+            // feature may ever create. The server sensor registry (sensors_) is permanent — there
+            // is no delete-sensor API — so without a bound a host that churns through distinctly
+            // named processes (CI/build agents, batch jobs) would grow the namespace without limit
+            // and could silently consume the global MaxSensors cap, starving legitimately-busy
+            // processes. 8x the per-tick count (min 64) leaves generous headroom for normal
+            // rotation of busy processes while containing runaway churn. Once the cap is reached,
+            // new names are skipped; already-tracked names keep updating.
+            const size_t max_tracked_names =
+                std::max<size_t>(static_cast<size_t>(top_cpu_count_) * 8, 64);
+            bool cap_logged = false;
+
             sampler.Sample(); // seed baseline — first call returns empty map, so first post is a true delta
 
             while (true)
@@ -3282,6 +3294,21 @@ namespace
                         auto it = sensor_cache.find(usage.name);
                         if (it == sensor_cache.end())
                         {
+                            // Dedicated namespace cap: stop creating new per-process sensors once
+                            // the bound is reached so transient processes can't grow the registry
+                            // without limit or exhaust the global MaxSensors cap. Log once.
+                            if (sensor_cache.size() >= max_tracked_names)
+                            {
+                                if (!cap_logged)
+                                {
+                                    LogError("top-CPU: tracked-process cap (" +
+                                             std::to_string(max_tracked_names) +
+                                             ") reached; new process names will not get a sensor.");
+                                    cap_logged = true;
+                                }
+                                continue;
+                            }
+
                             // Creating a sensor from this background thread (after Start) is safe:
                             // CollectorImpl::CreateSensor serializes on mutex_, and the scheduler
                             // reads the registry only via a snapshot under the same lock.


### PR DESCRIPTION
## Summary

Follow-up to [#1180](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/pull/1180), addressing the one **Medium** review finding left unfixed at merge: the per-process top-CPU feature grew the sensor namespace **without bound**.

The `Top CPU processes/<exe>` feature created one sensor per distinct exe name ever seen above threshold, never evicting. The server sensor registry is **permanent** (no delete API), so a host that churns through distinctly named processes (CI/build agents, batch jobs) grew the namespace without limit — and on native could silently consume the global `MaxSensors` cap, starving legitimately-busy processes.

## Fix

Dedicated cap of `max(count * 8, 64)` distinct names in **both** collectors. Once reached, newly seen process names are skipped; already-tracked names keep updating.

- **Native** (`hsm_collector.cpp`): `max_tracked_names` guard in `RunTopCpuLoop` + one-shot `LogError` when the cap is first hit.
- **.NET** (`WindowsTopCpuMonitor.cs`): `_maxTrackedNames` guard on `_sensors` **and** on the `_fullPaths` cache (the latter grew per distinct process name across all processes, not just top-N).
- Documented the bound on both public APIs (`hsm_collector.h`, `IWindowsCollection.cs`) and in `aicontext/features/agent/feature.md`.

### Why a hard cap, not LRU
The server registry is permanent and the collector has no delete-sensor API, so LRU eviction of the local cache would not reclaim native `sensors_`. A hard cap is the only thing that genuinely bounds server-side sensor count, and it gives top-CPU its own budget well below the global `MaxSensors` so transient processes can't exhaust it. `8 * count` (min 64) leaves generous headroom for normal rotation of busy processes.

## Test plan

- [x] Native builds clean (MSVC Release); `cpu_select_top_n_selects_busiest_above_threshold` + `conformance_top_cpu_contract` pass in CTest
- [x] .NET collector builds clean; **205/205** conformance tests pass (`Collector_contract_matches_shared_fixture`)

The cap path itself is Win32-only (`RunTopCpuLoop`/`Sample`) and only triggers after 64+ distinct busy processes, so it is not portably assertable in the conformance corpus; the portable selection logic (`SelectTopN`) is unaffected and stays covered.

Part of #1179.

🤖 Generated with [Claude Code](https://claude.com/claude-code)