### PR TITLE
Upgrade dompurify 3.0.1 -> ^3.4.11 (fix ~17 HIGH XSS)

### DIFF
--- a/src/server/HSMServer/package.json
+++ b/src/server/HSMServer/package.json
@@ -44,7 +44,7 @@
     "codemirror-json-schema": "^0.8.1",
     "datatables": "1.10.18",
     "datatables.net-dt": "2.0.8",
-    "dompurify": "^3.4.11",
+    "dompurify": "3.4.11",
     "emojionearea": "3.4.2",
     "flatpickr": "^4.6.13",
     "interactjs": "1.10.19",

--- a/src/server/HSMServer/package.json
+++ b/src/server/HSMServer/package.json
@@ -9,7 +9,6 @@
   "author": "HSM team",
   "license": "MIT",
   "devDependencies": {
-    "@types/dompurify": "3.0.5",
     "@types/jquery": "3.5.29",
     "@types/plotly.js": "2.29.1",
     "buffer": "6.0.3",
@@ -45,7 +44,7 @@
     "codemirror-json-schema": "^0.8.1",
     "datatables": "1.10.18",
     "datatables.net-dt": "2.0.8",
-    "dompurify": "3.0.1",
+    "dompurify": "^3.4.11",
     "emojionearea": "3.4.2",
     "flatpickr": "^4.6.13",
     "interactjs": "1.10.19",

--- a/src/server/HSMServer/wwwroot/src/index.js
+++ b/src/server/HSMServer/wwwroot/src/index.js
@@ -26,7 +26,7 @@ window.TimeSpan = TimeSpan;
 import * as Marked from 'marked'
 window.marked = Marked;
 
-import * as DOMPurify from 'dompurify';
+import DOMPurify from 'dompurify';
 window.DOMPurify = DOMPurify;
 
 import 'datatables';


### PR DESCRIPTION
## Summary

Upgrades `dompurify` from `3.0.1` to `3.4.11` (pinned exact) in `src/server/HSMServer/package.json` to eliminate ~17 known HIGH-severity XSS / sanitization-bypass advisories that ship to end-user browsers. Removes the deprecated `@types/dompurify` stub (DOMPurify ships its own types since 3.x).

**Includes a runtime binding fix** caught in review: dompurify 3.4.11's ESM build is default-only (`export { purify as default }`), so the previous `import * as DOMPurify` in `index.js` produced `{ default: purify }` and `window.DOMPurify.sanitize(...)` would have thrown `TypeError` at runtime (build still compiled clean). Switched to a default import matching `site-helper.ts`.

## Changes

- `package.json`: `dompurify` `3.0.1` -> `3.4.11` (exact pin, no caret — security-critical dep with no committed lockfile)
- `package.json`: removed `@types/dompurify@3.0.5` (deprecated stub)
- `index.js:29`: `import * as DOMPurify` -> `import DOMPurify` (runtime fix)

## Verification done

**Build:**
- `npm install` — clean
- `npm run build_dev` — webpack compiled successfully
- `npm run build_prod` — webpack compiled successfully (2 pre-existing bundle-size warnings, unrelated)
- `npm audit` — dompurify no longer listed

**Runtime smoke test (jsdom-backed, real DOM — faithful to browser):**
- `isSupported: true`, `typeof DOMPurify.sanitize: 'function'` — method reachable via default import
- `<img src=x onerror=alert(1)>` -> `<img src="x">` — **onerror stripped** (the payload from review)
- `<script>alert("xss")</script>` -> `` — script removed
- plain markdown / legitimate links / formatting preserved unchanged
- `namespace.sanitize` reachable = **false** (confirms the old `import *` pattern was broken at runtime)
- `default.sanitize` reachable = **true**

This proves the default-import path resolves `window.DOMPurify.sanitize` to a working function in a DOM environment, and that the old namespace import would not have. Full browser-based UI test (sensor comments / chat rendering) still recommended before merge as final sign-off.

## Test plan

- [x] `npm run build_dev` / `build_prod` compile cleanly
- [x] jsdom smoke test: sanitize reachable, XSS payloads stripped, safe content preserved
- [ ] Manual (browser): render a markdown comment/tooltip, confirm no TypeError and no console errors
- [ ] Manual (browser): confirm sanitization strips `<img src=x onerror=...>`-style payloads in real UI

Closes #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)