### PR TITLE
Show Slack destinations in Alert Template notification dropdown

### DIFF
--- a/src/server/HSMServer/Controllers/AlertTemplatesController.cs
+++ b/src/server/HSMServer/Controllers/AlertTemplatesController.cs
@@ -83,7 +83,9 @@ namespace HSMServer.Controllers
             return View(result);
         }
 
-        private sealed record ChatItem(Guid Id, string Name, byte Type);
+        private sealed record ChatEntry(Guid Id, string Name);
+
+        private sealed record ChatsPayload(List<ChatEntry> Groups, List<ChatEntry> Users, List<ChatEntry> SlackDestinations);
 
         private class UpdateResponse
         {
@@ -91,12 +93,12 @@ namespace HSMServer.Controllers
 
             public byte? Type { get; set; }
             public string Sensors { get; set; }
-            public List<ChatItem> Chats { get; set; }
+            public ChatsPayload Chats { get; set; }
             public int TotalCount { get; set; }
             public int Page { get; set; }
             public int TotalPages { get; set; }
 
-            public UpdateResponse(byte? type, List<BaseSensorModel> sensors, List<ChatItem> chats, int page = 1)
+            public UpdateResponse(byte? type, List<BaseSensorModel> sensors, ChatsPayload chats, int page = 1)
             {
                 Type = type;
                 Chats = chats;
@@ -130,13 +132,27 @@ namespace HSMServer.Controllers
 
             var (sensorType, sensors) = GetAffectedSensors(type, pathList, folderId);
 
-            List<ChatItem> chats = [];
-            if (_folders.TryGetValue(folderId, out var folder))
+            ChatsPayload chats = null;
+            if (_folders.TryGetValue(folderId, out var folder) && folder.TryGetChats(out var folderChats))
             {
-                chats = _telegram.GetValues()
-                    .Where(c => folder.Chats.Contains(c.Id) || c.Folders.Count == 0)
-                    .Select(c => new ChatItem(c.Id, c.Name, (byte)c.Type))
-                    .ToList();
+                // Mirrors folder.GetAvailableChats(_telegram, _slackDestinations) used by the POST
+                // path so the live-updated dropdown shows the same destinations as the saved form.
+                var groups = new List<ChatEntry>();
+                var users = new List<ChatEntry>();
+                var slack = new List<ChatEntry>();
+
+                foreach (var c in _telegram.GetValues())
+                    if (folderChats.Contains(c.Id) || c.Folders.Count == 0)
+                    {
+                        var list = c.Type == ConnectedChatType.TelegramGroup ? groups : users;
+                        list.Add(new ChatEntry(c.Id, c.Name));
+                    }
+
+                foreach (var d in _slackDestinations.GetValues())
+                    if (folderChats.Contains(d.Id) || d.Folders.Count == 0)
+                        slack.Add(new ChatEntry(d.Id, d.Name));
+
+                chats = new ChatsPayload(groups, users, slack);
             }
 
             var response = new UpdateResponse(sensorType, sensors, chats, page);

--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -258,8 +258,9 @@
     @await Html.PartialAsync("~/Views/Home/Alerts/_AlertsFormCollection.cshtml")
 
     function updateTemplateChatDropdowns(chats) {
-        var groups = chats.filter(c => c.Type === 1);
-        var users = chats.filter(c => c.Type === 0);
+        var groups = (chats && chats.Groups) || [];
+        var users = (chats && chats.Users) || [];
+        var slackDestinations = (chats && chats.SlackDestinations) || [];
 
         $('form#addAlertTemplate_form select[name="Chats"]').each(function() {
             var $select = $(this);
@@ -267,21 +268,25 @@
 
             $select.find('option').not('.general-group-chat-mode').remove();
 
-            $select.append('<option data-divider="true"></option>');
-            $select.append('<option disabled>Groups</option>');
-            groups.forEach(function(chat) {
-                var isSelected = currentSelected.includes(chat.Id);
-                $select.append(`<option value="${chat.Id}" ${isSelected ? 'selected' : ''}>${chat.Name}</option>`);
-            });
-
-            $select.append('<option data-divider="true"></option>');
-            $select.append('<option disabled>Users</option>');
-            users.forEach(function(chat) {
-                var isSelected = currentSelected.includes(chat.Id);
-                $select.append(`<option value="${chat.Id}" ${isSelected ? 'selected' : ''}>${chat.Name}</option>`);
-            });
+            appendChatSection($select, 'Groups', groups, currentSelected);
+            appendChatSection($select, 'Users', users, currentSelected);
+            appendChatSection($select, 'Slack destinations', slackDestinations, currentSelected, 'No Slack destinations configured');
 
             $select.selectpicker('refresh');
+        });
+    }
+
+    function appendChatSection($select, title, items, currentSelected, emptyMessage) {
+        $select.append('<option data-divider="true"></option>');
+        $select.append(`<option disabled>${title}</option>`);
+        if (items.length === 0) {
+            if (emptyMessage)
+                $select.append(`<option disabled value="">${emptyMessage}</option>`);
+            return;
+        }
+        items.forEach(function(chat) {
+            var isSelected = currentSelected.includes(chat.Id);
+            $select.append(`<option value="${chat.Id}"${isSelected ? ' selected' : ''}>${chat.Name}</option>`);
         });
     }
 

--- a/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using HSMCommon.Model;
@@ -221,5 +222,134 @@ namespace HSMServer.Core.Tests.Controllers
             // Verifies the helper iterates paths rather than short-circuiting on the first mismatch.
             _cacheMock.Verify(c => c.GetSensors(It.IsAny<string>(), It.IsAny<SensorType?>(), It.IsAny<Guid?>()), Times.Exactly(3));
         }
+
+        // Regression coverage for #1244: UpdateTemplate feeds the live-refreshed notification dropdown,
+        // so it had to return Slack destinations alongside Telegram — otherwise any Slack selection
+        // disappeared the moment the user changed folder/type/path.
+        [Fact]
+        [Trait("Category", "Alert Template authoring")]
+        public void UpdateTemplate_ReturnsTelegramAndSlackChats()
+        {
+            var folderId = Guid.NewGuid();
+            var telegramChat = BuildTelegramChat(Guid.NewGuid(), "tg-group", ConnectedChatType.TelegramGroup);
+            var slackDestination = BuildSlackDestination(Guid.NewGuid(), "slack-channel");
+
+            var folder = new FolderModel(BuildFolderEntity(folderId, telegramChat.Id, slackDestination.Id));
+
+            _folderManagerMock.Setup(f => f.TryGetValue(folderId, out folder)).Returns(true);
+            _telegramMock.Setup(t => t.GetValues()).Returns(new List<TelegramChat> { telegramChat });
+            _slackDestinationsMock.Setup(s => s.GetValues()).Returns(new List<SlackDestination> { slackDestination });
+
+            var controller = CreateController();
+
+            var result = controller.UpdateTemplate(DataAlertTemplateViewModel.AnyType, "[]", folderId);
+
+            var json = Assert.IsType<JsonResult>(result);
+            using var doc = JsonDocument.Parse((string)json.Value);
+            var chats = doc.RootElement.GetProperty("Chats");
+
+            var tg = Assert.Single(chats.GetProperty("Groups").EnumerateArray());
+            Assert.Equal(telegramChat.Id, Guid.Parse(tg.GetProperty("Id").GetString()));
+            Assert.Equal(telegramChat.Name, tg.GetProperty("Name").GetString());
+
+            Assert.Empty(chats.GetProperty("Users").EnumerateArray());
+
+            var slack = Assert.Single(chats.GetProperty("SlackDestinations").EnumerateArray());
+            Assert.Equal(slackDestination.Id, Guid.Parse(slack.GetProperty("Id").GetString()));
+            Assert.Equal(slackDestination.Name, slack.GetProperty("Name").GetString());
+        }
+
+        [Fact]
+        [Trait("Category", "Alert Template authoring")]
+        public void UpdateTemplate_FiltersSlackDestinationsByFolderBinding()
+        {
+            // A Slack destination bound to a different folder must not appear in this folder's dropdown.
+            // Mirrors the Telegram availability rule used by GetAvailableChats.
+            var folderId = Guid.NewGuid();
+            var boundSlack = BuildSlackDestination(Guid.NewGuid(), "bound-slack");
+            boundSlack.Folders.Add(folderId);
+
+            var unboundSlack = BuildSlackDestination(Guid.NewGuid(), "other-folder-slack");
+            unboundSlack.Folders.Add(Guid.NewGuid()); // tied to a different folder
+
+            var folder = new FolderModel(BuildFolderEntity(folderId, boundSlack.Id));
+
+            _folderManagerMock.Setup(f => f.TryGetValue(folderId, out folder)).Returns(true);
+            _telegramMock.Setup(t => t.GetValues()).Returns(new List<TelegramChat>());
+            _slackDestinationsMock.Setup(s => s.GetValues()).Returns(new List<SlackDestination> { boundSlack, unboundSlack });
+
+            var controller = CreateController();
+
+            var result = controller.UpdateTemplate(DataAlertTemplateViewModel.AnyType, "[]", folderId);
+
+            var json = Assert.IsType<JsonResult>(result);
+            using var doc = JsonDocument.Parse((string)json.Value);
+            var slackIds = doc.RootElement
+                .GetProperty("Chats")
+                .GetProperty("SlackDestinations")
+                .EnumerateArray()
+                .Select(c => Guid.Parse(c.GetProperty("Id").GetString()))
+                .ToList();
+
+            Assert.Single(slackIds);
+            Assert.Equal(boundSlack.Id, slackIds[0]);
+        }
+
+        [Fact]
+        [Trait("Category", "Alert Template authoring")]
+        public void UpdateTemplate_ReturnsNullChats_WhenFolderNotFound()
+        {
+            // When the folder lookup misses, Chats stays null so the JS `if (data.Chats != null)`
+            // guard skips the dropdown rebuild entirely. A non-null empty payload would wipe the
+            // existing selection — the null contract is load-bearing.
+            var unknownFolderId = Guid.NewGuid();
+            FolderModel folder = null;
+            _folderManagerMock.Setup(f => f.TryGetValue(unknownFolderId, out folder)).Returns(false);
+
+            var controller = CreateController();
+
+            var result = controller.UpdateTemplate(DataAlertTemplateViewModel.AnyType, "[]", unknownFolderId);
+
+            var json = Assert.IsType<JsonResult>(result);
+            using var doc = JsonDocument.Parse((string)json.Value);
+            Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("Chats").ValueKind);
+        }
+
+
+        private static TelegramChat BuildTelegramChat(Guid id, string name, ConnectedChatType type) =>
+            new(new TelegramChatEntity
+            {
+                Id = id.ToByteArray(),
+                Author = Guid.NewGuid().ToByteArray(),
+                CreationDate = DateTime.UtcNow.Ticks,
+                Name = name,
+                ChatId = long.MaxValue,
+                SendMessages = true,
+                Type = (byte)type,
+                MessagesAggregationTimeSec = 60,
+                AuthorizationTime = DateTime.UtcNow.Ticks,
+            });
+
+        private static SlackDestination BuildSlackDestination(Guid id, string name) =>
+            new(new SlackDestinationEntity
+            {
+                Id = id.ToByteArray(),
+                Author = Guid.NewGuid().ToByteArray(),
+                CreationDate = DateTime.UtcNow.Ticks,
+                Name = name,
+                WebhookUrl = "https://hooks.slack.com/services/test",
+                SendMessages = true,
+                MessagesAggregationTimeSec = 60,
+            });
+
+        private static FolderEntity BuildFolderEntity(Guid folderId, params Guid[] chatIds) =>
+            new()
+            {
+                Id = folderId.ToString(),
+                DisplayName = "Test folder",
+                AuthorId = Guid.NewGuid().ToString(),
+                CreationDate = DateTime.UtcNow.Ticks,
+                Chats = chatIds.Select(c => c.ToByteArray()).ToList(),
+            };
     }
 }


