### PR TITLE
Fix: sensor-group directive leaves the agent stopped (no restart)

### DIFF
--- a/aicontext/features/agent/feature.md
+++ b/aicontext/features/agent/feature.md
@@ -137,9 +137,16 @@ agent's real data path, so emitting only on the typed endpoints means it never s
   persistently-failing update (download error / hash mismatch) doesn't re-download the exe every batch;
   the first trigger after a quiet period still applies promptly. The scheduled poll is unaffected.
 - `sensor-disable:<group>` / `sensor-enable:<group>` (groups: computer/system/disk/network/module/
-  process) — re-sent on **every** response while the group stays toggled, so the agent acts **only
-  when the flag actually changes**: it rewrites `config.json` and restarts once, then ignores the
-  re-sent directive (otherwise it would restart-loop on every POST).
+  process, mapped by `SensorGroupFlag` — the single source of truth shared with its unit test) —
+  re-sent on **every** response while the group stays toggled, so the agent acts **only when the flag
+  actually changes**: it rewrites `config.json`, then **restarts the service to apply it** (the
+  collector's sensor set is fixed at `Start`). A graceful (exit-0) stop is *not* auto-restarted by the
+  SCM, so the agent spawns a detached **`--restart-service`** helper — the no-swap twin of
+  `--apply-update` (wait for `STOPPED` → `StartService`) — *before* `RequestStop()`. Unchanged groups
+  are ignored so it never restart-loops; if several groups change in one response only the first
+  spawns the helper (which re-reads the fully-updated config), the rest just record their flag. If the
+  helper can't be spawned the agent does **not** stop (so it never strands itself down) and retries on
+  the next re-send.
 - Toggling a product's sensor groups (server `ProductController.UpdateSensorGroups`) is gated by the
   **ProductManager** role on that product, like every other product mutation.
 
@@ -179,8 +186,8 @@ stderr. The collector's own dedup window keeps a flapping server from spamming t
 
 ## Verification
 
-- Portable unit tests (`tests/agent_tests.cpp`, name-dispatched, 13 cases — config parser + topCpu config + update config) — run on every
-  platform, registered in `ctest`.
+- Portable unit tests (`tests/agent_tests.cpp`, name-dispatched, 15 cases — config parser + topCpu/update
+  config + the sensor-group directive name↔field map) — run on every platform, registered in `ctest`.
 - **CI build lane (W8):** `.github/workflows/agent-windows-build.yml` — windows-latest, vcpkg curl,
   configures + builds `src/agent` Release with warnings-as-errors, runs the config `ctest`, and uploads
   the bundle payload (`hsm-agent.exe` + `config.json` template + `install.cmd`/`uninstall.cmd`) as an

--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_HOST_WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
     set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "vcpkg triplet for the self-contained agent build")
 endif()
 
-project(HsmAgent VERSION 0.5.21 LANGUAGES CXX)
+project(HsmAgent VERSION 0.5.22 LANGUAGES CXX)
 
 if(MSVC)
     # Static CRT (/MT) to match the static triplet — the exe must run on a clean machine with no VC++
@@ -71,7 +71,8 @@ if(HSM_AGENT_BUILD_TESTS)
             agent_topcpu_config_parses_and_defaults
             agent_topcpu_rejects_bad_config
             agent_update_config_parses_and_defaults
-            agent_update_config_rejects_bad_period)
+            agent_update_config_rejects_bad_period
+            agent_sensor_group_flag_maps_names)
         add_test(NAME ${name} COMMAND hsm_agent_tests ${name})
     endforeach()
 endif()

--- a/src/agent/include/agent/apply_update.hpp
+++ b/src/agent/include/agent/apply_update.hpp
@@ -14,4 +14,17 @@ namespace hsm::agent
     /// Entry point for the --apply-update detached helper. Returns 0 on success, non-zero on any
     /// failure (rename error, start failure, health gate failure after rollback).
     int RunApplyUpdate();
+
+    /// Entry point for the --restart-service detached helper. Waits up to 60 s for the HSMAgent
+    /// service to reach STOPPED, then StartService()s it again. Unlike --apply-update there is NO
+    /// binary swap — it just bounces the service so an on-disk config change (a sensor-group
+    /// enable/disable directive, #1198) takes effect, since the collector's sensor set is built once
+    /// at Start. Returns 0 on success, non-zero on any failure.
+    int RunRestartService();
+
+    /// Spawn THIS exe as a detached `--restart-service` helper. The running service calls this right
+    /// before RequestStop()ing: the helper outlives the service process, waits for it to stop, then
+    /// starts it back up — a graceful (exit-0) stop is NOT auto-restarted by the SCM. Returns false
+    /// if the child process could not be created.
+    bool SpawnRestartService();
 } // namespace hsm::agent

