### PR TITLE
fix(collector): ASCII-only top-CPU "system process" note (avoid MSVC mojibake)

### DIFF
--- a/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
+++ b/src/collector/HSMDataCollector/DefaultSensors/Windows/Process/WindowsTopCpuMonitor.cs
@@ -164,8 +164,12 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                     curCpu[key] = cpuMs;
 
                     // Cache full path on first encounter — MainModule throws for protected/system
-                    // processes (e.g. vmmemWSL, System). Cache the failure as an empty string so the
-                    // lookup is attempted once per name, not re-thrown every tick. Bounded by the same
+                    // processes (e.g. vmmemWSL, System), and also, less commonly, for transient/benign
+                    // reasons: a 32-bit-vs-64-bit access mismatch, a brief ACCESS_DENIED, or a process
+                    // still initializing its module list. Cache the failure as an empty string so the
+                    // lookup is attempted once per name, not re-thrown every tick. Trade-off: such a
+                    // process keeps the "system process" label below for the collector's lifetime — an
+                    // accepted false-positive for a best-effort description hint. Bounded by the same
                     // cap as the sensor map so this dictionary can't grow without limit.
                     if (_fullPaths.Count < _maxTrackedNames && !_fullPaths.ContainsKey(p.ProcessName))
                     {
@@ -228,7 +232,7 @@ namespace HSMDataCollector.DefaultSensors.Windows.Process
                     if (!string.IsNullOrEmpty(fullPath))
                         pathLine = "\n\n**Path:** `" + fullPath + "`";
                     else if (resolved)
-                        pathLine = "\n\n**Path:** _(system process — path unavailable)_";
+                        pathLine = "\n\n**Path:** _(system process - path unavailable)_"; // ASCII '-' to match native
                     else
                         pathLine = "";
                     sensor = _storage.CreateInstantSensor<double>(

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -3351,13 +3351,16 @@ namespace
                             // Path line: the resolved exe path, or an explicit "system process" note
                             // when QueryFullProcessImageNameW was denied (protected/system process such
                             // as vmmemWSL / System), so an empty path reads as intentional, not a bug.
-                            // Mirrors the managed WindowsTopCpuMonitor description.
+                            // Mirrors the managed WindowsTopCpuMonitor description. ASCII-only literal
+                            // (plain '-', not an em-dash): this string is the sensor description sent on
+                            // the wire, and MSVC without /utf-8 reads narrow literals in the system code
+                            // page, so a non-ASCII byte here could turn into mojibake on a non-UTF-8 host.
                             RegistrationOptions opts = InstantRegistrationDefaults();
                             opts.description =
                                 "Top **" + std::to_string(top_cpu_count_) + "** CPU consumers"
                                                                             " by % of machine CPU" +
                                 (usage.full_path.empty()
-                                     ? "\n\n**Path:** _(system process — path unavailable)_"
+                                     ? "\n\n**Path:** _(system process - path unavailable)_"
                                      : "\n\n**Path:** `" + usage.full_path + "`");
                             std::shared_ptr<NativeSensor> sensor;
                             if (CreateSensor(("Top CPU processes/" + usage.name).c_str(),


### PR DESCRIPTION
Follow-up to the [#1194](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/pull/1194) automated review (finding #2).

## Problem

The `(system process — path unavailable)` note added in #1194 used an **em-dash** (`—`, U+2014) inside a **narrow string literal**. In the native collector that string is the **sensor description sent on the wire**, and MSVC without `/utf-8` reads narrow literals in the host **system code page** — so on a non-UTF-8 host (e.g. a Russian-locale Windows, CP1251) the bytes `E2 80 94` can become mojibake in the description. It was the only non-ASCII byte in any native string literal, so there was no precedent proving it round-trips.

## Fix

- **native + managed**: use a plain ASCII `-` in the note, so both are byte-safe and textually identical.
- **managed**: expand the comment to acknowledge that `Process.MainModule` also throws for **transient/benign** reasons (a 32-vs-64-bit access mismatch, a brief `ACCESS_DENIED`, a process still initializing its module list) — so a normal process can keep the cached *"system process"* label for the collector's lifetime. An accepted false-positive for a best-effort description hint (review finding #1, documented rather than fixed — a bounded retry/eviction would be scope creep).

## Verification

- Native MSVC **Release** builds clean (warnings-as-errors) and **clang-format** clean.
- C# collector builds clean.
- The top-CPU description is not byte-pinned in the conformance corpus, so the text change is wire-safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)