### PR TITLE
test(e2e): folder teardown + cleanup helper (stop autotest junk accumulation)

### DIFF
--- a/src/tests/Autotests/.gitignore
+++ b/src/tests/Autotests/.gitignore
@@ -1,0 +1,5 @@
+# Playwright test outputs
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/src/tests/Autotests/add_environment/add_folders_products.spec.ts
+++ b/src/tests/Autotests/add_environment/add_folders_products.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { testConfig } from '../config.ts';
 import { login } from '../login.ts';
+import { removeFolderByName } from '../cleanup.ts';
+
+test.afterEach(async ({ page }) => {
+  // Remove the folders this spec creates so they do not accumulate on the server (best-effort).
+  await removeFolderByName(page, testConfig.folder_name1);
+  await removeFolderByName(page, testConfig.folder_name3);
+});
 
 // Loging
 test('Add folders/products', async ({ page }) => {

--- a/src/tests/Autotests/cleanup.ts
+++ b/src/tests/Autotests/cleanup.ts
@@ -1,0 +1,61 @@
+import { type Page } from '@playwright/test';
+
+const GUID_SRC = '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}';
+
+/**
+ * Best-effort teardown: delete a folder by its display name via the server's RemoveFolder endpoint,
+ * located through the folder's EditFolder link in the Products tree. A no-op when the folder is
+ * absent, and it never throws — so an afterEach hook can't fail an otherwise-green run. Reuses the
+ * already-authenticated test page.
+ */
+export async function removeFolderByName(page: Page, name: string): Promise<void> {
+  try {
+    await page.goto('/Product/Index');
+    await page.waitForLoadState('networkidle');
+
+    const folderId = await page.evaluate(
+      ({ target, guidSrc }) => {
+        const guid = new RegExp(guidSrc, 'i');
+        for (const a of Array.from(document.querySelectorAll('a[href*="/Folders/EditFolder?folderId="]'))) {
+          const box = a.closest('.d-flex') ?? a.parentElement;
+          const nameEl = box?.querySelector('div[style*="font-weight"], div[style*="bold"]');
+          if ((nameEl?.textContent ?? '').trim() === target) {
+            const href = a.getAttribute('href') ?? '';
+            return (href.match(guid) ?? [])[0] ?? '';
+          }
+        }
+        return '';
+      },
+      { target: name, guidSrc: GUID_SRC }
+    );
+
+    if (folderId)
+      await page.request.post(`/Folders/RemoveFolder?folderId=${folderId}`);
+  } catch {
+    // best-effort cleanup — never fail the run on teardown
+  }
+}
+
+/**
+ * Best-effort teardown: delete a product by its display name via the server's RemoveProduct endpoint,
+ * located through its `inputName_<guid>` anchor in the Products tree. No-op when absent; never throws.
+ */
+export async function removeProductByName(page: Page, name: string): Promise<void> {
+  try {
+    await page.goto('/Product/Index');
+    await page.waitForLoadState('networkidle');
+
+    const productId = await page.evaluate((target) => {
+      for (const a of Array.from(document.querySelectorAll('a[id^="inputName_"]'))) {
+        if ((a.textContent ?? '').trim() === target)
+          return a.id.replace('inputName_', '');
+      }
+      return '';
+    }, name);
+
+    if (productId)
+      await page.request.get(`/Product/RemoveProduct?product=${productId}`);
+  } catch {
+    // best-effort cleanup — never fail the run on teardown
+  }
+}


### PR DESCRIPTION
## What

The E2E `add_folders_products` spec created `Folder1`/`Folder2` with **no teardown**, so every run left them on the server — a source of the accumulating autotest junk the tree filled up with.

- Add `src/tests/Autotests/cleanup.ts` — best-effort helpers `removeFolderByName` / `removeProductByName` that delete by display name via the server's `RemoveFolder` / `RemoveProduct` endpoints, located through the tree's `EditFolder?folderId` / `inputName_<guid>` anchors. No-op when the entity is absent, and never throws — so an `afterEach` hook can't fail an otherwise-green run.
- Wire an `afterEach` into `add_folders_products.spec.ts` to remove the folders it creates.
- Add a `.gitignore` for Playwright outputs (`test-results/`, reports).

## Verified locally

Ran the spec against the local Docker server (`CI=1`, headless): it passes, and `Folder1`/`Folder2` are **gone afterward** — teardown confirmed.

## Follow-ups

- The same helpers can be wired into the user/product specs (`add_users`, `register_new_user`) to stop those accumulating too.
- Separately (manual, not in this PR) I swept the ~22 already-accumulated test-fixture products/folders off the local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
