### PR TITLE
Prune stale template policies on Alert Template edit

### DIFF
--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1557,7 +1557,29 @@ namespace HSMServer.Core.Cache
                     }
                 }
 
-                // Each sensor's policies are mutated only on its own product queue thread.
+                // Reconcile sensors that previously held policies from this template but no longer
+                // match after the edit (path or sensor-type change). Their template-derived
+                // policies must be pruned, otherwise they stay attached with no template to manage
+                // them (#1209). On a new-template creation no sensor carries the id yet, so this
+                // scan is empty and the pass is a no-op.
+                var staleSensors = new List<BaseSensorModel>();
+                foreach (var product in products)
+                {
+                    foreach (var sensor in product.GetAllSensors())
+                    {
+                        if (matchedSensors.Contains(sensor))
+                            continue;
+
+                        var hasTemplateTtl = sensor.Policies.TTLPolicies.Any(t => t.TemplateId == alertTemplateModel.Id);
+                        var hasTemplatePolicy = sensor.Policies.Any(p => p.TemplateId == alertTemplateModel.Id);
+                        if (hasTemplateTtl || hasTemplatePolicy)
+                            staleSensors.Add(sensor);
+                    }
+                }
+
+                // Each sensor's policies are mutated only on its own product queue thread. A sensor
+                // cannot appear in both sets because staleSensors excludes matchedSensors, so the
+                // two dispatch loops are independent.
                 await Parallel.ForEachAsync(matchedSensors, new ParallelOptions
                 {
                     MaxDegreeOfParallelism = Environment.ProcessorCount,
@@ -1565,6 +1587,16 @@ namespace HSMServer.Core.Cache
                 }, async (sensor, ct) =>
                 {
                     var request = new ApplyTemplateRequest(sensor.Id, alertTemplateModel);
+                    await ProcessRequestAsync(sensor.Root.Id, request, ct);
+                });
+
+                await Parallel.ForEachAsync(staleSensors, new ParallelOptions
+                {
+                    MaxDegreeOfParallelism = Environment.ProcessorCount,
+                    CancellationToken = token
+                }, async (sensor, ct) =>
+                {
+                    var request = new RemoveTemplateFromSensorRequest(sensor.Id, alertTemplateModel.Id);
                     await ProcessRequestAsync(sensor.Root.Id, request, ct);
                 });
             }

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1542,6 +1542,12 @@ namespace HSMServer.Core.Cache
             // Persist the template once before dispatching per-sensor applications.
             // This makes it visible to concurrent AddSensor calls and removes the previous
             // reliance on a queue-thread "isPrimary" side effect.
+            // Capture the previous folder before replacing so the stale-sensor scan can also
+            // visit sensors in the old folder when the template is moved to another folder (#1209).
+            Guid? previousFolderId = null;
+            if (_alertTemplates.TryGetValue(alertTemplateModel.Id, out var previousTemplate))
+                previousFolderId = previousTemplate.FolderId;
+
             _alertTemplates[alertTemplateModel.Id] = alertTemplateModel;
             _database.AddAlertTemplate(alertTemplateModel.ToEntity());
 
@@ -1558,12 +1564,17 @@ namespace HSMServer.Core.Cache
                 }
 
                 // Reconcile sensors that previously held policies from this template but no longer
-                // match after the edit (path or sensor-type change). Their template-derived
+                // match after the edit (path, sensor-type, or folder change). Their template-derived
                 // policies must be pruned, otherwise they stay attached with no template to manage
                 // them (#1209). On a new-template creation no sensor carries the id yet, so this
-                // scan is empty and the pass is a no-op.
+                // scan is empty and the pass is a no-op. When the template moved folders, sensors
+                // in the old folder are also scanned because they can no longer match the new folder.
+                var scanProducts = products;
+                if (previousFolderId is Guid oldFolder && oldFolder != alertTemplateModel.FolderId)
+                    scanProducts = [.. products, .. GetProducts().Where(x => x.FolderId == oldFolder)];
+
                 var staleSensors = new List<BaseSensorModel>();
