### PR TITLE
docs(native-examples): demonstrate EnableFileLogging in windows-monitor

### DIFF
--- a/src/native/collector/examples/windows-monitor/main.cpp
+++ b/src/native/collector/examples/windows-monitor/main.cpp
@@ -8,6 +8,10 @@
 // Writes NLog-parity log files to ./Logs (override the directory with HSM_LOG_DIR):
 // DataCollector_<date>.txt for all levels, DataCollector_error_<date>.txt for errors.
 
+// std::getenv (the HSM_LOG_DIR lookup below) is a read-only env read; silence MSVC's C4996
+// deprecation (must precede the CRT headers).
+#define _CRT_SECURE_NO_WARNINGS
+
 #include <hsm_collector/hsm_collector.hpp>
 
 #include <chrono>

--- a/src/native/collector/examples/windows-monitor/main.cpp
+++ b/src/native/collector/examples/windows-monitor/main.cpp
@@ -5,6 +5,8 @@
 //
 // Usage: hsm_windows_monitor [server_address] [port] [access_key] [seconds]
 //   defaults: https://localhost 44330 demo-key 30
+// Writes NLog-parity log files to ./Logs (override the directory with HSM_LOG_DIR):
+// DataCollector_<date>.txt for all levels, DataCollector_error_<date>.txt for errors.
 
 #include <hsm_collector/hsm_collector.hpp>
 
@@ -23,6 +25,9 @@ int main(int argc, char** argv)
     const std::string access_key = argc > 3 ? argv[3] : "demo-key";
     const int seconds = argc > 4 ? std::atoi(argv[4]) : 30;
 
+    const char* log_dir_env = std::getenv("HSM_LOG_DIR");
+    const std::string log_dir = (log_dir_env && *log_dir_env) ? log_dir_env : "Logs";
+
     try
     {
         hc::CollectorOptions options;
@@ -39,6 +44,11 @@ int main(int argc, char** argv)
             std::cerr << "[hsm] (" << static_cast<int>(level) << ") " << message << '\n';
         });
 
+        // Built-in async file logger (NLog parity) — the feature under test. Writes
+        // <log_dir>/DataCollector_<date>.txt (+ _error_ for errors), independent of the stderr
+        // callback above; both sinks receive every message. Enable before Start.
+        collector.EnableFileLogging(log_dir, hc::LogLevel::Info);
+
         // Real server transport (#1165) + the Windows live readers (#1164). Install both before Start.
         collector.UseHttpTransport();
         collector.InstallWindowsMetricSources();
@@ -48,7 +58,8 @@ int main(int argc, char** argv)
         collector.AddAllComputerSensors();
         collector.AddAllModuleSensors("1.0.0.0");
 
-        std::cout << "Monitoring Windows -> " << server << ':' << port << " for " << seconds << "s...\n";
+        std::cout << "Monitoring Windows -> " << server << ':' << port << " for " << seconds
+                  << "s... (log files: " << log_dir << ")\n";
         collector.Start();
         std::this_thread::sleep_for(std::chrono::seconds(seconds));
         collector.Stop();


### PR DESCRIPTION
## What

Enable the collector's built-in file logger in the `windows-monitor` example:
- `collector.EnableFileLogging(log_dir, LogLevel::Info)` before `Start()`.
- `log_dir` defaults to `./Logs`, overridable via the `HSM_LOG_DIR` env var.
- Header comment documents the NLog-parity output (`DataCollector_<date>.txt` + `DataCollector_error_<date>.txt`).

## Why

#1221 added a built-in async file logger to the native collector for consumers that don't supply their own sink (e.g. the tt-aggregator native adapter). This wires it into the live `windows-monitor` example so the feature is demonstrated end-to-end in a runnable app — a run now streams to the server **and** writes the parity log files next to it.

Example-only; no library/production change. Both sinks (the existing stderr callback + the file logger) receive every message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
