### PR TITLE
Replace nested-form re-render with replaceWith on template save

### DIFF
--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -209,15 +209,12 @@
                         );
                     }
                     else {
-                        // The returned partial is the full _AlertTemplate.cshtml, which wraps
-                        // everything in <form id="addAlertTemplate_form">…</form>. Setting it as
-                        // innerHTML of the existing form nests the new form inside the old one —
-                        // the browser then drops/merges the inner <form> tag during parsing,
-                        // leaving duplicate ids and inputs that the next submit collects from the
-                        // wrong element, so the user's second Save silently fails or sends stale
-                        // data (#1247). replaceWith swaps the outer form element for the freshly
-                        // rendered one, keeping a single form in the DOM and preserving all
-                        // user-entered values that were echoed back server-side.
+                        // _AlertTemplate.cshtml wraps its content in <form id="addAlertTemplate_form">.
+                        // Setting that as the existing form's innerHTML nests the new form inside the
+                        // old one; the HTML parser drops the inner <form> tag and leaves duplicate
+                        // ids/inputs that the next Save reads from the wrong element, so the second
+                        // Save after a validation error silently fails or sends stale data (#1247).
+                        // replaceWith swaps the outer form for the freshly rendered one.
                         $("#addAlertTemplate_form").replaceWith(viewData);
                         initForm();
                     }

--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -209,7 +209,16 @@
                         );
                     }
                     else {
-                        $("#addAlertTemplate_form").html(viewData);
+                        // The returned partial is the full _AlertTemplate.cshtml, which wraps
+                        // everything in <form id="addAlertTemplate_form">…</form>. Setting it as
+                        // innerHTML of the existing form nests the new form inside the old one —
+                        // the browser then drops/merges the inner <form> tag during parsing,
+                        // leaving duplicate ids and inputs that the next submit collects from the
+                        // wrong element, so the user's second Save silently fails or sends stale
+                        // data (#1247). replaceWith swaps the outer form element for the freshly
+                        // rendered one, keeping a single form in the DOM and preserving all
+                        // user-entered values that were echoed back server-side.
+                        $("#addAlertTemplate_form").replaceWith(viewData);
                         initForm();
                     }
                 }

--- a/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
@@ -120,6 +120,36 @@ namespace HSMServer.Core.Tests.Controllers
             Assert.Contains("separate Alert Template", message);
         }
 
+        // Regression coverage for #1247: when validation blocks Save, the action returns the
+        // _AlertTemplate partial and the client re-renders the form via replaceWith. That
+        // client-side fix only works if the server echoes the user-entered values back in the
+        // rebuilt DataAlertTemplateViewModel. The rebuild path (controller ~line 250: model ??=
+        // data.ToModel(...); data = new DataAlertTemplateViewModel(model, ...)) must carry Name,
+        // Type, and PathTemplates through. If a future refactor rebuilds from a different source
+        // (cached template, default viewmodel, etc.), this test fails instead of silently
+        // breaking the second Save after a validation error.
+        [Fact]
+        [Trait("Category", "Alert Template authoring")]
+        public async Task ValidationFailure_ReturnsPartialView_PreservingUserData()
+        {
+            _cacheMock.Setup(c => c.GetSensors(It.IsAny<string>(), It.IsAny<SensorType?>(), It.IsAny<Guid?>()))
+                .Returns(new List<BaseSensorModel> { BuildSensor(SensorType.Double) });
+
+            var controller = CreateController();
+            var data = BuildData((byte)SensorType.Integer, "*/intPath", "*/mixedPath");
+            data.Name = "UserEnteredName";
+
+            var result = await controller.AlertTemplate(data);
+
+            var partial = Assert.IsType<PartialViewResult>(result);
+            Assert.Equal("_AlertTemplate", partial.ViewName);
+            var model = Assert.IsType<DataAlertTemplateViewModel>(partial.Model);
+            Assert.Equal("UserEnteredName", model.Name);
+            Assert.Equal((byte)SensorType.Integer, model.Type);
+            Assert.Contains("*/intPath", model.PathTemplates);
+            Assert.Contains("*/mixedPath", model.PathTemplates);
+        }
+
         [Fact]
         [Trait("Category", "Alert Template authoring")]
         public async Task AllCompatiblePaths_ModelStateValid()

--- a/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Controllers/AlertTemplatesControllerTests.cs
@@ -120,17 +120,16 @@ namespace HSMServer.Core.Tests.Controllers
             Assert.Contains("separate Alert Template", message);
         }
 