-                foreach (var product in products)
+                foreach (var product in scanProducts)
                 {
                     foreach (var sensor in product.GetAllSensors())
                     {

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/Fixture/TemplateApplicationFixture.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/Fixture/TemplateApplicationFixture.cs
@@ -14,6 +14,10 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests.Fixture
         internal Guid ProductId { get; } = Guid.NewGuid();
         internal Guid AccessKeyId { get; private set; }
 
+        internal Guid FolderId2 { get; private set; }
+        internal Guid ProductId2 { get; } = Guid.NewGuid();
+        internal Guid AccessKeyId2 { get; private set; }
+
 
         internal override void InitializeDatabase(IDatabaseCore dbCore)
         {
@@ -34,6 +38,25 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests.Fixture
             var key = EntitiesFactory.BuildAccessKeyEntity(productId: product.Id);
             AccessKeyId = Guid.Parse(key.Id);
             dbCore.AddAccessKey(key);
+
+            // Second folder + product for tests that move a template between folders (#1209).
+            var folder2 = EntitiesFactory.BuildFolderEntity();
+            FolderId2 = Guid.Parse(folder2.Id);
+            dbCore.AddFolder(folder2);
+
+            var product2 = new ProductEntity
+            {
+                Id = ProductId2.ToString(),
+                DisplayName = "TemplateTestProduct2",
+                CreationDate = DateTime.UtcNow.Ticks,
+                State = 1 << 30,
+                FolderId = folder2.Id,
+            };
+            dbCore.AddProduct(product2);
+
+            var key2 = EntitiesFactory.BuildAccessKeyEntity(productId: product2.Id);
+            AccessKeyId2 = Guid.Parse(key2.Id);
+            dbCore.AddAccessKey(key2);
         }
     }
 }

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateApplicationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateApplicationTests.cs
@@ -7,6 +7,7 @@ using HSMServer.Core.Cache.UpdateEntities;
 using HSMServer.Core.Model;
 using HSMServer.Core.Model.NodeSettings;
 using HSMServer.Core.Model.Policies;
+using HSMServer.Core.TableOfChanges;
 using HSMServer.Core.Tests.Infrastructure;
 using HSMServer.Core.Tests.MonitoringCoreTests;
 using HSMServer.Core.Tests.MonitoringCoreTests.Fixture;
@@ -194,6 +195,211 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                 _fixture.ProductId, sensorPath, out var sensor);
             Assert.True(found, "Sensor was not found in cache");
             Assert.Empty(sensor.Policies.TTLPolicies);