### PR DESCRIPTION
## Summary
- `AlertTemplatesController.UpdateTemplate` now returns Slack destinations alongside Telegram, using `folder.TryGetChats` with the same availability rule as the POST save path (`folder.GetAvailableChats(_telegram, _slackDestinations)`).
- Response shape changed from a flat `List<ChatItem>` with a stringly-typed `Kind` discriminator to three explicit arrays (`Groups`, `Users`, `SlackDestinations`). This matches the canonical pattern in `_DefaultChat.cshtml` and lets the client render directly without filtering by `Kind`/`Type`.
- `updateTemplateChatDropdowns` rebuilt via a shared `appendChatSection($select, title, items, currentSelected, emptyMessage?)` helper; preserves the currently selected Slack ids across refreshes (selection captured before option wipe).
- `Chats` is `null` (not an empty payload) when the folder lookup misses, so the existing `if (data.Chats != null)` JS guard skips the dropdown rebuild instead of clearing the user's selection.

## Test plan
- [ ] Run `dotnet test src/tests/HSMServer.Core.Tests --filter "FullyQualifiedName~AlertTemplatesControllerTests"`
- [ ] Manual: open an Alert Template bound to a folder with a Slack destination; confirm Slack appears under "Slack destinations" in the notification dropdown.
- [ ] Manual: select a Slack destination, change folder/type/path to trigger the form refresh; confirm the Slack selection persists.
- [ ] Manual: save the template, reopen it; confirm the Slack destination is still selected.
- [ ] Manual: apply the template to a matching sensor; confirm the applied alert retains the Slack destination.
- [ ] Manual: Telegram groups/users still appear and save as before.

Closes #1244

🤖 Generated with [Claude Code](https://claude.com/claude-code)