### PR TITLE
chore(agent): bump 0.5.26 → 0.5.27 for the decoupled collector (#1228)

### DIFF
--- a/src/agent/CMakeLists.txt
+++ b/src/agent/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_HOST_WIN32 AND NOT DEFINED VCPKG_TARGET_TRIPLET)
     set(VCPKG_TARGET_TRIPLET "x64-windows-static" CACHE STRING "vcpkg triplet for the self-contained agent build")
 endif()
 
-project(HsmAgent VERSION 0.5.26 LANGUAGES CXX)
+project(HsmAgent VERSION 0.5.27 LANGUAGES CXX)
 
 if(MSVC)
     # Static CRT (/MT) to match the static triplet — the exe must run on a clean machine with no VC++


### PR DESCRIPTION
#1228 decoupled the native collector's reported version (`.module/Collector version` now = the collector's own `0.6.1`, not the managed `3.4.12`) but did **not** bump the agent that embeds the collector. Per `src/agent/AGENTS.md`, a collector change compiled into the agent alters the shipped binary → the agent version must bump, so self-update delivers it. Bump `0.5.26 → 0.5.27`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)