### PR TITLE
fix(collector): C# log quality — quiet graceful-stop discard, HTTP code in single-command failure

### DIFF
--- a/src/collector/HSMDataCollector/Client/HttpsClient/RequestHandlers/CommandHandlers.cs
+++ b/src/collector/HSMDataCollector/Client/HttpsClient/RequestHandlers/CommandHandlers.cs
@@ -92,7 +92,7 @@ namespace HSMDataCollector.Client.HttpsClient
                         var stream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
                         var error = await JsonSerializer.DeserializeAsync<string>(stream, cancellationToken: token).ConfigureAwait(false);
 
-                        _logger.Error($"Command request for {value.Path} has been faulted. {error}.");
+                        _logger.Error($"Command request for {value.Path} has been faulted. Status Code: {response.StatusCode}, Status Text: {error}.");
                     }
                     else
                     {

--- a/src/collector/HSMDataCollector/Core/DataProcessor.cs
+++ b/src/collector/HSMDataCollector/Core/DataProcessor.cs
@@ -392,8 +392,10 @@ namespace HSMDataCollector.Core
 
         private void LogDiscardedItems(int count, string queueName)
         {
+            // Info, not Error: discarding still-buffered values on a graceful shutdown is expected and
+            // contracted (a stop must not block on a dead/slow transport) — it is not a fault.
             if (count > 0)
-                _logger.Error($"{queueName} queue discarded {count} item(s) during collector shutdown.");
+                _logger.Info($"{queueName} queue discarded {count} item(s) during collector shutdown.");
         }
 
         private void RollbackStartedQueues(bool dataStarted, bool priorityStarted, bool fileStarted, bool commandStarted)


### PR DESCRIPTION
## What

The native collector log-quality fixes (#1225) surfaced two issues that **also exist in the C# collector** (native is a port of it). This mirrors them:

1. **Graceful-stop discard is not an Error.** `DataProcessor.LogDiscardedItems` logged `"{queue} queue discarded N item(s) during collector shutdown."` at **Error** on every graceful stop. Dropping still-buffered values on a bounded shutdown is expected and contracted (a stop must not block on a dead/slow transport) — now **Info**.
2. **HTTP status in the single-command failure log.** The batch registration-failure path already logs `Status Code: {response.StatusCode}`; the single-command path (`CommandHandler.HandleRequestResultAsync(response, value, …)`) logged only the body text. Add the status code for consistency (parity with the batch path and with the native #1225 fix).

## Not changed (intentionally)

- **Registration resilience** (native #5): C# is already **more resilient** — registration commands sit in a persistent command queue and retry unboundedly on connection failures, recovering without a restart. The native collector was one-shot; its companion PR brings native *up to* this. No C# change needed.
- **Per-registration "accepted" Info verbosity** (native #1): milder in C# (no false "on connect" label), and cleanly fixing it needs a connect-vs-runtime distinction to avoid losing the Info registration signal — deferred.

## Verified locally

- `HSMDataCollector` builds clean on **net6.0** (0 errors).
- Shutdown + command unit tests: **27 passed, 0 failed** (net48).

Logging-only; no behavior change. The C# collector is a published package, so a version bump is left as a release decision (root `AGENTS.md`: bump only when preparing a release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