+        }
+
+
+        // Regression for #1209: editing an Alert Template's sensor type so a previously matched
+        // sensor no longer matches must prune the template-derived TTL policy from that sensor.
+        // The save path goes through AddAlertTemplateAsync for both new and edited templates.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task EditTemplate_ChangeSensorType_RemovesTtlFromNoLongerMatchingSensor()
+        {
+            // Arrange: create a template matching Integer sensors on */sensorEditType.
+            var template = BuildTemplate(SensorType.Integer, "*/sensorEditType",
+                ttlInterval: TimeSpan.FromMinutes(5));
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var sensorPath = "sensorEditType";
+            var sensorValue = SensorValuesFactory.BuildSensorValue(
+                SensorType.Integer, sensorPath, DateTime.UtcNow);
+
+            var addResult = await _valuesCache.AddSensorValueAsync(
+                _fixture.AccessKeyId, _fixture.ProductId, sensorValue);
+            Assert.True(addResult.IsOk, $"Failed to add sensor value: {addResult.Error}");
+            await Task.Delay(200);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorBefore));
+            Assert.Single(sensorBefore.Policies.TTLPolicies);
+            Assert.Equal(template.Id, sensorBefore.Policies.TTLPolicies[0].TemplateId);
+
+            // Act: re-issue AddAlertTemplateAsync with the same Id but a different SensorType,
+            // so the existing sensor no longer matches the template.
+            template.SensorType = (byte)SensorType.Double;
+            template.TryApplyPathTemplates(out _);
+
+            var (editOk, editError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(editOk, $"Failed to edit template: {editError}");
+            await Task.Delay(300);
+
+            // Assert: the template TTL is gone from the sensor.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorAfter));
+            Assert.DoesNotContain(sensorAfter.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+        }
+
+        // Regression for #1209: editing an Alert Template's path so a previously matched sensor
+        // no longer matches must prune the template-derived TTL policy from that sensor.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task EditTemplate_ChangePath_RemovesTtlFromNoLongerMatchingSensor()
+        {
+            // Arrange: template matches */sensorEditPath.
+            var template = BuildTemplate(SensorType.Integer, "*/sensorEditPath",
+                ttlInterval: TimeSpan.FromMinutes(5));
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var sensorPath = "sensorEditPath";
+            var sensorValue = SensorValuesFactory.BuildSensorValue(
+                SensorType.Integer, sensorPath, DateTime.UtcNow);
+
+            var addResult = await _valuesCache.AddSensorValueAsync(
+                _fixture.AccessKeyId, _fixture.ProductId, sensorValue);
+            Assert.True(addResult.IsOk, $"Failed to add sensor value: {addResult.Error}");
+            await Task.Delay(200);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorBefore));
+            Assert.Single(sensorBefore.Policies.TTLPolicies);
+            Assert.Equal(template.Id, sensorBefore.Policies.TTLPolicies[0].TemplateId);
+
+            // Act: re-issue AddAlertTemplateAsync with the same Id but a path that no longer
+            // matches the existing sensor.
+            template.Paths = ["*/sensorDifferentPath"];
+            template.TryApplyPathTemplates(out _);
+
+            var (editOk, editError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(editOk, $"Failed to edit template: {editError}");
+            await Task.Delay(300);
+
+            // Assert: the template TTL is gone from the sensor.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorAfter));
+            Assert.DoesNotContain(sensorAfter.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+        }
+
+        // Regression for #1209: when pruning stale template policies after an edit, a manual TTL
+        // policy on the same sensor must remain untouched.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task EditTemplate_ChangeSensorType_PreservesManualTtl()
+        {
+            // Arrange: create a matching template and sensor, then add a manual TTL.
+            var template = BuildTemplate(SensorType.Integer, "*/sensorEditManual",
+                ttlInterval: TimeSpan.FromMinutes(5));
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var sensorPath = "sensorEditManual";
+            var sensorValue = SensorValuesFactory.BuildSensorValue(
+                SensorType.Integer, sensorPath, DateTime.UtcNow);
+
+            var addResult = await _valuesCache.AddSensorValueAsync(
+                _fixture.AccessKeyId, _fixture.ProductId, sensorValue);
+            Assert.True(addResult.IsOk, $"Failed to add sensor value: {addResult.Error}");
+            await Task.Delay(200);
+
+            await AddManualTtlToSensor(_fixture.ProductId, sensorPath, TimeSpan.FromMinutes(10));
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorBefore));
+            Assert.Equal(2, sensorBefore.Policies.TTLPolicies.Count);
+            Assert.Contains(sensorBefore.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+            Assert.Contains(sensorBefore.Policies.TTLPolicies, p => p.TemplateId == null);
+
+            // Act: edit the template so the sensor no longer matches.
+            template.SensorType = (byte)SensorType.Double;
+            template.TryApplyPathTemplates(out _);
+
+            var (editOk, editError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(editOk, $"Failed to edit template: {editError}");
+            await Task.Delay(300);
+
+            // Assert: only the template TTL is removed; the manual TTL remains.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorAfter));
+            var remaining = sensorAfter.Policies.TTLPolicies;
+            Assert.Single(remaining);
+            Assert.Null(remaining[0].TemplateId);
+        }
+
+        // Regression for #1209: when pruning stale template policies after an edit, policies from
+        // a different template that still matches the sensor must remain untouched.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task EditTemplate_ChangeSensorType_PreservesOtherTemplatePolicies()
+        {
+            // Arrange: two templates matching the same sensor; edit one away.
+            var templateA = BuildTemplate(SensorType.Integer, "*/sensorEditOther",
+                ttlInterval: TimeSpan.FromMinutes(5));
+            var templateB = BuildTemplate(SensorType.Integer, "*/sensorEditOther",
+                ttlInterval: TimeSpan.FromMinutes(10));
+
+            var (addA, errA) = await _valuesCache.AddAlertTemplateAsync(templateA);
+            Assert.True(addA, $"Failed to add template A: {errA}");
+            var (addB, errB) = await _valuesCache.AddAlertTemplateAsync(templateB);
+            Assert.True(addB, $"Failed to add template B: {errB}");
+
+            var sensorPath = "sensorEditOther";
+            var sensorValue = SensorValuesFactory.BuildSensorValue(
+                SensorType.Integer, sensorPath, DateTime.UtcNow);
+
+            var addResult = await _valuesCache.AddSensorValueAsync(
+                _fixture.AccessKeyId, _fixture.ProductId, sensorValue);
+            Assert.True(addResult.IsOk, $"Failed to add sensor value: {addResult.Error}");
+            await Task.Delay(200);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorBefore));
+            Assert.Equal(2, sensorBefore.Policies.TTLPolicies.Count);
+            var templateIds = sensorBefore.Policies.TTLPolicies
+                .Select(p => p.TemplateId!.Value)
+                .OrderBy(id => id)
+                .ToArray();
+            var expectedIds = new[] { templateA.Id, templateB.Id }.OrderBy(id => id).ToArray();
+            Assert.Equal(expectedIds, templateIds);
+
+            // Act: edit templateA so the sensor no longer matches it.
+            templateA.SensorType = (byte)SensorType.Double;
+            templateA.TryApplyPathTemplates(out _);
+
+            var (editOk, editError) = await _valuesCache.AddAlertTemplateAsync(templateA);
+            Assert.True(editOk, $"Failed to edit template A: {editError}");
+            await Task.Delay(300);
+
+            // Assert: only templateA's TTL is removed; templateB's TTL remains.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorAfter));
+            var remaining = sensorAfter.Policies.TTLPolicies;
+            Assert.Single(remaining);
+            Assert.Equal(templateB.Id, remaining[0].TemplateId);
+        }
+
+
+        private async Task AddManualTtlToSensor(Guid productId, string sensorPath, TimeSpan ttl)
+        {
+            Assert.True(_valuesCache.TryGetSensorByPath(productId, sensorPath, out var sensor),
+                $"Sensor {sensorPath} not found");
+
+            var force = InitiatorInfo.AsSystemForce("test_add_manual_ttl");
+
+            // Id = Guid.Empty signals "new TTL policy" to UpdateTTLs.
+            var ttlUpdate = new PolicyUpdate
+            {
+                Id = Guid.Empty,
+                TTL = ttl.Ticks,
+                Initiator = force,
+                ConfirmationPeriod = 0,
+                Conditions = [],
+            };
+
+            var sensorUpdate = new SensorUpdate
+            {
+                Id = sensor.Id,
+                TTLPolicies = [ttlUpdate],
+                Initiator = force,
+            };
+
+            var result = await _valuesCache.UpdateSensorAsync(sensorUpdate);
+            Assert.True(result.IsOk, result.Error);
         }
 
 

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateApplicationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TemplateApplicationTests.cs
@@ -373,6 +373,95 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             Assert.Equal(templateB.Id, remaining[0].TemplateId);
         }
 