--- a/src/agent/include/agent/config.hpp
+++ b/src/agent/include/agent/config.hpp
@@ -77,4 +77,10 @@ namespace hsm::agent
     /// Serialize `config` back to `path` in config.json format. Called when a sensor-enable/disable
     /// server directive arrives so the change persists across the service restart that follows.
     bool WriteAgentConfig(const std::string& path, const AgentConfig& config, std::string& error);
+
+    /// Map a sensor-group directive name ("computer"/"system"/"disk"/"network"/"module"/"process")
+    /// to the AgentConfig flag it toggles, or nullptr for an unknown group. Single source of truth
+    /// shared by the runtime directive handler (#1198) and its unit test, so the name↔field mapping
+    /// can never silently drift.
+    bool AgentConfig::* SensorGroupFlag(const std::string& group);
 } // namespace hsm::agent

--- a/src/agent/src/agent_runtime.cpp
+++ b/src/agent/src/agent_runtime.cpp
@@ -1,6 +1,7 @@
 #include "agent/agent_runtime.hpp"
 
 #ifdef _WIN32
+#include "agent/apply_update.hpp"
 #include "agent/config.hpp"
 #include "agent/paths.hpp"
 #include "agent/update_checker.hpp"
@@ -128,14 +129,8 @@ namespace hsm::agent
                 {
                     const bool enable = (verb == "sensor-enable");
                     const std::string& group = payload;
-                    bool AgentConfig::* member = nullptr;
-                    if      (group == "computer") member = &AgentConfig::sensors_computer;
-                    else if (group == "system")   member = &AgentConfig::sensors_system;
-                    else if (group == "disk")     member = &AgentConfig::sensors_disk;
-                    else if (group == "network")  member = &AgentConfig::sensors_network;
-                    else if (group == "module")   member = &AgentConfig::sensors_module;
-                    else if (group == "process")  member = &AgentConfig::sensors_process;
-                    else
+                    bool AgentConfig::* member = SensorGroupFlag(group);
+                    if (member == nullptr)
                     {
                         Log(hc::LogLevel::Error, "directive: unknown sensor group '" + group + "'");
                         return;
@@ -167,9 +162,34 @@ namespace hsm::agent
                         return;
                     }
 
+                    // A sensor-group change only takes effect on a fresh process — the collector's
+                    // sensor set is built once at Start. RequestStop() alone just stops the service:
+                    // the SCM does NOT auto-restart a graceful (exit-0) stop, only a crash. So spawn the
+                    // detached --restart-service helper FIRST; it outlives this process, waits for
+                    // STOPPED, then StartService()s us back up (the no-swap twin of the self-update
+                    // --apply-update path). If several groups change in ONE response, only the first
+                    // spawns the helper and calls RequestStop — the helper re-reads the now fully
+                    // updated config.json, so the rest just record their flag.
+                    bool already_stopping;
+                    {
+                        std::lock_guard<std::mutex> lock(mutex_);
+                        already_stopping = stop_requested_;
+                    }
+                    if (!already_stopping && !SpawnRestartService())
+                    {
+                        // Could not spawn the restarter: do NOT stop (that would leave the agent down)
+                        // and do NOT mark config_ applied, so the server's next re-send retries the
+                        // spawn. The new value is already on disk, so a manual restart also applies it.
+                        Log(hc::LogLevel::Error, "directive: could not spawn restart helper; config saved, will apply on next restart");
+                        return;
+                    }
+
                     config_.*member = enable; // bool-only mutation (no string realloc -> no data race)
-                    Log(hc::LogLevel::Info, "directive: " + verb + ":" + group + " — restarting to apply");
-                    RequestStop();
+                    Log(hc::LogLevel::Info,
+                        "directive: " + verb + ":" + group +
+                            (already_stopping ? " — applies on the pending restart" : " — restarting to apply"));
+                    if (!already_stopping)
+                        RequestStop();
                 }
             };
 #endif

--- a/src/agent/src/apply_update.cpp
+++ b/src/agent/src/apply_update.cpp
@@ -194,4 +194,73 @@ namespace hsm::agent
         return 0;
     }
 
