### PR TITLE
ci(claude): route Claude Code action through ANTHROPIC_BASE_URL proxy

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -25,6 +25,11 @@ jobs:
         with:
           fetch-depth: 1
       - uses: anthropics/claude-code-action@v1
+        # Route the Anthropic API through the self-hosted proxy (the key is only valid via it).
+        # Claude Code reads ANTHROPIC_BASE_URL/ANTHROPIC_API_KEY from the environment; set the
+        # ANTHROPIC_BASE_URL repo secret to the proxy endpoint (empty => public Anthropic API).
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,6 +22,12 @@ jobs:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        # Route the Anthropic API through the self-hosted proxy: the key is only valid via it.
+        # Claude Code reads ANTHROPIC_BASE_URL/ANTHROPIC_API_KEY from the environment, and the action
+        # inherits the step env. Set the ANTHROPIC_BASE_URL repo secret to the proxy endpoint; if it
+        # is empty the action falls back to the public Anthropic API.
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Problem

The `claude-review` and `claude-agent` workflows have been **failing silently on every run**: the `claude-code-action` returns `is_error: true` after ~200 ms with `total_cost_usd: 0` and **no model output**, then posts nothing (`No buffered inline comments`). Because the step is non-gating, the check still shows green — so PRs look "reviewed" when no review happened.

Root cause: the `ANTHROPIC_API_KEY` is only valid **through a self-hosted proxy**, but the action talked to the public Anthropic endpoint directly → the request was rejected on arrival (instant, $0).

## Fix

Set `ANTHROPIC_BASE_URL` on the action step (from a repo secret) so Claude Code routes the API through the proxy:

```yaml
- uses: anthropics/claude-code-action@v1
  env:
    ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
  with:
    anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
    ...
```

Claude Code reads `ANTHROPIC_BASE_URL` / `ANTHROPIC_API_KEY` from the environment, and the action inherits the step env. Applied to **both** `claude-review.yml` and `claude-agent.yml`. An empty/unset secret falls back to the public Anthropic API, so this is a **no-op until the secret is configured** (safe to merge).

## Action required (repo admin)

1. Add repo secret **`ANTHROPIC_BASE_URL`** = the proxy ("Light") endpoint.
2. Ensure **`ANTHROPIC_API_KEY`** is the key valid through that proxy.

Once set, this PR's own `claude-review` check exercises the new path (same-repo PR → secrets available, and `pull_request` uses the head's workflow), so a posted review here confirms it works.

> Note: if the proxy only accepts a specific model id, we may also need to pin one via `claude_args --model <id>` (the action currently defaults to `claude-opus-4-8`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)