### PR TITLE
ci: expose Claude review SDK error and execution output

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -31,6 +31,7 @@ jobs:
           claude_args: >-
             --verbose
             --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Bash(git diff*),Bash(git log*),Write"
+          show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -60,5 +61,6 @@ jobs:
           path: |
             review_output.md
             *.log
+            /home/runner/work/_temp/claude-execution-output.json
           if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary

- Add `show_full_output: true` to `anthropics/claude-code-action@v1` so the SDK's error text is no longer hidden "for security" in the step log.
- Add `/home/runner/work/_temp/claude-execution-output.json` to the `claude-logs` artifact upload so the full diagnostic JSON survives even when the step log is truncated.

## Motivation

`claude-review` currently fails in ~200ms with `is_error: true`, `total_cost_usd: 0`, `num_turns: 1` — i.e. the very first API call is rejected. The model resolves to `claude-opus-4-8[1m]` (valid alias, released 2026-05-28), so the failure is an API-side rejection (likely key lacks Opus 4.8 / 1M-context access, or quota/billing), not a bad model ID.

Right now the real error is invisible: `continue-on-error: true` marks the step green, the SDK hides its error text by default, and `claude-execution-output.json` is not in the artifact paths. These two edits make the actual error message reachable without changing failure semantics (`continue-on-error` is intentionally kept).

Follow-up to #1238.

## Test plan

- [ ] Trigger `claude-review` on a test PR and confirm the SDK error text now appears in the step log (`show_full_output`).
- [ ] Confirm the `claude-logs` artifact contains `claude-execution-output.json`.
- [ ] Read the actual error and follow up with the real fix (key access / model override).

🤖 Generated with [Claude Code](https://claude.com/claude-code)