+    // ---- --restart-service: bounce the service to apply a config change (no binary swap) ----------
+
+    int RunRestartService()
+    {
+        SC_HANDLE scm = OpenSCManagerW(nullptr, nullptr, SC_MANAGER_CONNECT);
+        if (!scm)
+        {
+            LogErr("restart: cannot open SCM");
+            return 1;
+        }
+
+        SC_HANDLE svc = OpenServiceW(scm, kServiceName, SERVICE_QUERY_STATUS | SERVICE_START);
+        if (!svc)
+        {
+            CloseServiceHandle(scm);
+            LogErr("restart: cannot open HSMAgent service");
+            return 1;
+        }
+
+        // The caller RequestStop()s right after spawning us, so wait for the graceful shutdown to
+        // finish before starting a fresh process (which re-reads config.json).
+        Log("restart: waiting for HSMAgent to stop (up to 60 s)...");
+        if (!WaitForServiceState(svc, SERVICE_STOPPED, 60000))
+        {
+            CloseServiceHandle(svc);
+            CloseServiceHandle(scm);
+            LogErr("restart: HSMAgent did not stop within 60 s — leaving it as-is");
+            return 1;
+        }
+
+        if (!StartServiceW(svc, 0, nullptr))
+        {
+            const DWORD err = GetLastError();
+            // ALREADY_RUNNING: a second --restart-service helper (several groups toggled in one
+            // response) already started it — that is success, not failure.
+            if (err != ERROR_SERVICE_ALREADY_RUNNING)
+            {
+                CloseServiceHandle(svc);
+                CloseServiceHandle(scm);
+                LogErr("restart: StartService failed (" + std::to_string(err) + ") — service is stopped");
+                return 1;
+            }
+        }
+
+        Log("restart: HSMAgent restarted to apply a configuration change");
+        CloseServiceHandle(svc);
+        CloseServiceHandle(scm);
+        return 0;
+    }
+
+    bool SpawnRestartService()
+    {
+        wchar_t exe_path[MAX_PATH] = {};
+        if (!GetModuleFileNameW(nullptr, exe_path, MAX_PATH))
+            return false;
+
+        std::wstring cmd_line = std::wstring(L"\"") + exe_path + L"\" --restart-service";
+        STARTUPINFOW si = {};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi = {};
+        if (!CreateProcessW(nullptr, cmd_line.data(), nullptr, nullptr, FALSE,
+                            DETACHED_PROCESS | CREATE_NO_WINDOW, nullptr, nullptr, &si, &pi))
+            return false;
+
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+        return true;
+    }
+
 } // namespace hsm::agent

--- a/src/agent/src/config.cpp
+++ b/src/agent/src/config.cpp
@@ -712,4 +712,15 @@ namespace hsm::agent
         }
         return true;
     }
+
+    bool AgentConfig::* SensorGroupFlag(const std::string& group)
+    {
+        if (group == "computer") return &AgentConfig::sensors_computer;
+        if (group == "system")   return &AgentConfig::sensors_system;
+        if (group == "disk")     return &AgentConfig::sensors_disk;
+        if (group == "network")  return &AgentConfig::sensors_network;
+        if (group == "module")   return &AgentConfig::sensors_module;
+        if (group == "process")  return &AgentConfig::sensors_process;
+        return nullptr;
+    }
 } // namespace hsm::agent

--- a/src/agent/src/main.cpp
+++ b/src/agent/src/main.cpp
@@ -4,6 +4,8 @@
 //   --install / --uninstall register/remove the auto-start service (requires elevation)
 //   --apply-update          detached helper: waits for service to stop, swaps binaries, restarts
 //                           with health gate (epic #1174)
+//   --restart-service       detached helper: waits for service to stop, then restarts it (no swap) —
+//                           applies a config change pushed by a server directive (#1198)
 //   --config <path>         override the config.json location (default %ProgramData%\HSM Agent)
 //
 // The single signed binary is identical across every product download; only the bundled config.json
@@ -62,6 +64,7 @@ namespace
                      "  --install      register the auto-start service (requires elevation)\n"
                      "  --uninstall    remove the service (requires elevation)\n"
                      "  --apply-update apply a staged update (spawned automatically by the agent)\n"
+                     "  --restart-service  bounce the service to apply a config change (spawned automatically)\n"
                      "  --config <p>   use config file <p> (default: %ProgramData%\\HSM Agent\\config.json)\n"
                      "  --version      print version and exit\n";
     }
