### PR TITLE
Restore Telegram/Slack icons in Alert Template destinations dropdown

### DIFF
--- a/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
+++ b/src/server/HSMServer/Views/AlertTemplates/AlertTemplate.cshtml
@@ -282,15 +282,15 @@
 
             $select.find('option').not('.general-group-chat-mode').remove();
 
-            appendChatSection($select, 'Groups', groups, currentSelected);
-            appendChatSection($select, 'Users', users, currentSelected);
-            appendChatSection($select, 'Slack destinations', slackDestinations, currentSelected, 'No Slack destinations configured');
+            appendChatSection($select, 'Groups', groups, currentSelected, 'fab fa-telegram');
+            appendChatSection($select, 'Users', users, currentSelected, 'fab fa-telegram');
+            appendChatSection($select, 'Slack destinations', slackDestinations, currentSelected, 'fab fa-slack', 'No Slack destinations configured');
 
             $select.selectpicker('refresh');
         });
     }
 
-    function appendChatSection($select, title, items, currentSelected, emptyMessage) {
+    function appendChatSection($select, title, items, currentSelected, brandClass, emptyMessage) {
         $select.append('<option data-divider="true"></option>');
         $select.append(`<option disabled>${title}</option>`);
         if (items.length === 0) {
@@ -300,7 +300,11 @@
         }
         items.forEach(function(chat) {
             var isSelected = currentSelected.includes(chat.Id);
-            $select.append(`<option value="${chat.Id}"${isSelected ? ' selected' : ''}>${chat.Name}</option>`);
+            // data-content lets bootstrap-select render the brand icon inline; matches the static
+            // markup emitted by Views/Home/Alerts/_ActionBlock.cshtml so the dropdown looks the same
+            // after a form refresh as on initial render.
+            var dataContent = `<i class='${brandClass}'></i> ${chat.Name}`;
+            $select.append(`<option value="${chat.Id}"${isSelected ? ' selected' : ''} data-content="${dataContent}">${chat.Name}</option>`);
         });
     }
 


### PR DESCRIPTION
## Summary

`appendChatSection` in `AlertTemplate.cshtml` rebuilt dropdown options without a `data-content` attribute, so after any folder/type/path form refresh `bootstrap-select` rendered chat names as plain text and the Telegram/Slack brand icons vanished. This passes the brand class per section (`fab fa-telegram` for Groups/Users, `fab fa-slack` for Slack) and emits `data-content="<i class='<brand>'></i> <name>"`, matching the static render in `_ActionBlock.cshtml`.

Server-side `ChatsPayload` shape and `UpdateTemplate` regression tests are unchanged — this is a client-only markup fix.

## Test plan

- [ ] Edit an existing Alert Template (folder + path) so `updateForm` fires on load; open the destinations dropdown — Telegram groups/users show the Telegram icon, Slack destinations show the Slack icon.
- [ ] Change folder/type/path on a template; reopen the destinations dropdown — icons survive the refresh.
- [ ] Verify icons appear both in the closed dropdown title and in the open option list.
- [ ] Verify "No Slack destinations configured" still shows when the Slack section is empty.
- [ ] Confirm previously selected chat IDs are still marked selected after refresh.

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)