+        // Regression for #1209: editing an Alert Template's folder moves it to a different folder.
+        // Sensors in the OLD folder that previously matched must have the template-derived TTL
+        // policy pruned — they can no longer match a template that now belongs to another folder.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task EditTemplate_ChangeFolder_RemovesTtlFromSensorsInOldFolder()
+        {
+            // Arrange: template in Folder1 matching */sensorFolderChange.
+            var template = BuildTemplate(SensorType.Integer, "*/sensorFolderChange",
+                ttlInterval: TimeSpan.FromMinutes(5));
+            template.FolderId = _fixture.FolderId;
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var sensorPath = "sensorFolderChange";
+            var sensorValue = SensorValuesFactory.BuildSensorValue(
+                SensorType.Integer, sensorPath, DateTime.UtcNow);
+
+            var addResult = await _valuesCache.AddSensorValueAsync(
+                _fixture.AccessKeyId, _fixture.ProductId, sensorValue);
+            Assert.True(addResult.IsOk, $"Failed to add sensor value: {addResult.Error}");
+            await Task.Delay(200);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorBefore));
+            Assert.Single(sensorBefore.Policies.TTLPolicies);
+            Assert.Equal(template.Id, sensorBefore.Policies.TTLPolicies[0].TemplateId);
+
+            // Act: re-issue AddAlertTemplateAsync with the same Id but FolderId moved to Folder2.
+            // Use a fresh instance (mirrors the controller's data.ToModel path) so the cached
+            // template still reflects the previous FolderId when AddAlertTemplateAsync captures it.
+            var edited = new AlertTemplateModel
+            {
+                Id = template.Id,
+                Name = template.Name,
+                FolderId = _fixture.FolderId2,
+                SensorType = template.SensorType,
+                Paths = [.. template.Paths],
+                TtlEntries = [.. template.TtlEntries],
+            };
+            edited.TryApplyPathTemplates(out _);
+
+            var (editOk, editError) = await _valuesCache.AddAlertTemplateAsync(edited);
+            Assert.True(editOk, $"Failed to edit template: {editError}");
+            await Task.Delay(300);
+
+            // Assert: the sensor in the old folder no longer carries the template TTL.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorAfter));
+            Assert.DoesNotContain(sensorAfter.Policies.TTLPolicies, p => p.TemplateId == template.Id);
+        }
+
+        // Regression for #1209: regular (non-TTL) template policies are pruned by the same
+        // reconciliation path. Verifies both policy kinds listed in the issue tasks.
+        [Fact]
+        [Trait("Category", "Template application")]
+        public async Task EditTemplate_ChangeSensorType_RemovesRegularPolicyFromNoLongerMatchingSensor()
+        {
+            // Arrange: template with a regular Integer policy (value > 0), no TTL.
+            var template = BuildTemplateWithRegularPolicy(SensorType.Integer, "*/sensorRegularPolicy");
+            template.FolderId = _fixture.FolderId;
+
+            var (addOk, addError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(addOk, $"Failed to add template: {addError}");
+
+            var sensorPath = "sensorRegularPolicy";
+            var sensorValue = SensorValuesFactory.BuildSensorValue(
+                SensorType.Integer, sensorPath, DateTime.UtcNow);
+
+            var addResult = await _valuesCache.AddSensorValueAsync(
+                _fixture.AccessKeyId, _fixture.ProductId, sensorValue);
+            Assert.True(addResult.IsOk, $"Failed to add sensor value: {addResult.Error}");
+            await Task.Delay(200);
+
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorBefore));
+            Assert.Contains(sensorBefore.Policies, p => p.TemplateId == template.Id);
+
+            // Act: change the template's SensorType so the Integer sensor no longer matches.
+            template.SensorType = (byte)SensorType.Double;
+            template.TryApplyPathTemplates(out _);
+
+            var (editOk, editError) = await _valuesCache.AddAlertTemplateAsync(template);
+            Assert.True(editOk, $"Failed to edit template: {editError}");
+            await Task.Delay(300);
+
+            // Assert: the regular template policy is gone from the sensor.
+            Assert.True(_valuesCache.TryGetSensorByPath(_fixture.ProductId, sensorPath, out var sensorAfter));
+            Assert.DoesNotContain(sensorAfter.Policies, p => p.TemplateId == template.Id);
+        }
+
 
         private async Task AddManualTtlToSensor(Guid productId, string sensorPath, TimeSpan ttl)
         {
@@ -419,6 +508,35 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                 [
                     new TtlEntry(new TTLPolicy(ttlSetting, null), ttlSetting.Value ?? TimeIntervalModel.None),
                 ],
+            };
+            template.TryApplyPathTemplates(out _);
+
+            return template;
+        }
+
+        private AlertTemplateModel BuildTemplateWithRegularPolicy(SensorType sensorType, string pathPattern)
+        {
+            var policy = Policy.BuildPolicy((byte)sensorType);
+            var update = new PolicyUpdate
+            {
+                ConfirmationPeriod = 0,
+                Conditions =
+                [
+                    new PolicyConditionUpdate(
+                        PolicyOperation.GreaterThan,
+                        PolicyProperty.Value,
+                        new TargetValue(TargetType.Const, "0")),
+                ],
+            };
+            policy.UpdatePolicy(update);
+
+            var template = new AlertTemplateModel
+            {
+                Name = $"Test template {Guid.NewGuid():N}",
+                FolderId = _fixture.FolderId,
+                SensorType = (byte)sensorType,
+                Paths = [pathPattern],
+                Policies = [policy],
             };
             template.TryApplyPathTemplates(out _);
 


### PR DESCRIPTION
## Summary

`AddAlertTemplateAsync` (which serves both new-template creation and template edits) previously visited only sensors matching the NEW path/type after an edit. Sensors that matched the PREVIOUS path/type were never revisited, so their `TemplateId` policies stayed attached to the sensor with no template left to manage them.

This adds a stale-sensor reconciliation pass that scans the folder's products for sensors carrying policies with the edited template's id but not in the new matched set, and dispatches `RemoveTemplateFromSensorRequest` to each sensor's own product queue. The pass reuses the existing per-sensor removal handler (which already preserves manual alerts and other templates' policies) and is a no-op on new-template creation.