@@ -112,7 +115,7 @@ int wmain(int argc, wchar_t** argv)
     for (int i = 1; i < argc; ++i)
     {
         const std::wstring arg = argv[i];
-        if (arg == L"--install" || arg == L"--uninstall" || arg == L"--console" || arg == L"--service" || arg == L"--apply-update")
+        if (arg == L"--install" || arg == L"--uninstall" || arg == L"--console" || arg == L"--service" || arg == L"--apply-update" || arg == L"--restart-service")
         {
             mode = arg;
         }
@@ -145,6 +148,8 @@ int wmain(int argc, wchar_t** argv)
         return UninstallService();
     if (mode == L"--apply-update")
         return RunApplyUpdate();
+    if (mode == L"--restart-service")
+        return RunRestartService();
 
     // Console + service runs must be single-instance so they never double-send. A Global mutex may
     // fail for a non-elevated user (no SeCreateGlobalPrivilege); in that case skip the guard rather

--- a/src/agent/tests/agent_tests.cpp
+++ b/src/agent/tests/agent_tests.cpp
@@ -255,6 +255,29 @@ namespace
         ExpectReject(R"({ "server": { "address": "h", "accessKey": "k" }, "update": "on" })", "non-object update");
     }
 
+    // Guards the sensor-group directive name<->field mapping (#1198): a typo (e.g. "disk" pointing at
+    // sensors_network) would silently toggle the wrong group. SensorGroupFlag is the single source of
+    // truth shared with the runtime directive handler, so testing it here covers both.
+    void SensorGroupFlagMapsNames()
+    {
+        using hsm::agent::SensorGroupFlag;
+        Check(SensorGroupFlag("computer") == &AgentConfig::sensors_computer, "computer -> sensors_computer");
+        Check(SensorGroupFlag("system") == &AgentConfig::sensors_system, "system -> sensors_system");
+        Check(SensorGroupFlag("disk") == &AgentConfig::sensors_disk, "disk -> sensors_disk");
+        Check(SensorGroupFlag("network") == &AgentConfig::sensors_network, "network -> sensors_network");
+        Check(SensorGroupFlag("module") == &AgentConfig::sensors_module, "module -> sensors_module");
+        Check(SensorGroupFlag("process") == &AgentConfig::sensors_process, "process -> sensors_process");
+        Check(SensorGroupFlag("bogus") == nullptr, "unknown group -> nullptr");
+        Check(SensorGroupFlag("") == nullptr, "empty group -> nullptr");
+
+        // The returned pointer-to-member reads and writes the intended field.
+        AgentConfig c; // defaults: process off, the rest on
+        auto process = SensorGroupFlag("process");
+        Check(process != nullptr && !(c.*process), "process flag reads its default (off)");
+        c.*process = true;
+        Check(c.sensors_process, "writing via the pointer flips the right field");
+    }
+
     const std::map<std::string, std::function<void()>>& Tests()
     {
         static const std::map<std::string, std::function<void()>> tests = {
@@ -272,6 +295,7 @@ namespace
             { "agent_topcpu_rejects_bad_config", TopCpuRejectsBadConfig },
             { "agent_update_config_parses_and_defaults", UpdateConfigParsesAndDefaults },
             { "agent_update_config_rejects_bad_period", UpdateConfigRejectsBadPeriod },
+            { "agent_sensor_group_flag_maps_names", SensorGroupFlagMapsNames },
         };
         return tests;
     }


### PR DESCRIPTION
## Problem

A `sensor-enable`/`sensor-disable` directive (#1198) rewrites `config.json` and calls `RequestStop()` to "restart to apply" — but **nothing restarts the service**. The self-update path works only because it spawns a detached `--apply-update` helper that waits for `STOPPED` then `StartService()`s; the SCM does **not** auto-restart a graceful (exit-0) stop, only a crash.

Found live in the eval: on first connect the server sent `sensor-enable:process` (the `process` group is off by default, the product wants it on); the agent rewrote its config, `RequestStop()`'d — and stayed **STOPPED**.

## Fix

- New **`--restart-service`** detached helper in `apply_update.cpp` — the no-swap twin of `--apply-update` (wait for `STOPPED` → `StartService`).
- The directive handler spawns it **before** `RequestStop()`:
  - If several groups change in one response, only the first spawns the helper (which re-reads the fully-updated config) — the rest just record their flag (`already_stopping` guard).
  - If the helper can't be spawned, the agent does **not** stop (so it never strands itself down) and retries on the server's next re-send.
- Extracted the group-name → `AgentConfig` flag mapping into **`SensorGroupFlag()`** (single source of truth) + a unit test (`agent_sensor_group_flag_maps_names`).
- Agent bumped to **0.5.22**; agent feature doc updated.

## Test

- `ctest`: 15/15 agent unit tests pass (incl. the new mapping test).
- Clean Release build (static triplet), no warnings.
- The restart mechanism mirrors the already-proven `--apply-update` (the working self-update path), so it uses the same SCM dance.

Follow-up to #1198 (server directive channel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
