### PR TITLE
Move "Download agent" to the product edit page

### DIFF
--- a/aicontext/features/server/agent-download/feature.md
+++ b/aicontext/features/server/agent-download/feature.md
@@ -8,7 +8,7 @@
 
 ## Description
 
-An admin opens a product's access-keys view and clicks **Download agent**; the server streams a zip
+An admin opens a product's edit page ("HSM Agent" section) and clicks **Download agent**; the server streams a zip
 containing the byte-identical signed `hsm-agent.exe` + a generated `config.json` (this server's address
 + the product's access key) + silent `install.cmd`/`uninstall.cmd`. The client runs `install.cmd` → the
 **C++ exe self-installs** as an auto-start Windows service and connects — zero configuration.
@@ -34,7 +34,7 @@ pure-native exe's own `--install`. No .NET runtime, no C#/MSI installer is produ
 | Bundle builder (config.json + scripts + zip; pure/testable) | `HSMServer/Model/Agent/AgentInstallerBundle.cs` |
 | Server settings "Agent connection URL" + "Allow untrusted server certificate" + "Report top processes by CPU" | `HSMServer/ServerConfiguration/Sections/AgentConfig.cs` (`ExternalConnectionUrl`, `AllowUntrustedCertificate`, `EnableTopCpuProcesses`) (+ `IServerConfig`/`ServerConfig`) |
 | Settings UI (Agent tab) | `Views/Configuration/_Agent.cshtml`, `Views/Configuration/Index.cshtml`, `AgentSettingsViewModel`, `ConfigurationController.SaveAgentSettings` |
-| Download button | `Views/AccessKeys/_ProductAccessKeys.cshtml` (admin-only) |
+| Download button | `Views/Product/EditProduct.cshtml` — "HSM Agent" section (admin-only) |
 | Exe drop-point | `HSMServer/wwwroot/agent/hsm-agent.exe` (staged by `server-build.yml` before publish, W9) |
 | Key selection / URL resolution (pure, testable) | `Model/Agent/AgentKeySelector.cs`, `Model/Agent/AgentConnectionResolver.cs` |
 | Tests | `tests/HSMServer.Core.Tests/AgentInstallerBundleTests.cs` (7: incl. topCpu on/off) + `AgentDownloadLogicTests.cs` (13: key selection + URL resolution) |

--- a/src/server/HSMServer/Views/AccessKeys/_ProductAccessKeys.cshtml
+++ b/src/server/HSMServer/Views/AccessKeys/_ProductAccessKeys.cshtml
@@ -7,11 +7,6 @@
 @model ProductNodeViewModel
 
 
-@{
-    var user = User as User;
-}
-
-
 @await Html.PartialAsync("~/Views/Shared/_ConfirmationModal.cshtml")
 
 <input class="d-none" id='accessKey_prodcutId' value="@Model.EncodedId"/>
@@ -26,10 +21,6 @@
 
     <div class="container-fluid d-flex flex-row-reverse align-items-center flex-shrink-0 ">
         <div class="row flex-nowrap">
-            @if (user is not null && user.IsAdmin)
-            {
-                <button id="downloadAgentButton" class="btn btn-secondary mx-1" type="button" onclick="downloadAgentClick()" title="Download a ready-to-run Windows agent for this product (server address + key pre-configured)">Download agent</button>
-            }
             @if (Model.IsChangingAccessKeysAvailable(User as User))
             {
                 <button id="addButton" class="btn btn-secondary col-2 w-50 mx-1" type="button" onclick="addButtonClick()">Add</button>
@@ -48,40 +39,6 @@
         showNewAccessKeyModal(`${newAccessKeyURL}?selectedId=${productId}`, false);
     }
 
-    async function downloadAgentClick() {
-        // Fetch + blob (not window.location) so a 503/BadRequest surfaces as an in-modal toast
-        // instead of navigating the browser to a raw error page — e.g. when the product has no
-        // usable access key or the agent binary isn't staged on the server yet.
-        const button = document.getElementById('downloadAgentButton');
-        button.disabled = true;
-        try {
-            const response = await fetch('/api/Agent/installer?productId=@Model.Id');
-            if (!response.ok) {
-                const message = await response.text();
-                showToast(message || 'Failed to download the HSM Agent.', 'Error');
-                return;
-            }
-
-            const blob = await response.blob();
-            const disposition = response.headers.get('Content-Disposition') || '';
-            const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition);
-            const fileName = match ? decodeURIComponent(match[1]) : 'hsm-agent.zip';
-
-            const url = URL.createObjectURL(blob);
-            const link = document.createElement('a');
-            link.href = url;
-            link.download = fileName;
-            document.body.appendChild(link);
-            link.click();
-            link.remove();
-            URL.revokeObjectURL(url);
-        } catch (error) {
-            showToast('Failed to download the HSM Agent: ' + error, 'Error');
-        } finally {
-            button.disabled = false;
-        }
-    }
-    
     $(document).ready(() => {
         if (document.getElementById('addButton') !== null){
             document.getElementById('closeButton').classList.add('w-50')

--- a/src/server/HSMServer/Views/Product/EditProduct.cshtml
+++ b/src/server/HSMServer/Views/Product/EditProduct.cshtml
@@ -170,6 +170,22 @@
         </div>
     
         <div class="my-1">
+            <h5 class="mt-2">HSM Agent</h5>
+            <p class="text-muted small">Download a ready-to-run Windows agent pre-configured for this product — this server's address and an access key are baked into its <code>config.json</code>. Run <code>install.cmd</code> on the target machine; the agent self-installs as an auto-start Windows service and connects.</p>
+            @{ var pageUser = User as User; }
+            @if (pageUser is not null && pageUser.IsAdmin)
+            {
+                <button id="downloadAgentButton" class="btn btn-secondary" type="button" onclick="downloadAgentClick()" title="Download a ready-to-run Windows agent for this product (server address + key pre-configured)">
+                    <i class="fa-solid fa-download"></i> Download agent
+                </button>
+            }
+            else
+            {
+                <p class="text-muted small mb-0">Only administrators can download the agent bundle.</p>
+            }
+        </div>
+
+        <div class="my-1">
             <h5 class="mt-2">Agent sensor groups</h5>
             <p class="text-muted small">Disabled groups will stop being collected by agents after their next data send (no restart needed).</p>
             <div id="sensorGroups_div">
@@ -393,6 +409,42 @@
     $('#accessKeys_modal').on('hidden.bs.modal', function(e) {
         document.location.reload();
     });
+</script>
+
+<script>
+    async function downloadAgentClick() {
+        // Fetch + blob (not window.location) so a 503/BadRequest surfaces as a toast instead of
+        // navigating the browser to a raw error page — e.g. when the product has no usable access
+        // key or the agent binary isn't staged on the server yet.
+        const button = document.getElementById('downloadAgentButton');
+        button.disabled = true;
+        try {
+            const response = await fetch('/api/Agent/installer?productId=@Model.GeneralInfo.Id');
+            if (!response.ok) {
+                const message = await response.text();
+                showToast(message || 'Failed to download the HSM Agent.', 'Error');
+                return;
+            }
+
+            const blob = await response.blob();
+            const disposition = response.headers.get('Content-Disposition') || '';
+            const match = /filename\*?=(?:UTF-8'')?"?([^";]+)"?/i.exec(disposition);
+            const fileName = match ? decodeURIComponent(match[1]) : 'hsm-agent.zip';
+
+            const url = URL.createObjectURL(blob);
+            const link = document.createElement('a');
+            link.href = url;
+            link.download = fileName;
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+            URL.revokeObjectURL(url);
+        } catch (error) {
+            showToast('Failed to download the HSM Agent: ' + error, 'Error');
+        } finally {
+            button.disabled = false;
+        }
+    }
 </script>
 
 <script>


### PR DESCRIPTION
## What

Move the per-product **Download agent** button from the Access keys modal into a dedicated **HSM Agent** section on the product edit page (`Views/Product/EditProduct.cshtml`).

## Why

The agent binary is **byte-identical everywhere** — only the generated `config.json` (this server's address + the product's access key) differs per product. So the download belongs in the product context, where an operator configures the product and immediately gets an agent pre-wired to it. The Access keys modal was an incidental host (it had the product id handy).

## Changes

- **`EditProduct.cshtml`** — new admin-only "HSM Agent" section (between Members and Agent sensor groups) with the Download agent button + `fetch`/blob handler that surfaces 503/400 as a toast instead of navigating to a raw error page.
- **`_ProductAccessKeys.cshtml`** — remove the button, its `downloadAgentClick` script, and the now-unused `user` local.
- **`agent-download/feature.md`** — update the canonical doc to point at the new button location.

No server-side change: the `/api/Agent/installer?productId=…` endpoint, key selection, URL resolution, and bundle builder are untouched — this only moves the UI entry point.

## Verification

Built `HSMServer.csproj` (0 errors) and deployed locally via `docker compose` (`hsmonitoring/hierarchical_sensor_monitoring:latest`); web UI serves and the new section renders on the product edit page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)