The scan also covers the folder-change case: the template's previous `FolderId` is captured before the cached entry is replaced, and when the folder changed, sensors in the old folder are scanned too — otherwise moving a template to another folder left stale policies on sensors in the old folder.

## Test plan

- [x] New regression tests in `TemplateApplicationTests.cs`:
  - `EditTemplate_ChangeSensorType_RemovesTtlFromNoLongerMatchingSensor` — the core bug
  - `EditTemplate_ChangePath_RemovesTtlFromNoLongerMatchingSensor` — path-change variant
  - `EditTemplate_ChangeSensorType_PreservesManualTtl` — manual TTL untouched
  - `EditTemplate_ChangeSensorType_PreservesOtherTemplatePolicies` — other template's TTL untouched
  - `EditTemplate_ChangeFolder_RemovesTtlFromSensorsInOldFolder` — folder-move variant
  - `EditTemplate_ChangeSensorType_RemovesRegularPolicyFromNoLongerMatchingSensor` — regular (non-TTL) policy
- [x] `dotnet test --filter "Category=Template application"` — 17/17 pass
- [x] `dotnet test --filter "FullyQualifiedName~TreeValuesCacheTests"` — 221/221 pass (no regressions)
- [ ] Manual QA: reproduce the issue flow from the bug report (create template → create matching sensor → change template sensor type → verify the sensor no longer carries the template alert)

Closes #1209

🤖 Generated with [Claude Code](https://claude.com/claude-code)