### PR TITLE
fix(collector): top-CPU system processes — stop per-tick exception, label path

### DIFF
--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -102,6 +102,11 @@ before `Stop()`, waits on the same `cv_` so it exits the moment stop is requeste
    registry is permanent, with no delete API): once the cap is reached, newly seen process names are
    skipped so a churn-heavy host can't grow the namespace without bound or exhaust the global MaxSensors.
 
+The sensor description carries the process's full exe path; for a protected/system process whose path
+the OS denies (e.g. `vmmemWSL`, `System`), it shows `**Path:** _(system process — path unavailable)_`
+instead of an empty line, in both collectors. The managed collector caches that denial (an empty path
+entry) so `MainModule` is probed once per name rather than throwing every tick.
+
 Aggregating by exe name (not PID, not PDH `#n` suffix) keeps a stable sensor identity over time.
 **Out of scope:** browser tab/site attribution (needs browser-level instrumentation; tracked separately).
 

--- a/src/collector/HSMDataCollector.Tests/CollectorQueueShutdownTests.cs
+++ b/src/collector/HSMDataCollector.Tests/CollectorQueueShutdownTests.cs
@@ -447,14 +447,17 @@ namespace HSMDataCollector.Tests
             using (var collector = new DataCollector(CreateOptions(sender, "flush-message")))
             {
                 collector.AddCustomLogger(logger);
-                var sensor = collector.CreateDoubleSensor("flush-message/data");
 
                 await collector.Start().ConfigureAwait(false);
-                sensor.AddValue(7);
 
-                // Give the run loop a chance to dequeue and either dispatch or land in queue
-                // before shutdown — we want at least one queued item to survive into the flush.
-                await Task.Delay(TimeSpan.FromMilliseconds(100)).ConfigureAwait(false);
+                // Enqueue straight into the live data queue so an item is GUARANTEED present when the
+                // Stop flush runs. The sender always errors, so the run loop re-enqueues (never drops,
+                // queue is far below MaxQueueSize) and the item survives deterministically into the
+                // flush. The previous approach — sensor.AddValue + Task.Delay(100ms) — relied on a value
+                // happening to be queued at shutdown and was flaky on slow CI agents ("Captured: []"):
+                // if the value had not reached the data queue by Stop, the flush had nothing to dispatch.
+                var dataQueue = GetDataQueue(collector);
+                InvokeEnqueue(dataQueue, new IntBarSensorValue { Count = 1, Comment = "flush-item" });
 
                 await collector.Stop().ConfigureAwait(false);
             }

--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
@@ -163,12 +163,16 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                     var cpuMs = p.TotalProcessorTime.TotalMilliseconds;
                     curCpu[key] = cpuMs;
 
-                    // Cache full path on first encounter — MainModule can throw for protected processes.
-                    // Bounded by the same cap as the sensor map so this dictionary can't grow without limit.
+                    // Cache full path on first encounter — MainModule throws for protected/system
+                    // processes (e.g. vmmemWSL, System). Cache the failure as an empty string so the
+                    // lookup is attempted once per name, not re-thrown every tick. Bounded by the same
+                    // cap as the sensor map so this dictionary can't grow without limit.
                     if (_fullPaths.Count < _maxTrackedNames && !_fullPaths.ContainsKey(p.ProcessName))
                     {
-                        try { _fullPaths[p.ProcessName] = p.MainModule.FileName; }
-                        catch { }
+                        string resolved;
+                        try { resolved = p.MainModule.FileName; }
+                        catch { resolved = ""; }
+                        _fullPaths[p.ProcessName] = resolved ?? "";
                     }
 
                     double prevMs;
@@ -214,9 +218,19 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                     if (_sensors.Count >= _maxTrackedNames)
                         continue;
 
+                    // Path line: the resolved exe path when we have it; an explicit "system process"
+                    // note when the OS denied MainModule (a cached empty entry), so an empty path reads
+                    // as intentional rather than a bug; omitted entirely when the path was never looked
+                    // up (name-cap reached) so we don't mislabel an unresolved process as a system one.
                     string fullPath;
-                    _fullPaths.TryGetValue(name, out fullPath);
-                    var pathLine = string.IsNullOrEmpty(fullPath) ? "" : "\n\n**Path:** `" + fullPath + "`";
+                    var resolved = _fullPaths.TryGetValue(name, out fullPath);
+                    string pathLine;
+                    if (!string.IsNullOrEmpty(fullPath))
+                        pathLine = "\n\n**Path:** `" + fullPath + "`";
+                    else if (resolved)
+                        pathLine = "\n\n**Path:** _(system process — path unavailable)_";
+                    else
+                        pathLine = "";
                     sensor = _storage.CreateInstantSensor<double>(
                         "Top CPU processes/" + name,
                         new InstantSensorOptions

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -3312,12 +3312,16 @@ namespace
                             // Creating a sensor from this background thread (after Start) is safe:
                             // CollectorImpl::CreateSensor serializes on mutex_, and the scheduler
                             // reads the registry only via a snapshot under the same lock.
+                            // Path line: the resolved exe path, or an explicit "system process" note
+                            // when QueryFullProcessImageNameW was denied (protected/system process such
+                            // as vmmemWSL / System), so an empty path reads as intentional, not a bug.
+                            // Mirrors the managed WindowsTopCpuMonitor description.
                             RegistrationOptions opts = InstantRegistrationDefaults();
                             opts.description =
                                 "Top **" + std::to_string(top_cpu_count_) + "** CPU consumers"
                                                                             " by % of machine CPU" +
                                 (usage.full_path.empty()
-                                     ? ""
+                                     ? "\n\n**Path:** _(system process — path unavailable)_"
                                      : "\n\n**Path:** `" + usage.full_path + "`");
                             std::shared_ptr<NativeSensor> sensor;
                             if (CreateSensor(("Top CPU processes/" + usage.name).c_str(),


### PR DESCRIPTION
## Problem

In the `Top CPU processes/<exe>` sensors (#1179), a protected/system process such as **`vmmemWSL`** or `System` has no accessible `MainModule`, so:

1. The sensor description showed **no `Path:` line at all** — indistinguishable from a bug (the original report: *"почему пустой файл?"*).
2. On the managed side, `Process.MainModule` **threw on every sample tick**, forever, because the failed lookup was never cached — continuous exception churn for every protected process.

## Fix

- **Managed (`WindowsTopCpuMonitor`)** — cache the `MainModule` failure as an empty-path entry, so the lookup is attempted **once per name** instead of throwing every tick. (Native already uses Win32 error codes, no exceptions.)
- **Both collectors** — when the path is unavailable, the description now shows:

  > **Path:** *(system process — path unavailable)*

  instead of an empty line, so the missing path reads as intentional. The managed side still omits the line entirely when the path was **never looked up** (name-cap reached), to avoid mislabeling a merely-unresolved process as a system one.

## Verification

- C# builds clean; **205/205** collector conformance tests pass (net48).
- Native MSVC **Release** builds clean (warnings-as-errors); **105/105** native tests pass.
- The top-CPU description is **not byte-pinned** in the conformance corpus (sensors are lazily created, Windows-only), so the text change is wire-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)