### PR TITLE
Wait for GetOperation AJAX before submitting alert form (#1246)

### DIFF
--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -176,36 +176,42 @@
     }
 
     function submitForm() {
-        let form = document.getElementById('addAlertTemplate_form');
-        var formData = new FormData(form);
-        collectAlerts(formData);
+        // Wait for any in-flight GetOperation partials (promote/demote) before collecting form
+        // data — otherwise collectAlerts would read a stale operation div and silently drop the
+        // edited row (#1246). Use .always so a failed fetch still submits and surfaces a server
+        // validation error rather than hanging the Save button.
+        waitForOperationLoads().always(function () {
+            let form = document.getElementById('addAlertTemplate_form');
+            var formData = new FormData(form);
+            collectAlerts(formData);
 
-        $.ajax({
-            url: $("#addAlertTemplate_form").attr("action"),
-            type: $("#addAlertTemplate_form").attr("method"),
-            data: formData,
-            processData: false,
-            contentType: false,
-            async: true,
-            success: (viewData) => {
-                if (!viewData){
-                    window.location.href = '@Html.Raw(Url.Action(nameof(AlertTemplatesController.Index), ViewConstants.AlertTemplatesController))';
+            $.ajax({
+                url: $("#addAlertTemplate_form").attr("action"),
+                type: $("#addAlertTemplate_form").attr("method"),
+                data: formData,
+                processData: false,
+                contentType: false,
+                async: true,
+                success: (viewData) => {
+                    if (!viewData){
+                        window.location.href = '@Html.Raw(Url.Action(nameof(AlertTemplatesController.Index), ViewConstants.AlertTemplatesController))';
+                    }
+                    else if (typeof viewData === 'object' && viewData.success === false) {
+                        showConfirmationModal(
+                            'Failed to save template',
+                            viewData.error,
+                            () => {},
+                            () => { window.location.href = '@Html.Raw(Url.Action(nameof(AlertTemplatesController.Index), ViewConstants.AlertTemplatesController))'; },
+                            'Edit',
+                            'Discard'
+                        );
+                    }
+                    else {
+                        $("#addAlertTemplate_form").html(viewData);
+                        initForm();
+                    }
                 }
-                else if (typeof viewData === 'object' && viewData.success === false) {
-                    showConfirmationModal(
-                        'Failed to save template',
-                        viewData.error,
-                        () => {},
-                        () => { window.location.href = '@Html.Raw(Url.Action(nameof(AlertTemplatesController.Index), ViewConstants.AlertTemplatesController))'; },
-                        'Edit',
-                        'Discard'
-                    );
-                }
-                else {
-                    $("#addAlertTemplate_form").html(viewData);
-                    initForm();
-                }
-            }
+            });
         });
     }
 

--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -178,8 +178,10 @@
     function submitForm() {
         // Wait for any in-flight GetOperation partials (promote/demote) before collecting form
         // data — otherwise collectAlerts would read a stale operation div and silently drop the
-        // edited row (#1246). Use .always so a failed fetch still submits and surfaces a server
-        // validation error rather than hanging the Save button.
+        // edited row (#1246). waitForOperationLoads drains pending requests in a loop, so a
+        // second edit during the wait is still covered; GetOperation has its own timeout, so a
+        // stalled connection rejects (not hangs) and .always still submits to surface a server
+        // validation error instead of freezing the Save button.
         waitForOperationLoads().always(function () {
             let form = document.getElementById('addAlertTemplate_form');
             var formData = new FormData(form);

--- a/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
@@ -22,7 +22,16 @@
     // redeclaration would throw SyntaxError and break the whole sensor editor. var + function
     // declarations are idempotent across re-execution — same pattern as the rest of the file.
     var pendingOperationLoads = [];
-    function registerOperationLoad(req) { pendingOperationLoads.push(req); }
+    function registerOperationLoad(req) {
+        pendingOperationLoads.push(req);
+        // Prune on settle so the array reflects only truly in-flight requests. Without this a
+        // failed or timed-out request would sit in the array forever; since $.when is reject-fast
+        // it would short-circuit every later save and re-open #1246 for the rest of the session.
+        req.always(function () {
+            var i = pendingOperationLoads.indexOf(req);
+            if (i !== -1) pendingOperationLoads.splice(i, 1);
+        });
+    }
     function waitForOperationLoads() {
         // Drain in a loop: snapshot the in-flight requests, clear the array, await them, and
         // re-check. Requests fired by a Property change on another row during the wait are now
@@ -30,6 +39,12 @@
         // the race where Save followed by a second edit would let collectAlerts read a stale
         // operation div on the second row. Loop bounded in practice: GetOperation is fast and
         // has its own timeout in _ConditionBlock.cshtml, so the array drains within seconds.
+        //
+        // Each request is wrapped in .then(null, resolve) so $.when waits for ALL of them to
+        // settle instead of short-circuiting on the first rejection. A timed-out request still
+        // lets its siblings' wait complete normally; the user gets the accepted degraded case
+        // (stale div for the failed row only) rather than the bug (every row past the first
+        // failure racing).
         var deferred = $.Deferred();
         (function drain() {
             var snapshot = pendingOperationLoads.slice();
@@ -38,7 +53,10 @@
                 deferred.resolve();
                 return;
             }
-            $.when.apply($, snapshot).always(drain);
+            var settled = snapshot.map(function (r) {
+                return r.then(null, function () { return $.Deferred().resolve(); });
+            });
+            $.when.apply($, settled).always(drain);
         })();
         return deferred.promise();
     }

--- a/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
@@ -10,6 +10,21 @@
     const byte ttlType = TimeToLiveAlertViewModel.AlertKey;
 }
 
+    // Tracks in-flight GetOperation AJAX calls fired by the Property change handler in
+    // _ConditionBlock.cshtml. On promote/demote, data-alert-type flips synchronously but the
+    // operation partial swaps in only after the AJAX resolves — if the form is submitted during
+    // that window, collectAlerts would read the stale operation div and send contradictory data
+    // (Property=Value but TimeToLive.Interval instead of Operation/Target), causing the demoted
+    // row to be silently dropped (#1246). submitForm waits on these before collecting.
+    const pendingOperationLoads = [];
+    function registerOperationLoad(req) { pendingOperationLoads.push(req); }
+    function waitForOperationLoads() {
+        // Snapshot + clear so requests fired during the wait are tracked for the next submit.
+        const snapshot = pendingOperationLoads.slice();
+        pendingOperationLoads.length = 0;
+        return $.when.apply($, snapshot);
+    }
+
     function setFormDataAlerts(formData, type, alertsList) {
         // Per-row destination type: read data-alert-type if present (set in _DataAlert.cshtml
         // based on whether the main condition is TTL). Rows whose main condition is TTL route

--- a/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
@@ -24,10 +24,23 @@
     var pendingOperationLoads = [];
     function registerOperationLoad(req) { pendingOperationLoads.push(req); }
     function waitForOperationLoads() {
-        // Snapshot + clear so requests fired during the wait are tracked for the next submit.
-        var snapshot = pendingOperationLoads.slice();
-        pendingOperationLoads.length = 0;
-        return $.when.apply($, snapshot);
+        // Drain in a loop: snapshot the in-flight requests, clear the array, await them, and
+        // re-check. Requests fired by a Property change on another row during the wait are now
+        // picked up by the next iteration instead of leaking past the current submit — closes
+        // the race where Save followed by a second edit would let collectAlerts read a stale
+        // operation div on the second row. Loop bounded in practice: GetOperation is fast and
+        // has its own timeout in _ConditionBlock.cshtml, so the array drains within seconds.
+        var deferred = $.Deferred();
+        (function drain() {
+            var snapshot = pendingOperationLoads.slice();
+            pendingOperationLoads.length = 0;
+            if (snapshot.length === 0) {
+                deferred.resolve();
+                return;
+            }
+            $.when.apply($, snapshot).always(drain);
+        })();
+        return deferred.promise();
     }
 
     function setFormDataAlerts(formData, type, alertsList) {

--- a/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_AlertsFormCollection.cshtml
@@ -16,11 +16,16 @@
     // that window, collectAlerts would read the stale operation div and send contradictory data
     // (Property=Value but TimeToLive.Interval instead of Operation/Target), causing the demoted
     // row to be silently dropped (#1246). submitForm waits on these before collecting.
-    const pendingOperationLoads = [];
+    //
+    // var (not const) on top level: _MetaInfo.cshtml is re-rendered into #meta_info_<id> via
+    // jQuery .html() on every revert/load, which re-executes this inline <script>. A const
+    // redeclaration would throw SyntaxError and break the whole sensor editor. var + function
+    // declarations are idempotent across re-execution — same pattern as the rest of the file.
+    var pendingOperationLoads = [];
     function registerOperationLoad(req) { pendingOperationLoads.push(req); }
     function waitForOperationLoads() {
         // Snapshot + clear so requests fired during the wait are tracked for the next submit.
-        const snapshot = pendingOperationLoads.slice();
+        var snapshot = pendingOperationLoads.slice();
         pendingOperationLoads.length = 0;
         return $.when.apply($, snapshot);
     }

--- a/src/server/HSMServer/Views/Home/Alerts/_ConditionBlock.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_ConditionBlock.cshtml
@@ -105,12 +105,17 @@
             }
         }
 
-        $.ajax({
+        // Register with the in-flight tracker so submitForm waits for the partial before
+        // collecting form data. Without this, a Save fired before the partial lands would read
+        // the stale operation div and misroute the row's fields (#1246).
+        const operationReq = $.ajax({
             // containerType (real sensor type), not `type` (which is Boolean for TTL alerts loaded
             // from storage — see #1207) so demote fetches the right operation partial.
             url: `@Url.Action(nameof(HomeController.GetOperation), ViewConstants.HomeController)?type=${containerType}&property=${property}`,
             cache: false
-        }).done(function (viewData) {
+        });
+        registerOperationLoad(operationReq);
+        operationReq.done(function (viewData) {
             operation.html(viewData);
         });
     });

--- a/src/server/HSMServer/Views/Home/Alerts/_ConditionBlock.cshtml
+++ b/src/server/HSMServer/Views/Home/Alerts/_ConditionBlock.cshtml
@@ -108,11 +108,16 @@
         // Register with the in-flight tracker so submitForm waits for the partial before
         // collecting form data. Without this, a Save fired before the partial lands would read
         // the stale operation div and misroute the row's fields (#1246).
+        // timeout: cap how long the wait can block submit. GetOperation is a fast local endpoint
+        // and normally returns in milliseconds; if it stalls (proxy black-hole, dead socket),
+        // waitForOperationLoads' .always still fires on fail and submit proceeds with the stale
+        // operation div for this row rather than hanging Save indefinitely.
         const operationReq = $.ajax({
             // containerType (real sensor type), not `type` (which is Boolean for TTL alerts loaded
             // from storage — see #1207) so demote fetches the right operation partial.
             url: `@Url.Action(nameof(HomeController.GetOperation), ViewConstants.HomeController)?type=${containerType}&property=${property}`,
-            cache: false
+            cache: false,
+            timeout: 10000
         });
         registerOperationLoad(operationReq);
         operationReq.done(function (viewData) {

--- a/src/server/HSMServer/Views/Home/_MetaInfo.cshtml
+++ b/src/server/HSMServer/Views/Home/_MetaInfo.cshtml
@@ -210,7 +210,8 @@
 
         // Wait for any in-flight GetOperation partials (promote/demote) before collecting form
         // data — otherwise collectAlerts would read a stale operation div and silently drop the
-        // edited row (#1246). Same race and same shared partial as the Alert Template editor.
+        // edited row (#1246). Same race, same shared partial, and same loop+timeout protection
+        // as the Alert Template editor — see _AlertsFormCollection.cshtml for the drain loop.
         waitForOperationLoads().always(function () {
             var formData = new FormData(this);
             collectAlerts(formData);

--- a/src/server/HSMServer/Views/Home/_MetaInfo.cshtml
+++ b/src/server/HSMServer/Views/Home/_MetaInfo.cshtml
@@ -208,29 +208,34 @@
         event.preventDefault();
         event.stopImmediatePropagation();
 
-        var formData = new FormData(this);
-        collectAlerts(formData);
-        if (window.fillDefaultChatMode) {
-            window.fillDefaultChatMode(formData);
-        }
-
-        $.ajax({
-            url: $("#editMetaInfo_form").attr("action"),
-            type: 'POST',
-            data: formData,
-            processData: false,
-            contentType: false,
-            async: true,
-            success: (viewData) => {
-                $('#editButtonMetaInfo').removeClass('d-none');
-                displayMetaInfo($('#metaInfo_encodedId').val(), viewData);
-
-                if ($(".field-validation-error").length !== 0)
-                    editInfoButtonClick();
-
-                window.InitializeHistory();
+        // Wait for any in-flight GetOperation partials (promote/demote) before collecting form
+        // data — otherwise collectAlerts would read a stale operation div and silently drop the
+        // edited row (#1246). Same race and same shared partial as the Alert Template editor.
+        waitForOperationLoads().always(function () {
+            var formData = new FormData(this);
+            collectAlerts(formData);
+            if (window.fillDefaultChatMode) {
+                window.fillDefaultChatMode(formData);
             }
-        });
+
+            $.ajax({
+                url: $("#editMetaInfo_form").attr("action"),
+                type: 'POST',
+                data: formData,
+                processData: false,
+                contentType: false,
+                async: true,
+                success: (viewData) => {
+                    $('#editButtonMetaInfo').removeClass('d-none');
+                    displayMetaInfo($('#metaInfo_encodedId').val(), viewData);
+
+                    if ($(".field-validation-error").length !== 0)
+                        editInfoButtonClick();
+
+                    window.InitializeHistory();
+                }
+            });
+        }.bind(this));
     });
 
     function collectAlerts(formData) {

--- a/src/server/HSMServer/wwwroot/src/js/nodeData.js
+++ b/src/server/HSMServer/wwwroot/src/js/nodeData.js
@@ -151,66 +151,74 @@ function saveMetaData(selectedId) {
         return;
     }
 
-    let formData = new FormData(form);
-    
-    collectAlerts(formData);
+    // Same #1246 race as the explicit Save button: if the user demotes a TTL row and then
+    // clicks another tree node before GetOperation resolves, collectAlerts would read the
+    // stale operation div and the demoted row would be misrouted / dropped. waitForOperationLoads
+    // is the same global defined via _AlertsFormCollection.cshtml. .always so a stalled
+    // GetOperation (which has its own timeout) still lets the user navigate away rather than
+    // hanging the tree click.
+    waitForOperationLoads().always(function () {
+        let formData = new FormData(form);
 
-    $.ajax({
-        type: 'POST',
-        url: isDataValidAction,
-        data: formData,
-        processData: false,
-        contentType: false,
-        async: true
-    }).done(function (isValid) {
-        let isAlertsValid = true;
-        $("#editMetaInfo_form").find("div.dataAlertRow").each(function () {
-            $(this).find(`input[name='Comment']`).each(function () {
-                isAlertsValid &= $(this)[0].checkValidity();
+        collectAlerts(formData);
+
+        $.ajax({
+            type: 'POST',
+            url: isDataValidAction,
+            data: formData,
+            processData: false,
+            contentType: false,
+            async: true
+        }).done(function (isValid) {
+            let isAlertsValid = true;
+            $("#editMetaInfo_form").find("div.dataAlertRow").each(function () {
+                $(this).find(`input[name='Comment']`).each(function () {
+                    isAlertsValid &= $(this)[0].checkValidity();
+                });
+
+                $(this).find('input[name="Target"]').each(function () {
+                    isAlertsValid &= $(this)[0].checkValidity();
+                });
             });
 
-            $(this).find('input[name="Target"]').each(function () {
-                isAlertsValid &= $(this)[0].checkValidity();
-            });
-        });
+            if (isValid && isAlertsValid) {
+                let path = $("#nodeHeader").text();
 
-        if (isValid && isAlertsValid) {
-            let path = $("#nodeHeader").text();
-
-            if (!formObserver.check())
-            {
-                showConfirmationModal(
-                    `Saving changes`,
-                    `Do you want to save '${path}' changes?`,
-                    () => {
-                        $.ajax({
-                            url: form.action,
-                            type: 'POST',
-                            data: formData,
-                            processData: false,
-                            contentType: false,
-                            async: true
-                        }).done(() => initSelectedNode(selectedId));
-                    },
-                    () => initSelectedNode(selectedId),
-                    "Yes",
-                    "No"
-                );
+                if (!formObserver.check())
+                {
+                    showConfirmationModal(
+                        `Saving changes`,
+                        `Do you want to save '${path}' changes?`,
+                        () => {
+                            $.ajax({
+                                url: form.action,
+                                type: 'POST',
+                                data: formData,
+                                processData: false,
+                                contentType: false,
+                                async: true
+                            }).done(() => initSelectedNode(selectedId));
+                        },
+                        () => initSelectedNode(selectedId),
+                        "Yes",
+                        "No"
+                    );
+                }
+                else {
+                    $.ajax({
+                        url: form.action,
+                        type: 'POST',
+                        data: formData,
+                        processData: false,
+                        contentType: false,
+                        async: true
+                    }).done(() => initSelectedNode(selectedId));
+                }
             }
             else {
-                $.ajax({
-                    url: form.action,
-                    type: 'POST',
-                    data: formData,
-                    processData: false,
-                    contentType: false,
-                    async: true
-                }).done(() => initSelectedNode(selectedId));
+                initSelectedNode(selectedId);
             }
-        }
-        else {
-            initSelectedNode(selectedId);
-        }
+        });
     });
 }
 

--- a/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
@@ -14,6 +14,7 @@ using HSMServer.Core.Tests.Infrastructure;
 using HSMServer.Controllers;
 using HSMServer.Folders;
 using HSMServer.Model.Authentication;
+using HSMServer.Model.DataAlerts;
 using HSMServer.Model.DataAlertTemplates;
 using HSMServer.Model.Folders;
 using HSMServer.Model.TreeViewModel;
@@ -220,6 +221,44 @@ namespace HSMServer.Core.Tests.Controllers
             Assert.Contains(errors, e => e.ErrorMessage.Contains("badPathThree"));
             // Verifies the helper iterates paths rather than short-circuiting on the first mismatch.
             _cacheMock.Verify(c => c.GetSensors(It.IsAny<string>(), It.IsAny<SensorType?>(), It.IsAny<Guid?>()), Times.Exactly(3));
+        }
+
+        // Regression coverage for #1246: when a demoted TTL row's Operation is missing from the
+        // form data (the client-side race where collectAlerts runs before the GetOperation AJAX
+        // completes), the server silently drops the condition — Property=Value is bound but
+        // Operation=null, so ToUpdate's `if (condition.Operation != null)` guard skips it.
+        // The resulting policy has zero conditions. This test documents that behavior so a future
+        // server-side change can't accidentally start auto-filling Operation; the real fix lives
+        // in submitForm (waits for the AJAX before collecting).
+        [Fact]
+        [Trait("Category", "Alert Template authoring")]
+        public async Task AlertTemplate_DemotedRowWithoutOperation_SavesPolicyWithNoConditions()
+        {
+            AlertTemplateModel captured = null;
+            _cacheMock.Setup(c => c.AddAlertTemplateAsync(It.IsAny<AlertTemplateModel>(), It.IsAny<CancellationToken>()))
+                .Callback<AlertTemplateModel, CancellationToken>((m, _) => captured = m)
+                .Returns(Task.FromResult((true, (string)null)));
+
+            var controller = CreateController();
+            var data = BuildData((byte)SensorType.Integer, "*/intSensor");
+            data.DataAlerts = new Dictionary<byte, List<DataAlertViewModelBase>>
+            {
+                [(byte)SensorType.Integer] =
+                [
+                    new DataAlertViewModelBase
+                    {
+                        Id = Guid.NewGuid(),
+                        Conditions = { new ConditionViewModel { Property = AlertProperty.Value } },
+                    },
+                ],
+            };
+
+            var result = await controller.AlertTemplate(data);
+
+            Assert.IsType<OkResult>(result);
+            Assert.NotNull(captured);
+            Assert.Single(captured.Policies);
+            Assert.Empty(captured.Policies[0].Conditions);
         }
     }
 }

--- a/src/tests/HSMServer.Core.Tests/DataAlertTemplateViewModelTests/DataAlertTemplateViewModelMultiRowDemoteTests.cs
+++ b/src/tests/HSMServer.Core.Tests/DataAlertTemplateViewModelTests/DataAlertTemplateViewModelMultiRowDemoteTests.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HSMCommon.Model;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Core.DataLayer;
+using HSMServer.Core.Model;
+using HSMServer.Core.Model.NodeSettings;
+using HSMServer.Core.Model.Policies;
+using HSMServer.Model.DataAlerts;
+using HSMServer.Model.DataAlertTemplates;
+using Xunit;
+
+namespace HSMServer.Core.Tests.DataAlertTemplateViewModelTests
+{
+    // Regression coverage for #1246: When an Alert Template has two TTL alerts and one is demoted
+    // to a regular condition client-side, the form posts one row under DataAlerts[sensorType] and
+    // the other under DataAlerts[255]. ToModel must persist both: the demoted row as a regular
+    // Policy, the untouched row as a TTLPolicy. Locks the server-side contract so a future
+    // refactor can't regress it; the client-side race that fed it bad data is fixed in submitForm.
+    public class DataAlertTemplateViewModelMultiRowDemoteTests
+    {
+        [Fact]
+        public void ToModel_DemoteOneOfTwoTtl_PersistsDemotedAsRegularAndOtherAsTtl()
+        {
+            // Template configured for Integer sensors with two TTL alerts loaded from storage.
+            var ttlId1 = Guid.NewGuid();
+            var ttlId2 = Guid.NewGuid();
+            var templateId = Guid.NewGuid();
+
+            var ttl1 = BuildTtl(ttlId1);
+            var ttl2 = BuildTtl(ttlId2);
+
+            var model = new AlertTemplateModel
+            {
+                Id = templateId,
+                Name = "two-ttl-template",
+                SensorType = (byte)SensorType.Integer,
+                Paths = ["*/intSensor"],
+                TtlEntries =
+                [
+                    new TtlEntry(ttl1, TimeIntervalModel.None),
+                    new TtlEntry(ttl2, TimeIntervalModel.None),
+                ],
+            };
+
+            var vm = new DataAlertTemplateViewModel(model);
+
+            Assert.Single(vm.DataAlerts);
+            Assert.Equal(TimeToLiveAlertViewModel.AlertKey, vm.DataAlerts.First().Key);
+            Assert.Equal(2, vm.DataAlerts.First().Value.Count);
+
+            // Simulate the form posts that the JS produces after the user demotes alert #1 to a
+            // regular Integer condition. The row's data-alert-type flips 255 -> (byte)Integer, so
+            // collectAlerts routes it under DataAlerts[4]. The unchanged TTL row stays under 255.
+            var demoted = vm.DataAlerts[TimeToLiveAlertViewModel.AlertKey][0];
+            var unchangedTtl = vm.DataAlerts[TimeToLiveAlertViewModel.AlertKey][1];
+
+            // Force a non-empty Id on the demoted row so ToModel can route it through
+            // Policy.BuildPolicy without inventing a fresh Guid (lets us assert equality below).
+            demoted.Id = ttlId1;
+
+            var rebuilt = new DataAlertTemplateViewModel
+            {
+                Id = templateId,
+                Name = "two-ttl-template",
+                Type = (byte)SensorType.Integer,
+                PathTemplates = ["*/intSensor"],
+                DataAlerts = new Dictionary<byte, List<DataAlertViewModelBase>>
+                {
+                    [(byte)SensorType.Integer] = new() { demoted },
+                    [TimeToLiveAlertViewModel.AlertKey] = new() { unchangedTtl },
+                },
+            };
+
+            var result = rebuilt.ToModel(null);
+
+            // The demoted row is persisted as a regular Integer Policy...
+            Assert.Single(result.Policies);
+            Assert.Equal(ttlId1, result.Policies[0].Id);
+
+            // ...and the unchanged row is still a TTL.
+            Assert.Single(result.TtlEntries);
+            Assert.Equal(ttlId2, result.TtlEntries[0].Policy.Id);
+        }
+
+
+        private static TTLPolicy BuildTtl(Guid id)
+        {
+            var ttlSetting = new TimeIntervalSettingProperty();
+            ttlSetting.TrySetValue(TimeIntervalModel.None);
+
+            // Construct via the (setting, entity) ctor so we can stamp a specific Id through the
+            // PolicyEntity — TTLPolicy's parameterless ctor generates a new Guid and FullUpdate
+            // does not overwrite it from PolicyUpdate.Id (the storage path uses TryUpdate).
+            var entity = new PolicyEntity
+            {
+                Id = id.ToByteArray(),
+                TTL = TimeIntervalModel.None.Ticks,
+                Destination = new PolicyDestinationEntity { UseDefaultChats = true },
+            };
+            return new TTLPolicy(ttlSetting, entity);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a race condition where demoting a saved TTL (Inactivity Period) alert to a regular condition in the Alert Template editor was not persisted when multiple alert rows were present.

**Root cause:** The Property change handler in `_ConditionBlock.cshtml` flips `data-alert-type` synchronously but fetches the replacement operation partial (`GetOperation`) asynchronously. If the user clicks Save before that AJAX resolves, `collectAlerts` reads the stale interval-operation div and routes the row's fields as TTL data even though the row is now keyed under the concrete sensor type. The server then sees `Property=Value` with `Operation=null` and silently drops the condition in `ToUpdate`, so the demoted row is not persisted.

**Fix:** Track pending `GetOperation` requests in a shared array (`_AlertsFormCollection.cshtml`) and have both `submitForm` paths (`AlertTemplate.cshtml`, `_MetaInfo.cshtml`) wait on them via `$.when` before collecting form data. The sensor editor gets the same fix because it shares the form-collection partial and has the same race.

## Changed files

- `Views/Home/Alerts/_AlertsFormCollection.cshtml` — adds `pendingOperationLoads` tracker, `registerOperationLoad`, `waitForOperationLoads`
- `Views/Home/Alerts/_ConditionBlock.cshtml` — registers the GetOperation AJAX with the tracker
- `Views/AlertTemplates/AlertTemplate.cshtml` — wraps `submitForm` body in `waitForOperationLoads().always(...)`
- `Views/Home/_MetaInfo.cshtml` — same wrapper for the sensor editor submit handler

## Test plan

- [x] `DataAlertTemplateViewModelMultiRowDemoteTests` — locks the server-side `ToModel` contract (1 demoted regular Policy + 1 untouched TTLPolicy)
- [x] `AlertTemplatesControllerTests.AlertTemplate_DemotedRowWithoutOperation_SavesPolicyWithNoConditions` — documents the silent-skip behavior the JS race leaves behind
- [ ] Manual repro: create Integer Alert Template with 2 TTL alerts, save, reopen, demote one TTL to Value, **immediately** click Save, reopen → demoted row should persist as regular; other row stays TTL
- [ ] Verify sensor editor (MetaInfo) demote still works after the same fix

Closes #1246

🤖 Generated with [Claude Code](https://claude.com/claude-code)