-        // Regression coverage for #1247: when validation blocks Save, the action returns the
-        // _AlertTemplate partial and the client re-renders the form via replaceWith. That
-        // client-side fix only works if the server echoes the user-entered values back in the
-        // rebuilt DataAlertTemplateViewModel. The rebuild path (controller ~line 250: model ??=
-        // data.ToModel(...); data = new DataAlertTemplateViewModel(model, ...)) must carry Name,
-        // Type, and PathTemplates through. If a future refactor rebuilds from a different source
-        // (cached template, default viewmodel, etc.), this test fails instead of silently
-        // breaking the second Save after a validation error.
+        // Regression coverage for #1247: when validation blocks Save, the AlertTemplate POST
+        // returns _AlertTemplate and the client re-renders the form via replaceWith. That client
+        // fix only works if the server echoes user-entered values back in the rebuilt viewmodel.
+        // Id matters for the Edit path — a different Id after re-render would make the second Save
+        // create a new template instead of updating the one being edited. If a future refactor
+        // rebuilds from a different source (cached template, default viewmodel), this test fails
+        // instead of silently breaking the second Save.
         [Fact]
         [Trait("Category", "Alert Template authoring")]
-        public async Task ValidationFailure_ReturnsPartialView_PreservingUserData()
+        public async Task ValidationFailure_PreservesUserEnteredData()
         {
             _cacheMock.Setup(c => c.GetSensors(It.IsAny<string>(), It.IsAny<SensorType?>(), It.IsAny<Guid?>()))
                 .Returns(new List<BaseSensorModel> { BuildSensor(SensorType.Double) });
@@ -138,14 +137,17 @@ namespace HSMServer.Core.Tests.Controllers
             var controller = CreateController();
             var data = BuildData((byte)SensorType.Integer, "*/intPath", "*/mixedPath");
             data.Name = "UserEnteredName";
+            var expectedId = data.Id;
 
             var result = await controller.AlertTemplate(data);
 
             var partial = Assert.IsType<PartialViewResult>(result);
             Assert.Equal("_AlertTemplate", partial.ViewName);
             var model = Assert.IsType<DataAlertTemplateViewModel>(partial.Model);
+            Assert.Equal(expectedId, model.Id);
             Assert.Equal("UserEnteredName", model.Name);
             Assert.Equal((byte)SensorType.Integer, model.Type);
+            Assert.Equal(_folderId, model.FolderId);
             Assert.Contains("*/intPath", model.PathTemplates);
             Assert.Contains("*/mixedPath", model.PathTemplates);
         }


### PR DESCRIPTION
## Summary
Fixes the Alert Template editor's second-Save-after-validation-error failure mode (#1247).

The validation-failure branch of `submitForm` was calling `$("#addAlertTemplate_form").html(viewData)`, but the returned `_AlertTemplate.cshtml` partial wraps its contents in a full `<form id="addAlertTemplate_form">…</form>` element. Setting that as the existing form's innerHTML nests the new form inside the old one; the HTML parser drops the inner `<form>` start tag and leaves duplicate ids/inputs in the DOM, so the next Save reads form data from the wrong element and either silently fails or sends stale values — forcing the user to recreate the template.

Switched to `.replaceWith(viewData)` so the freshly rendered form replaces the outer form element entirely, leaving a single form in the DOM. `initForm()` continues to rebind handlers via `.off().on()`, and `submitForm` already re-reads the form by id on every invocation.

Added a controller-level regression test (`ValidationFailure_PreservesUserEnteredData`) that asserts the partial returned on validation failure preserves the user-entered `Id`, `Name`, `Type`, `FolderId`, and `PathTemplates` — the contract the client-side `replaceWith` fix relies on. Id preservation is load-bearing for the Edit path (a different Id after re-render would make the second Save create a new template instead of updating the one being edited).

## Test plan
- [ ] Scenario A (#1210 mixed-type paths): create Integer template, add one Integer path + one Double path, Save → see validation error → fix the Double path → Save again → template saves without re-entering fields.
- [ ] Scenario B (empty Name): create template, leave Name empty, fill other fields, Save → see Name validation error → enter valid Name → Save again → template saves.
- [ ] Second Save without changes shows the same validation state and does not reset the form.
- [ ] After validation failure, the DOM contains a single `form#addAlertTemplate_form` (no nested/duplicate forms).
- [ ] Existing successful Alert Template save flow unchanged.
- [ ] `AlertTemplatesControllerTests` (11 tests, including the new `ValidationFailure_PreservesUserEnteredData`) passes.

## Known follow-ups (out of scope for #1247, pre-existing)
- `selectpicker` on chat selects inside re-rendered alert rows is not re-initialized after form replacement (the same was true with the old `.html()` call). Visual-only; chat selections still submit correctly via the underlying `<select>` state.
- "Affected Sensors" section is hidden after re-render; re-population requires user action (path/type/folder change). Deliberately not auto-refreshed here — `updateForm(false)` would call `selectpicker('refresh')` on uninitialized selects.

Closes #1247

🤖 Generated with [Claude Code](https://claude.com/claude-code)