### PR TITLE
Ship a Release PDB for HSMCppWrapper.dll (symbols for the aggregator)

### DIFF
--- a/src/wrapper/CMakeLists.txt
+++ b/src/wrapper/CMakeLists.txt
@@ -46,6 +46,13 @@ target_link_libraries(HSMCppWrapper PRIVATE hsm_collector_cpp)
 
 if(MSVC)
     target_compile_options(HSMCppWrapper PRIVATE /EHsc /W3)
+    # Emit a PDB for the Release DLL too (the VS Release config omits debug info by default, so the
+    # handoff bundle otherwise ships Release without symbols for crash analysis at tt-aggregator2).
+    # /Zi generates the debug info; the linker /DEBUG writes the .pdb; /OPT:REF /OPT:ICF restore the
+    # size/speed folding that /DEBUG turns off, so Release stays optimized but symbolizable. Exports/
+    # ABI are unaffected, so the relink stays byte-for-byte identical.
+    target_compile_options(HSMCppWrapper PRIVATE $<$<CONFIG:Release>:/Zi>)
+    target_link_options(HSMCppWrapper PRIVATE $<$<CONFIG:Release>:/DEBUG /OPT:REF /OPT:ICF>)
 endif()
 
 # Re-export the native C ABI from the DLL so a consumer can call hsm::collector directly via


### PR DESCRIPTION
The VS Release config omits debug info by default, so the handoff bundle shipped **Release without a `.pdb`** (pack.ps1 warned) — no symbols for crash analysis at tt-aggregator2. This adds `/Zi` (compile) + `/DEBUG /OPT:REF /OPT:ICF` (link) for the **Release config only** of the `HSMCppWrapper` target: Release stays optimized but produces a PDB.

Exports/ABI are unchanged, so the aggregator relink stays byte-for-byte identical (545 exports).

**Verified end-to-end:** a `workflow_dispatch` build off this branch produced a bundle whose `dll/HSMCppWrapper/x64/Release/` now contains `HSMCppWrapper.pdb` alongside the dll + libcurl/z runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)