### PR TITLE
ci: surface Claude review agent logs and upload artifacts

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -22,11 +22,15 @@ jobs:
           fetch-depth: 1
 
       - uses: anthropics/claude-code-action@v1
+        id: claude
+        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           base_branch: master
-          claude_args: --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Bash(git diff*),Bash(git log*),Write"
+          claude_args: >-
+            --verbose
+            --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Bash(git diff*),Bash(git log*),Write"
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -41,3 +45,20 @@ jobs:
             Use `git diff origin/${{ github.base_ref }}...origin/${{ github.head_ref }}` to see the changes.
             Write your review to review_output.md, then post it:
             gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
+
+      - name: Dump review output (on failure)
+        if: always() && steps.claude.outcome == 'failure'
+        run: |
+          echo "=== review_output.md ==="
+          cat review_output.md 2>/dev/null || echo "(file not created)"
+
+      - name: Upload Claude logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-logs
+          path: |
+            review_output.md
+            *.log
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## Summary

- Add `--verbose` to `claude_args` so agent reasoning, tool calls, and error messages appear in the GitHub Actions step log (previously the agent failed silently with no visible output).
- Add `continue-on-error: true` + a dump step that prints `review_output.md` when the agent fails, so intermediate output is not lost.
- Upload `review_output.md` and any `*.log` files as a `claude-logs` artifact (7-day retention) for post-mortem debugging when step logs are truncated.

## Motivation

The Claude review workflow was failing without exposing the agent's error. These changes make the agent's behavior observable: `--verbose` surfaces the reasoning trace, the dump step preserves partial output on failure, and the artifact survives even if GitHub truncates the step log.

## Test plan

- [ ] Trigger the workflow on a test PR and confirm `--verbose` output appears in the step log.
- [ ] Force a failure (e.g., invalid prompt) and confirm the "Dump review output" step runs and prints `review_output.md` (or "file not created").
- [ ] Confirm the `claude-logs` artifact is attached to the workflow run and downloadable.
- [ ] Confirm a successful review still posts the PR comment as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)