### PR TITLE
Add unified Chat entity + LevelDB migration (1/4)

### DIFF
--- a/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/ChatEntity.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/ChatEntity.cs
@@ -1,0 +1,28 @@
+using HSMDatabase.AccessManager.DatabaseEntities.VisualEntity;
+
+namespace HSMDatabase.AccessManager.DatabaseEntities
+{
+    public sealed record ChatEntity : BaseServerEntity
+    {
+        // Common
+        public bool SendMessages { get; set; }
+
+        public int MessagesAggregationTimeSec { get; set; }
+
+
+        // Telegram (optional)
+        public byte? TelegramType { get; set; }
+
+        public long? TelegramChatId { get; set; }
+
+        public long? AuthorizationTime { get; set; }
+
+
+        // Slack (optional)
+        public string SlackWebhookUrl { get; set; }
+
+
+        // Mattermost (optional, channel not implemented yet)
+        public string MattermostWebhookUrl { get; set; }
+    }
+}

--- a/src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs
@@ -144,9 +144,6 @@ namespace HSMServer.Core.DataLayer
         ChatEntity GetChat(byte[] chatId);
         List<ChatEntity> GetChats();
 
-        void RemoveTelegramChatsListKey();
-        void RemoveSlackDestinationsListKey();
-
         #endregion
 
         #region Alert Templates

--- a/src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseSettings/IDatabaseCore.cs
@@ -136,6 +136,19 @@ namespace HSMServer.Core.DataLayer
 
         #endregion
 
+        #region Chat
+
+        void AddChat(ChatEntity chat);
+        void UpdateChat(ChatEntity chat);
+        void RemoveChat(byte[] chatId);
+        ChatEntity GetChat(byte[] chatId);
+        List<ChatEntity> GetChats();
+
+        void RemoveTelegramChatsListKey();
+        void RemoveSlackDestinationsListKey();
+
+        #endregion
+
         #region Alert Templates
         List<AlertTemplateEntity> GetAllAlertTemplates();
         void AddAlertTemplate(AlertTemplateEntity policy);

--- a/src/database/HSMDatabase.AccessManager/IEnvironmentDatabase.cs
+++ b/src/database/HSMDatabase.AccessManager/IEnvironmentDatabase.cs
@@ -104,9 +104,6 @@ namespace HSMDatabase.AccessManager
         void AddChatToList(byte[] chatId);
         void RemoveChatFromList(byte[] chatId);
 
-        void RemoveTelegramChatsListKey();
-        void RemoveSlackDestinationsListKey();
-
         #endregion
 
         #region Alert templates

--- a/src/database/HSMDatabase.AccessManager/IEnvironmentDatabase.cs
+++ b/src/database/HSMDatabase.AccessManager/IEnvironmentDatabase.cs
@@ -95,6 +95,20 @@ namespace HSMDatabase.AccessManager
 
         #endregion
 
+        #region Chats
+
+        List<byte[]> GetChatsList();
+        ChatEntity GetChat(byte[] chatId);
+        void AddChat(ChatEntity chat);
+        void RemoveChat(byte[] chatId);
+        void AddChatToList(byte[] chatId);
+        void RemoveChatFromList(byte[] chatId);
+
+        void RemoveTelegramChatsListKey();
+        void RemoveSlackDestinationsListKey();
+
+        #endregion
+
         #region Alert templates
 
         List<byte[]> GetAllAlertTemplatesIds();

--- a/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
+++ b/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
@@ -794,7 +794,7 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
             {
                 var currentList = GetChatsList();
 
-                if (!currentList.Contains(chatId))
+                if (!currentList.Any(existing => existing.SequenceEqual(chatId)))
                     currentList.Add(chatId);
 
                 _database.Put(_chatIdsKey, JsonSerializer.SerializeToUtf8Bytes(currentList));
@@ -811,7 +811,7 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
             {
                 var currentList = GetChatsList();
 
-                currentList.Remove(chatId);
+                currentList.RemoveAll(existing => existing.SequenceEqual(chatId));
 
                 _database.Put(_chatIdsKey, JsonSerializer.SerializeToUtf8Bytes(currentList));
             }

--- a/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
+++ b/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
@@ -821,30 +821,6 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
             }
         }
 
-        public void RemoveTelegramChatsListKey()
-        {
-            try
-            {
-                _database.Delete(_telegramChatIdsKey);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Failed to remove legacy TelegramChats list key");
-            }
-        }
-
-        public void RemoveSlackDestinationsListKey()
-        {
-            try
-            {
-                _database.Delete(_slackDestinationIdsKey);
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Failed to remove legacy SlackDestinations list key");
-            }
-        }
-
         #endregion
 
         #region AlertTemplates

--- a/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
+++ b/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
@@ -26,6 +26,7 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
         private readonly byte[] _folderIdsKey = "FolderIds"u8.ToArray();
         private readonly byte[] _telegramChatIdsKey = "TelegramChats"u8.ToArray();
         private readonly byte[] _slackDestinationIdsKey = "SlackDestinations"u8.ToArray();
+        private readonly byte[] _chatIdsKey = "Chats"u8.ToArray();
         private readonly byte[] _alertTemplatesIdsKey = "AlertTemplates"u8.ToArray();
         private readonly byte[] _alertScheduleIdsKey = "AlertSchedule"u8.ToArray();
 
@@ -738,6 +739,109 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
             catch (Exception e)
             {
                 _logger.Error(e, $"Failed to remove slack destination id {id} from list");
+            }
+        }
+
+        #endregion
+
+        #region Chats
+
+        public List<byte[]> GetChatsList() => GetListOfBytes(_chatIdsKey, "Failed to get chats ids list");
+
+        public ChatEntity GetChat(byte[] chatId)
+        {
+            try
+            {
+                return _database.TryRead(chatId, out byte[] value)
+                    ? JsonSerializer.Deserialize<ChatEntity>(Encoding.UTF8.GetString(value))
+                    : null;
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to read info for chat {new Guid(chatId)}");
+            }
+
+            return null;
+        }
+
+        public void AddChat(ChatEntity chat)
+        {
+            try
+            {
+                _database.Put(chat.Id, JsonSerializer.SerializeToUtf8Bytes(chat));
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to add chat info for {chat.Id}");
+            }
+        }
+
+        public void RemoveChat(byte[] chatId)
+        {
+            try
+            {
+                _database.Delete(chatId);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to remove info for chat {new Guid(chatId)}");
+            }
+        }
+
+        public void AddChatToList(byte[] chatId)
+        {
+            try
+            {
+                var currentList = GetChatsList();
+
+                if (!currentList.Contains(chatId))
+                    currentList.Add(chatId);
+
+                _database.Put(_chatIdsKey, JsonSerializer.SerializeToUtf8Bytes(currentList));
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to add chat id to list");
+            }
+        }
+
+        public void RemoveChatFromList(byte[] chatId)
+        {
+            try
+            {
+                var currentList = GetChatsList();
+
+                currentList.Remove(chatId);
+
+                _database.Put(_chatIdsKey, JsonSerializer.SerializeToUtf8Bytes(currentList));
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, $"Failed to remove chat id {chatId} from list");
+            }
+        }
+
+        public void RemoveTelegramChatsListKey()
+        {
+            try
+            {
+                _database.Delete(_telegramChatIdsKey);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to remove legacy TelegramChats list key");
+            }
+        }
+
+        public void RemoveSlackDestinationsListKey()
+        {
+            try
+            {
+                _database.Delete(_slackDestinationIdsKey);
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to remove legacy SlackDestinations list key");
             }
         }
 

--- a/src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs
+++ b/src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs
@@ -617,10 +617,6 @@ namespace HSMDatabase.DatabaseWorkCore
             return chats;
         }
 
-        public void RemoveTelegramChatsListKey() => _environmentDatabase.RemoveTelegramChatsListKey();
-
-        public void RemoveSlackDestinationsListKey() => _environmentDatabase.RemoveSlackDestinationsListKey();
-
         #endregion
 
         #region Journal

--- a/src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs
+++ b/src/database/HSMDatabase/DatabaseWorkCore/DatabaseCore.cs
@@ -584,6 +584,45 @@ namespace HSMDatabase.DatabaseWorkCore
 
         #endregion
 
+        #region Environment database : Chat
+
+        public void AddChat(ChatEntity chat)
+        {
+            _environmentDatabase.AddChatToList(chat.Id);
+            _environmentDatabase.AddChat(chat);
+        }
+
+        public void UpdateChat(ChatEntity chat) => _environmentDatabase.AddChat(chat);
+
+        public void RemoveChat(byte[] chatId)
+        {
+            _environmentDatabase.RemoveChat(chatId);
+            _environmentDatabase.RemoveChatFromList(chatId);
+        }
+
+        public ChatEntity GetChat(byte[] chatId) => _environmentDatabase.GetChat(chatId);
+
+        public List<ChatEntity> GetChats()
+        {
+            var chats = new List<ChatEntity>(1 << 4);
+            var ids = _environmentDatabase.GetChatsList();
+
+            foreach (var id in ids)
+            {
+                var entity = _environmentDatabase.GetChat(id);
+                if (entity != null)
+                    chats.Add(entity);
+            }
+
+            return chats;
+        }
+
+        public void RemoveTelegramChatsListKey() => _environmentDatabase.RemoveTelegramChatsListKey();
+
+        public void RemoveSlackDestinationsListKey() => _environmentDatabase.RemoveSlackDestinationsListKey();
+
+        #endregion
+
         #region Journal
 
         public void AddJournalValue(JournalKey journalKey, JournalRecordEntity value)

--- a/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
+++ b/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
@@ -43,6 +43,7 @@ namespace HSMServer.ServiceExtensions
             services.AddSingleton(config);
 
             services.AddSingleton<IDatabaseCore, DatabaseCore>()
+                    .AddSingleton<HSMServer.Migrations.ChatMigrator>()
                     .AddSingleton<IAlertScheduleProvider, AlertScheduleProvider>()
                     .AddSingleton<ITreeStateSnapshot, TreeStateSnapshot>()
                     .AddSingleton<ITreeValuesCache, TreeValuesCache>()
@@ -52,6 +53,7 @@ namespace HSMServer.ServiceExtensions
                     .AddAsyncStorage<IFolderManager, FolderManager>()
                     .AddAsyncStorage<ITelegramChatsManager, TelegramChatsManager>()
                     .AddAsyncStorage<ISlackDestinationsManager, SlackDestinationsManager>()
+                    .AddAsyncStorage<HSMServer.Notifications.Chats.IChatsManager, HSMServer.Notifications.Chats.ChatsManager>()
                     .AddAsyncStorage<IDashboardManager, DashboardManager>();
 
             services.AddSingleton<DataCollectorWrapper>()
@@ -165,6 +167,8 @@ namespace HSMServer.ServiceExtensions
 
         public static async Task InitStorages(this IServiceProvider services)
         {
+            services.GetRequiredService<HSMServer.Migrations.ChatMigrator>().Migrate(services.GetRequiredService<IDatabaseCore>());
+
             foreach (var type in _asyncStorageTypes)
                 if (services.GetService(type) is IAsyncStorage storage)
                     await storage.Initialize();

--- a/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
+++ b/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
@@ -24,8 +24,10 @@ using HSMServer.Filters;
 using HSMServer.Folders;
 using HSMServer.Middleware;
 using HSMServer.Middleware.Telemetry;
+using HSMServer.Migrations;
 using HSMServer.Model.TreeViewModel;
 using HSMServer.Notifications;
+using HSMServer.Notifications.Chats;
 using HSMServer.ServerConfiguration;
 using HSMServer.Core.Schedule;
 
@@ -43,7 +45,7 @@ namespace HSMServer.ServiceExtensions
             services.AddSingleton(config);
 
             services.AddSingleton<IDatabaseCore, DatabaseCore>()
-                    .AddSingleton<HSMServer.Migrations.ChatMigrator>()
+                    .AddSingleton<ChatMigrator>()
                     .AddSingleton<IAlertScheduleProvider, AlertScheduleProvider>()
                     .AddSingleton<ITreeStateSnapshot, TreeStateSnapshot>()
                     .AddSingleton<ITreeValuesCache, TreeValuesCache>()
@@ -53,7 +55,7 @@ namespace HSMServer.ServiceExtensions
                     .AddAsyncStorage<IFolderManager, FolderManager>()
                     .AddAsyncStorage<ITelegramChatsManager, TelegramChatsManager>()
                     .AddAsyncStorage<ISlackDestinationsManager, SlackDestinationsManager>()
-                    .AddAsyncStorage<HSMServer.Notifications.Chats.IChatsManager, HSMServer.Notifications.Chats.ChatsManager>()
+                    .AddAsyncStorage<IChatsManager, ChatsManager>()
                     .AddAsyncStorage<IDashboardManager, DashboardManager>();
 
             services.AddSingleton<DataCollectorWrapper>()
@@ -167,7 +169,7 @@ namespace HSMServer.ServiceExtensions
 
         public static async Task InitStorages(this IServiceProvider services)
         {
-            services.GetRequiredService<HSMServer.Migrations.ChatMigrator>().Migrate(services.GetRequiredService<IDatabaseCore>());
+            services.GetRequiredService<ChatMigrator>().Migrate(services.GetRequiredService<IDatabaseCore>());
 
             foreach (var type in _asyncStorageTypes)
                 if (services.GetService(type) is IAsyncStorage storage)

--- a/src/server/HSMServer/Migrations/ChatMigrator.cs
+++ b/src/server/HSMServer/Migrations/ChatMigrator.cs
@@ -1,0 +1,85 @@
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Core.DataLayer;
+using NLog;
+using System;
+using System.Linq;
+
+namespace HSMServer.Migrations
+{
+    public sealed class ChatMigrator
+    {
+        private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+
+        public void Migrate(IDatabaseCore database)
+        {
+            if (database is null)
+                throw new ArgumentNullException(nameof(database));
+
+            if (database.GetChats().Count > 0)
+            {
+                _logger.Info("ChatMigrator: 'Chats' key already populated, skipping migration.");
+                return;
+            }
+
+            var telegramChats = database.GetTelegramChats() ?? Enumerable.Empty<TelegramChatEntity>();
+            var slackDestinations = database.GetSlackDestinations() ?? Enumerable.Empty<SlackDestinationEntity>();
+
+            var migrated = 0;
+
+            foreach (var tg in telegramChats)
+            {
+                database.AddChat(BuildFromTelegram(tg));
+                migrated++;
+            }
+
+            foreach (var slack in slackDestinations)
+            {
+                database.AddChat(BuildFromSlack(slack));
+                migrated++;
+            }
+
+            if (migrated == 0)
+            {
+                _logger.Info("ChatMigrator: no legacy chats found, nothing to migrate.");
+                return;
+            }
+
+            database.RemoveTelegramChatsListKey();
+            database.RemoveSlackDestinationsListKey();
+
+            _logger.Info($"ChatMigrator: migrated {migrated} chats to the unified 'Chats' key.");
+        }
+
+
+        private static ChatEntity BuildFromTelegram(TelegramChatEntity tg) => new()
+        {
+            Id = tg.Id,
+            Author = tg.Author,
+            CreationDate = tg.CreationDate,
+            Name = tg.Name,
+            Description = tg.Description,
+
+            SendMessages = tg.SendMessages,
+            MessagesAggregationTimeSec = tg.MessagesAggregationTimeSec,
+
+            TelegramType = tg.Type,
+            TelegramChatId = tg.ChatId,
+            AuthorizationTime = tg.AuthorizationTime,
+        };
+
+        private static ChatEntity BuildFromSlack(SlackDestinationEntity slack) => new()
+        {
+            Id = slack.Id,
+            Author = slack.Author,
+            CreationDate = slack.CreationDate,
+            Name = slack.Name,
+            Description = slack.Description,
+
+            SendMessages = slack.SendMessages,
+            MessagesAggregationTimeSec = slack.MessagesAggregationTimeSec,
+
+            SlackWebhookUrl = slack.WebhookUrl,
+        };
+    }
+}

--- a/src/server/HSMServer/Migrations/ChatMigrator.cs
+++ b/src/server/HSMServer/Migrations/ChatMigrator.cs
@@ -2,6 +2,7 @@ using HSMDatabase.AccessManager.DatabaseEntities;
 using HSMServer.Core.DataLayer;
 using NLog;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace HSMServer.Migrations
@@ -16,39 +17,42 @@ namespace HSMServer.Migrations
             if (database is null)
                 throw new ArgumentNullException(nameof(database));
 
-            if (database.GetChats().Count > 0)
-            {
-                _logger.Info("ChatMigrator: 'Chats' key already populated, skipping migration.");
-                return;
-            }
+            var existing = database.GetChats() ?? new List<ChatEntity>();
+            var existingIds = new HashSet<Guid>(existing.Select(c => new Guid(c.Id)));
 
             var telegramChats = database.GetTelegramChats() ?? Enumerable.Empty<TelegramChatEntity>();
             var slackDestinations = database.GetSlackDestinations() ?? Enumerable.Empty<SlackDestinationEntity>();
 
-            var migrated = 0;
+            var written = 0;
+            var skipped = 0;
 
             foreach (var tg in telegramChats)
             {
+                if (existingIds.Contains(new Guid(tg.Id)))
+                {
+                    skipped++;
+                    continue;
+                }
+
                 database.AddChat(BuildFromTelegram(tg));
-                migrated++;
+                written++;
             }
 
             foreach (var slack in slackDestinations)
             {
+                if (existingIds.Contains(new Guid(slack.Id)))
+                {
+                    skipped++;
+                    continue;
+                }
+
                 database.AddChat(BuildFromSlack(slack));
-                migrated++;
+                written++;
             }
 
-            if (migrated == 0)
-            {
-                _logger.Info("ChatMigrator: no legacy chats found, nothing to migrate.");
-                return;
-            }
+            _logger.Info($"ChatMigrator: wrote {written} chats, skipped {skipped} already-present entries.");
 
-            database.RemoveTelegramChatsListKey();
-            database.RemoveSlackDestinationsListKey();
-
-            _logger.Info($"ChatMigrator: migrated {migrated} chats to the unified 'Chats' key.");
+            // Legacy keys are left intact — consumers still read them; removal deferred to #1261.
         }
 
 

--- a/src/server/HSMServer/Migrations/ChatMigrator.cs
+++ b/src/server/HSMServer/Migrations/ChatMigrator.cs
@@ -52,7 +52,13 @@ namespace HSMServer.Migrations
 
             _logger.Info($"ChatMigrator: wrote {written} chats, skipped {skipped} already-present entries.");
 
-            // Legacy keys are left intact — consumers still read them; removal deferred to #1261.
+            // This migration is intentionally additive and is not the source of truth yet.
+            //   - Legacy `TelegramChats` / `SlackDestinations` keys are left intact; their managers
+            //     remain active and consumable until #1261 switches readers to IChatsManager.
+            //   - Renames / field changes / deletes performed through the legacy UI *after* this
+            //     migration runs are NOT propagated: the migrator skips by id and never updates or
+            //     deletes. #1261 must reconcile updates and deletes (not just adds) before it can
+            //     treat the unified `Chats` key as authoritative.
         }
 
 

--- a/src/server/HSMServer/Notifications/Chats/Chat.cs
+++ b/src/server/HSMServer/Notifications/Chats/Chat.cs
@@ -32,7 +32,7 @@ namespace HSMServer.Notifications.Chats
 
 
         // Telegram (optional)
-        public ChatId TelegramChatId { get; private set; }
+        public ChatId? TelegramChatId { get; private set; }
 
         public ConnectedChatType? TelegramType { get; init; }
 
@@ -50,15 +50,18 @@ namespace HSMServer.Notifications.Chats
         public bool ShouldSendNotification => MessagesAggregationTimeSec > 0 && _nextSendMessageTime <= DateTime.UtcNow;
 
 
-        public Chat() : base()
+        public Chat(ChatId chatId) : base()
         {
             SendMessages = DefaultSendMessages;
             MessagesAggregationTimeSec = DefaultMessagesAggregationTimeSec;
+
+            TelegramChatId = chatId;
         }
 
-        public Chat(global::Telegram.Bot.Types.Chat chat) : this()
+        internal Chat() : base()
         {
-            TelegramChatId = chat;
+            SendMessages = DefaultSendMessages;
+            MessagesAggregationTimeSec = DefaultMessagesAggregationTimeSec;
         }
 
         internal Chat(ChatEntity entity) : base(entity)

--- a/src/server/HSMServer/Notifications/Chats/Chat.cs
+++ b/src/server/HSMServer/Notifications/Chats/Chat.cs
@@ -1,0 +1,134 @@
+using HSMCommon.Extensions;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.ConcurrentStorage;
+using HSMServer.Notifications.AddressBook;
+using System;
+using System.Collections.Generic;
+using Telegram.Bot.Types;
+
+namespace HSMServer.Notifications.Chats
+{
+    public sealed class Chat : BaseServerModel<ChatEntity, ChatUpdate>
+    {
+        private const bool DefaultSendMessages = true;
+        private const int DefaultMessagesAggregationTimeSec = 60;
+
+        private DateTime _nextSendMessageTime;
+
+
+        internal HashSet<Guid> Folders { get; } = [];
+
+        internal ScheduleBuilder ScheduleMessageBuilder { get; } = new();
+
+        internal MessageBuilder MessageBuilder { get; } = new();
+
+
+        // Common
+        public int MessagesAggregationTimeSec { get; private set; }
+
+        public bool SendMessages { get; private set; }
+
+        public string Author { get; set; }
+
+
+        // Telegram (optional)
+        public ChatId TelegramChatId { get; private set; }
+
+        public ConnectedChatType? TelegramType { get; init; }
+
+        public DateTime? AuthorizationTime { get; init; }
+
+
+        // Slack (optional)
+        public string SlackWebhookUrl { get; private set; }
+
+
+        // Mattermost (optional, channel not implemented yet)
+        public string MattermostWebhookUrl { get; private set; }
+
+
+        public bool ShouldSendNotification => MessagesAggregationTimeSec > 0 && _nextSendMessageTime <= DateTime.UtcNow;
+
+
+        public Chat() : base()
+        {
+            SendMessages = DefaultSendMessages;
+            MessagesAggregationTimeSec = DefaultMessagesAggregationTimeSec;
+        }
+
+        public Chat(global::Telegram.Bot.Types.Chat chat) : this()
+        {
+            TelegramChatId = chat;
+        }
+
+        internal Chat(ChatEntity entity) : base(entity)
+        {
+            SendMessages = entity.SendMessages;
+            MessagesAggregationTimeSec = entity.MessagesAggregationTimeSec;
+
+            if (entity.TelegramType.HasValue)
+            {
+                TelegramType = (ConnectedChatType)entity.TelegramType.Value;
+                TelegramChatId = new ChatId(entity.TelegramChatId ?? 0L);
+                AuthorizationTime = entity.AuthorizationTime.HasValue
+                    ? new DateTime(entity.AuthorizationTime.Value)
+                    : null;
+            }
+
+            SlackWebhookUrl = entity.SlackWebhookUrl;
+            MattermostWebhookUrl = entity.MattermostWebhookUrl;
+        }
+
+
+        public void UpdateChatId(ChatId chatId) => TelegramChatId = chatId;
+
+
+        protected override void ApplyUpdate(ChatUpdate update)
+        {
+            SendMessages = update.SendMessages ?? SendMessages;
+            MessagesAggregationTimeSec = update.MessagesAggregationTimeSec ?? MessagesAggregationTimeSec;
+
+            SlackWebhookUrl = update.SlackWebhookUrl ?? SlackWebhookUrl;
+            MattermostWebhookUrl = update.MattermostWebhookUrl ?? MattermostWebhookUrl;
+
+            if (update.TelegramChatId.HasValue)
+                TelegramChatId = new ChatId(update.TelegramChatId.Value);
+        }
+
+        public override ChatEntity ToEntity()
+        {
+            var entity = base.ToEntity();
+
+            entity.SendMessages = SendMessages;
+            entity.MessagesAggregationTimeSec = MessagesAggregationTimeSec;
+
+            if (TelegramType.HasValue)
+            {
+                entity.TelegramType = (byte)TelegramType.Value;
+                entity.TelegramChatId = TelegramChatId?.Identifier;
+                entity.AuthorizationTime = AuthorizationTime?.Ticks;
+            }
+
+            entity.SlackWebhookUrl = SlackWebhookUrl;
+            entity.MattermostWebhookUrl = MattermostWebhookUrl;
+
+            return entity;
+        }
+
+
+        internal IEnumerable<string> GetNotifications()
+        {
+            try
+            {
+                foreach (var report in ScheduleMessageBuilder.GetReports())
+                    yield return report;
+
+                yield return MessageBuilder.GetAggregateMessage();
+            }
+            finally
+            {
+                _nextSendMessageTime = DateTime.UtcNow.Ceil(TimeSpan.FromSeconds(MessagesAggregationTimeSec));
+            }
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/Chats/Chat.cs
+++ b/src/server/HSMServer/Notifications/Chats/Chat.cs
@@ -56,6 +56,7 @@ namespace HSMServer.Notifications.Chats
             MessagesAggregationTimeSec = DefaultMessagesAggregationTimeSec;
 
             TelegramChatId = chatId;
+            TelegramType = ConnectedChatType.TelegramPrivate;
         }
 
         internal Chat() : base()

--- a/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
@@ -1,0 +1,28 @@
+using HSMServer.ConcurrentStorage;
+
+namespace HSMServer.Notifications.Chats
+{
+    public record ChatUpdate : BaseUpdateRequest
+    {
+        // Common
+        public bool? SendMessages { get; init; }
+
+        public int? MessagesAggregationTimeSec { get; init; }
+
+
+        // Telegram (optional)
+        public byte? TelegramType { get; init; }
+
+        public long? TelegramChatId { get; init; }
+
+        public long? AuthorizationTime { get; init; }
+
+
+        // Slack (optional)
+        public string SlackWebhookUrl { get; init; }
+
+
+        // Mattermost (optional)
+        public string MattermostWebhookUrl { get; init; }
+    }
+}

--- a/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
@@ -10,12 +10,8 @@ namespace HSMServer.Notifications.Chats
         public int? MessagesAggregationTimeSec { get; init; }
 
 
-        // Telegram (optional)
-        public byte? TelegramType { get; init; }
-
+        // Telegram chat id (optional; TelegramType / AuthorizationTime are init-only on Chat)
         public long? TelegramChatId { get; init; }
-
-        public long? AuthorizationTime { get; init; }
 
 
         // Slack (optional)

--- a/src/server/HSMServer/Notifications/Chats/ChatsManager.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatsManager.cs
@@ -58,6 +58,24 @@ namespace HSMServer.Notifications.Chats
             TryGetValue(remove.Id, out var chat) && await base.TryRemove(remove)
             && (chat.TelegramChatId is null || _telegramChatIds.TryRemove(chat.TelegramChatId, out _));
 
+        public override async Task<bool> TryUpdate(ChatUpdate update)
+        {
+            TryGetValue(update.Id, out var chat);
+            var oldTelegramChatId = chat?.TelegramChatId;
+
+            var result = await base.TryUpdate(update);
+
+            if (result && chat is not null && !Nullable.Equals(oldTelegramChatId, chat.TelegramChatId))
+            {
+                if (oldTelegramChatId is not null)
+                    _telegramChatIds.TryRemove(oldTelegramChatId, out _);
+                if (chat.TelegramChatId is not null)
+                    _telegramChatIds[chat.TelegramChatId] = chat;
+            }
+
+            return result;
+        }
+
 
         public override async Task Initialize()
         {
@@ -145,23 +163,22 @@ namespace HSMServer.Notifications.Chats
 
         public async Task MigrateToSupergroup(long oldChatId, long newChatId)
         {
-            await Task.Run(() =>
-                {
-                    Chat chat = GetChatByChatId(oldChatId);
+            var chat = GetChatByChatId(oldChatId);
 
-                    if (chat == null)
-                    {
-                        _logger.Warn($"MigrateToSupergroup: Chat '{oldChatId}' not found");
-                        return;
-                    }
+            if (chat is null)
+            {
+                _logger.Warn($"MigrateToSupergroup: Chat '{oldChatId}' not found");
+                return;
+            }
 
-                    chat.UpdateChatId(newChatId);
-                    _logger.Info($"MigrateToSupergroup: Chat '{oldChatId}' was updated to supergroup '{newChatId}'");
+            var updated = await TryUpdate(new ChatUpdate
+            {
+                Id = chat.Id,
+                TelegramChatId = newChatId,
+            });
 
-                    _database.UpdateChat(chat.ToEntity());
-                    _logger.Info($"MigrateToSupergroup: Chat '{newChatId}' was updated in DB");
-                }
-            );
+            if (updated)
+                _logger.Info($"MigrateToSupergroup: Chat '{oldChatId}' was updated to supergroup '{newChatId}'");
         }
     }
 }

--- a/src/server/HSMServer/Notifications/Chats/ChatsManager.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatsManager.cs
@@ -1,0 +1,165 @@
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Authentication;
+using HSMServer.ConcurrentStorage;
+using HSMServer.Core.DataLayer;
+using HSMServer.Core.TableOfChanges;
+using HSMServer.Model.Folders;
+using HSMServer.Notifications.Telegram.Tokens;
+using HSMServer.ServerConfiguration;
+using NLog;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
+using User = HSMServer.Model.Authentication.User;
+
+namespace HSMServer.Notifications.Chats
+{
+    public sealed class ChatsManager : ConcurrentStorage<Chat, ChatEntity, ChatUpdate>, IChatsManager
+    {
+        private readonly ConcurrentDictionary<ChatId, Chat> _telegramChatIds = new();
+
+        private readonly TelegramConfig _config;
+        private readonly IDatabaseCore _database;
+        private readonly IUserManager _userManager;
+
+        public TokensManager TokenManager { get; } = new();
+
+        internal string BotName => _config.BotName;
+        private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+
+        protected override Action<ChatEntity> AddToDb => _database.AddChat;
+
+        protected override Action<ChatEntity> UpdateInDb => _database.UpdateChat;
+
+        protected override Action<Chat> RemoveFromDb => chat => _database.RemoveChat(chat.Id.ToByteArray());
+
+        protected override Func<List<ChatEntity>> GetFromDb => _database.GetChats;
+
+
+        public event Func<Guid, Guid, string, Task<string>> ConnectChatToFolder;
+
+
+        public ChatsManager(IDatabaseCore database, IUserManager userManager, IServerConfig config)
+        {
+            _database = database;
+            _config = config.Telegram;
+            _userManager = userManager;
+        }
+
+
+        public async override Task<bool> TryAdd(Chat model) =>
+            await base.TryAdd(model) && (model.TelegramChatId is null || _telegramChatIds.TryAdd(model.TelegramChatId, model));
+
+        public async override Task<bool> TryRemove(RemoveRequest remove) =>
+            TryGetValue(remove.Id, out var chat) && await base.TryRemove(remove)
+            && (chat.TelegramChatId is null || _telegramChatIds.TryRemove(chat.TelegramChatId, out _));
+
+
+        public override async Task Initialize()
+        {
+            await base.Initialize();
+
+            foreach (var (_, chat) in this)
+            {
+                if (_userManager.TryGetValueById(chat.AuthorId, out var author))
+                    chat.Author = author.Name;
+
+                if (chat.TelegramChatId is not null)
+                    _telegramChatIds.TryAdd(chat.TelegramChatId, chat);
+            }
+        }
+
+        public string GetChatName(Guid id) => this.GetValueOrDefault(id)?.Name;
+
+        public Chat GetChatByChatId(ChatId chatId) => _telegramChatIds.GetValueOrDefault(chatId);
+
+        public string GetInvitationLink(Guid folderId, User user) =>
+            $"https://t.me/{BotName}?start={TokenManager.BuildInvitationToken(folderId, user)}";
+
+        public string GetGroupInvitation(Guid folderId, User user) =>
+            $"{TelegramBotCommands.Start}@{BotName} {TokenManager.BuildInvitationToken(folderId, user)}";
+
+        public async Task<string> TryConnect(Message message, InvitationToken token)
+        {
+            var isChatExist = _telegramChatIds.TryGetValue(message?.Chat, out var chat);
+
+            if (!isChatExist)
+            {
+                bool isUserChat = message?.Chat?.Type == ChatType.Private;
+
+                chat = new Chat(message.Chat)
+                {
+                    AuthorId = token.User.Id,
+                    Author = token.User.Name,
+                    AuthorizationTime = DateTime.UtcNow,
+                    TelegramType = isUserChat ? ConnectedChatType.TelegramPrivate : ConnectedChatType.TelegramGroup,
+                };
+
+                chat.Update(new ChatUpdate()
+                {
+                    Id = chat.Id,
+                    Name = isUserChat ? message.From.Username : message.Chat.Title
+                });
+            }
+
+            var folderName = await ConnectChatToFolder?.Invoke(chat.Id, token.FolderId, token.User.Name);
+
+            if (!string.IsNullOrEmpty(folderName))
+            {
+                if (!isChatExist)
+                    await TryAdd(chat);
+
+                chat.Folders.Add(token.FolderId);
+            }
+
+            return folderName;
+        }
+
+        public void AddFolderToChats(Guid folderId, List<Guid> chats)
+        {
+            foreach (var chatId in chats)
+                if (TryGetValue(chatId, out var chat))
+                    chat.Folders.Add(folderId);
+        }
+
+        public Task RemoveFolderFromChats(Guid folderId, List<Guid> chats, InitiatorInfo initiator)
+        {
+            foreach (var chatId in chats)
+                if (TryGetValue(chatId, out var chat))
+                    chat.Folders.Remove(folderId);
+
+            return Task.CompletedTask;
+        }
+
+        public void RemoveFolderHandler(FolderModel folder, InitiatorInfo initiator) =>
+            _ = RemoveFolderFromChats(folder.Id, folder.Chats.ToList(), initiator);
+
+
+        protected override Chat FromEntity(ChatEntity entity) => new(entity);
+
+        public async Task MigrateToSupergroup(long oldChatId, long newChatId)
+        {
+            await Task.Run(() =>
+                {
+                    Chat chat = GetChatByChatId(oldChatId);
+
+                    if (chat == null)
+                    {
+                        _logger.Warn($"MigrateToSupergroup: Chat '{oldChatId}' not found");
+                        return;
+                    }
+
+                    chat.UpdateChatId(newChatId);
+                    _logger.Info($"MigrateToSupergroup: Chat '{oldChatId}' was updated to supergroup '{newChatId}'");
+
+                    _database.UpdateChat(chat.ToEntity());
+                    _logger.Info($"MigrateToSupergroup: Chat '{newChatId}' was updated in DB");
+                }
+            );
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/Chats/ChatsManager.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatsManager.cs
@@ -106,7 +106,9 @@ namespace HSMServer.Notifications.Chats
                 });
             }
 
-            var folderName = await ConnectChatToFolder?.Invoke(chat.Id, token.FolderId, token.User.Name);
+            var folderName = ConnectChatToFolder is null
+                ? null
+                : await ConnectChatToFolder.Invoke(chat.Id, token.FolderId, token.User.Name);
 
             if (!string.IsNullOrEmpty(folderName))
             {

--- a/src/server/HSMServer/Notifications/Chats/IChatsManager.cs
+++ b/src/server/HSMServer/Notifications/Chats/IChatsManager.cs
@@ -1,0 +1,39 @@
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.ConcurrentStorage;
+using HSMServer.Core.TableOfChanges;
+using HSMServer.Model.Folders;
+using HSMServer.Notifications.Telegram.Tokens;
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Telegram.Bot.Types;
+using User = HSMServer.Model.Authentication.User;
+
+namespace HSMServer.Notifications.Chats
+{
+    public interface IChatsManager : IConcurrentStorage<Chat, ChatEntity, ChatUpdate>
+    {
+        TokensManager TokenManager { get; }
+
+        event Func<Guid, Guid, string, Task<string>> ConnectChatToFolder;
+
+
+        string GetChatName(Guid id);
+
+        Chat GetChatByChatId(ChatId chatId);
+
+        string GetInvitationLink(Guid folderId, User user);
+
+        string GetGroupInvitation(Guid folderId, User user);
+
+        Task<string> TryConnect(Message message, InvitationToken token);
+
+        void AddFolderToChats(Guid folderId, List<Guid> chats);
+
+        Task RemoveFolderFromChats(Guid folderId, List<Guid> chats, InitiatorInfo initiator);
+
+        void RemoveFolderHandler(FolderModel folder, InitiatorInfo initiator);
+
+        Task MigrateToSupergroup(long oldChatId, long newChatId);
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
+++ b/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
@@ -117,6 +117,14 @@ namespace HSMServer.Core.Tests.Infrastructure
         public SlackDestinationEntity GetSlackDestination(byte[] id) => _inner.GetSlackDestination(id);
         public List<SlackDestinationEntity> GetSlackDestinations() => _inner.GetSlackDestinations();
 
+        public void AddChat(ChatEntity chat) => _inner.AddChat(chat);
+        public void UpdateChat(ChatEntity chat) => _inner.UpdateChat(chat);
+        public void RemoveChat(byte[] chatId) => _inner.RemoveChat(chatId);
+        public ChatEntity GetChat(byte[] chatId) => _inner.GetChat(chatId);
+        public List<ChatEntity> GetChats() => _inner.GetChats();
+        public void RemoveTelegramChatsListKey() => _inner.RemoveTelegramChatsListKey();
+        public void RemoveSlackDestinationsListKey() => _inner.RemoveSlackDestinationsListKey();
+
         public List<AlertTemplateEntity> GetAllAlertTemplates() => _inner.GetAllAlertTemplates();
         public void AddAlertTemplate(AlertTemplateEntity policy) => _inner.AddAlertTemplate(policy);
         public void RemoveAlertTemplate(Guid id) => _inner.RemoveAlertTemplate(id);

--- a/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
+++ b/src/tests/HSMServer.Core.Tests/Infrastructure/FailingDatabaseCore.cs
@@ -122,8 +122,6 @@ namespace HSMServer.Core.Tests.Infrastructure
         public void RemoveChat(byte[] chatId) => _inner.RemoveChat(chatId);
         public ChatEntity GetChat(byte[] chatId) => _inner.GetChat(chatId);
         public List<ChatEntity> GetChats() => _inner.GetChats();
-        public void RemoveTelegramChatsListKey() => _inner.RemoveTelegramChatsListKey();
-        public void RemoveSlackDestinationsListKey() => _inner.RemoveSlackDestinationsListKey();
 
         public List<AlertTemplateEntity> GetAllAlertTemplates() => _inner.GetAllAlertTemplates();
         public void AddAlertTemplate(AlertTemplateEntity policy) => _inner.AddAlertTemplate(policy);

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Core.DataLayer;
+using HSMServer.Migrations;
+using Moq;
+using Xunit;
+
+namespace HSMServer.Core.Tests.Notifications
+{
+    public class ChatMigrationTests
+    {
+        [Fact]
+        public void Migrate_EmptyDb_WritesNothingAndDoesNotDeleteKeys()
+        {
+            var db = new Mock<IDatabaseCore>(MockBehavior.Strict);
+            db.Setup(d => d.GetChats()).Returns(new List<ChatEntity>());
+            db.Setup(d => d.GetTelegramChats()).Returns(new List<TelegramChatEntity>());
+            db.Setup(d => d.GetSlackDestinations()).Returns(new List<SlackDestinationEntity>());
+
+            new ChatMigrator().Migrate(db.Object);
+
+            db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Never);
+            db.Verify(d => d.RemoveTelegramChatsListKey(), Times.Never);
+            db.Verify(d => d.RemoveSlackDestinationsListKey(), Times.Never);
+        }
+
+        [Fact]
+        public void Migrate_ThreeTelegramAndTwoSlack_ProducesFiveChatsWithCorrectFields()
+        {
+            var tg1Id = Guid.NewGuid();
+            var tg2Id = Guid.NewGuid();
+            var tg3Id = Guid.NewGuid();
+            var slack1Id = Guid.NewGuid();
+            var slack2Id = Guid.NewGuid();
+
+            var telegramChats = new List<TelegramChatEntity>
+            {
+                BuildTelegram(tg1Id, "tg-1", type: 0, chatId: 100L),
+                BuildTelegram(tg2Id, "tg-2", type: 1, chatId: 200L),
+                BuildTelegram(tg3Id, "tg-3", type: 0, chatId: 300L),
+            };
+            var slackDestinations = new List<SlackDestinationEntity>
+            {
+                BuildSlack(slack1Id, "slack-1", "https://hooks.slack.com/services/A"),
+                BuildSlack(slack2Id, "slack-2", "https://hooks.slack.com/services/B"),
+            };
+
+            var written = new List<ChatEntity>();
+            var db = new Mock<IDatabaseCore>(MockBehavior.Strict);
+            db.Setup(d => d.GetChats()).Returns(new List<ChatEntity>());
+            db.Setup(d => d.GetTelegramChats()).Returns(telegramChats);
+            db.Setup(d => d.GetSlackDestinations()).Returns(slackDestinations);
+            db.Setup(d => d.AddChat(It.IsAny<ChatEntity>())).Callback<ChatEntity>(written.Add);
+            db.Setup(d => d.RemoveTelegramChatsListKey());
+            db.Setup(d => d.RemoveSlackDestinationsListKey());
+
+            new ChatMigrator().Migrate(db.Object);
+
+            Assert.Equal(5, written.Count);
+
+            var byId = written.ToDictionary(c => new Guid(c.Id));
+            Assert.Equal(new[] { tg1Id, tg2Id, tg3Id, slack1Id, slack2Id }.OrderBy(g => g), byId.Keys.OrderBy(g => g));
+
+            var migratedTg1 = byId[tg1Id];
+            Assert.Equal("tg-1", migratedTg1.Name);
+            Assert.Equal((byte)0, migratedTg1.TelegramType);
+            Assert.Equal(100L, migratedTg1.TelegramChatId);
+            Assert.Null(migratedTg1.SlackWebhookUrl);
+            Assert.Null(migratedTg1.MattermostWebhookUrl);
+
+            var migratedTg2 = byId[tg2Id];
+            Assert.Equal((byte)1, migratedTg2.TelegramType);
+            Assert.Equal(200L, migratedTg2.TelegramChatId);
+
+            var migratedSlack1 = byId[slack1Id];
+            Assert.Equal("slack-1", migratedSlack1.Name);
+            Assert.Equal("https://hooks.slack.com/services/A", migratedSlack1.SlackWebhookUrl);
+            Assert.Null(migratedSlack1.TelegramType);
+            Assert.Null(migratedSlack1.TelegramChatId);
+            Assert.Null(migratedSlack1.AuthorizationTime);
+
+            db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Exactly(5));
+            db.Verify(d => d.RemoveTelegramChatsListKey(), Times.Once);
+            db.Verify(d => d.RemoveSlackDestinationsListKey(), Times.Once);
+        }
+
+        [Fact]
+        public void Migrate_AlreadyMigrated_IsNoop()
+        {
+            var existing = new List<ChatEntity>
+            {
+                new() { Id = Guid.NewGuid().ToByteArray(), Name = "chat-1" },
+                new() { Id = Guid.NewGuid().ToByteArray(), Name = "chat-2" },
+            };
+
+            var db = new Mock<IDatabaseCore>(MockBehavior.Strict);
+            db.Setup(d => d.GetChats()).Returns(existing);
+
+            new ChatMigrator().Migrate(db.Object);
+
+            db.Verify(d => d.GetTelegramChats(), Times.Never);
+            db.Verify(d => d.GetSlackDestinations(), Times.Never);
+            db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Never);
+            db.Verify(d => d.RemoveTelegramChatsListKey(), Times.Never);
+            db.Verify(d => d.RemoveSlackDestinationsListKey(), Times.Never);
+        }
+
+
+        private static TelegramChatEntity BuildTelegram(Guid id, string name, byte type, long chatId) => new()
+        {
+            Id = id.ToByteArray(),
+            Author = Guid.NewGuid().ToByteArray(),
+            CreationDate = DateTime.UtcNow.Ticks,
+            Name = name,
+            Description = $"{name}-desc",
+            Type = type,
+            ChatId = chatId,
+            AuthorizationTime = DateTime.UtcNow.Ticks,
+            SendMessages = true,
+            MessagesAggregationTimeSec = 60,
+        };
+
+        private static SlackDestinationEntity BuildSlack(Guid id, string name, string webhook) => new()
+        {
+            Id = id.ToByteArray(),
+            Author = Guid.NewGuid().ToByteArray(),
+            CreationDate = DateTime.UtcNow.Ticks,
+            Name = name,
+            Description = $"{name}-desc",
+            WebhookUrl = webhook,
+            SendMessages = false,
+            MessagesAggregationTimeSec = 30,
+        };
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
@@ -67,6 +67,7 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Equal("tg-1", migratedTg1.Name);
             Assert.Equal((byte)0, migratedTg1.TelegramType);
             Assert.Equal(100L, migratedTg1.TelegramChatId);
+            Assert.NotNull(migratedTg1.AuthorizationTime);
             Assert.Null(migratedTg1.SlackWebhookUrl);
             Assert.Null(migratedTg1.MattermostWebhookUrl);
 

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
@@ -12,7 +12,7 @@ namespace HSMServer.Core.Tests.Notifications
     public class ChatMigrationTests
     {
         [Fact]
-        public void Migrate_EmptyDb_WritesNothingAndDoesNotDeleteKeys()
+        public void Migrate_EmptyDb_WritesNothing()
         {
             var db = new Mock<IDatabaseCore>(MockBehavior.Strict);
             db.Setup(d => d.GetChats()).Returns(new List<ChatEntity>());
@@ -22,8 +22,6 @@ namespace HSMServer.Core.Tests.Notifications
             new ChatMigrator().Migrate(db.Object);
 
             db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Never);
-            db.Verify(d => d.RemoveTelegramChatsListKey(), Times.Never);
-            db.Verify(d => d.RemoveSlackDestinationsListKey(), Times.Never);
         }
 
         [Fact]
@@ -53,8 +51,6 @@ namespace HSMServer.Core.Tests.Notifications
             db.Setup(d => d.GetTelegramChats()).Returns(telegramChats);
             db.Setup(d => d.GetSlackDestinations()).Returns(slackDestinations);
             db.Setup(d => d.AddChat(It.IsAny<ChatEntity>())).Callback<ChatEntity>(written.Add);
-            db.Setup(d => d.RemoveTelegramChatsListKey());
-            db.Setup(d => d.RemoveSlackDestinationsListKey());
 
             new ChatMigrator().Migrate(db.Object);
 
@@ -83,29 +79,87 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Null(migratedSlack1.AuthorizationTime);
 
             db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Exactly(5));
-            db.Verify(d => d.RemoveTelegramChatsListKey(), Times.Once);
-            db.Verify(d => d.RemoveSlackDestinationsListKey(), Times.Once);
         }
 
         [Fact]
-        public void Migrate_AlreadyMigrated_IsNoop()
+        public void Migrate_AllLegacyIdsAlreadyPresent_IsNoop()
         {
+            var tg1Id = Guid.NewGuid();
+            var tg2Id = Guid.NewGuid();
+            var slack1Id = Guid.NewGuid();
+
             var existing = new List<ChatEntity>
             {
-                new() { Id = Guid.NewGuid().ToByteArray(), Name = "chat-1" },
-                new() { Id = Guid.NewGuid().ToByteArray(), Name = "chat-2" },
+                new() { Id = tg1Id.ToByteArray(), Name = "tg-1" },
+                new() { Id = tg2Id.ToByteArray(), Name = "tg-2" },
+                new() { Id = slack1Id.ToByteArray(), Name = "slack-1" },
+            };
+
+            var telegramChats = new List<TelegramChatEntity>
+            {
+                BuildTelegram(tg1Id, "tg-1", type: 0, chatId: 100L),
+                BuildTelegram(tg2Id, "tg-2", type: 1, chatId: 200L),
+            };
+            var slackDestinations = new List<SlackDestinationEntity>
+            {
+                BuildSlack(slack1Id, "slack-1", "https://hooks.slack.com/services/A"),
             };
 
             var db = new Mock<IDatabaseCore>(MockBehavior.Strict);
             db.Setup(d => d.GetChats()).Returns(existing);
+            db.Setup(d => d.GetTelegramChats()).Returns(telegramChats);
+            db.Setup(d => d.GetSlackDestinations()).Returns(slackDestinations);
 
             new ChatMigrator().Migrate(db.Object);
 
-            db.Verify(d => d.GetTelegramChats(), Times.Never);
-            db.Verify(d => d.GetSlackDestinations(), Times.Never);
             db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Never);
-            db.Verify(d => d.RemoveTelegramChatsListKey(), Times.Never);
-            db.Verify(d => d.RemoveSlackDestinationsListKey(), Times.Never);
+        }
+
+        [Fact]
+        public void Migrate_PartialRun_ResumesAndWritesOnlyMissingChats()
+        {
+            // Simulates a previously interrupted migration: tg1 already written, tg2/tg3/slack1/slack2 still pending.
+            var tg1Id = Guid.NewGuid();
+            var tg2Id = Guid.NewGuid();
+            var tg3Id = Guid.NewGuid();
+            var slack1Id = Guid.NewGuid();
+            var slack2Id = Guid.NewGuid();
+
+            var existing = new List<ChatEntity>
+            {
+                new() { Id = tg1Id.ToByteArray(), Name = "tg-1" },
+            };
+
+            var telegramChats = new List<TelegramChatEntity>
+            {
+                BuildTelegram(tg1Id, "tg-1", type: 0, chatId: 100L),
+                BuildTelegram(tg2Id, "tg-2", type: 1, chatId: 200L),
+                BuildTelegram(tg3Id, "tg-3", type: 0, chatId: 300L),
+            };
+            var slackDestinations = new List<SlackDestinationEntity>
+            {
+                BuildSlack(slack1Id, "slack-1", "https://hooks.slack.com/services/A"),
+                BuildSlack(slack2Id, "slack-2", "https://hooks.slack.com/services/B"),
+            };
+
+            var written = new List<ChatEntity>();
+            var db = new Mock<IDatabaseCore>(MockBehavior.Strict);
+            db.Setup(d => d.GetChats()).Returns(existing);
+            db.Setup(d => d.GetTelegramChats()).Returns(telegramChats);
+            db.Setup(d => d.GetSlackDestinations()).Returns(slackDestinations);
+            db.Setup(d => d.AddChat(It.IsAny<ChatEntity>())).Callback<ChatEntity>(written.Add);
+
+            new ChatMigrator().Migrate(db.Object);
+
+            Assert.Equal(4, written.Count);
+            var writtenIds = written.Select(c => new Guid(c.Id)).ToHashSet();
+            Assert.DoesNotContain(tg1Id, writtenIds);
+            Assert.Contains(tg2Id, writtenIds);
+            Assert.Contains(tg3Id, writtenIds);
+            Assert.Contains(slack1Id, writtenIds);
+            Assert.Contains(slack2Id, writtenIds);
+
+            db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Exactly(4));
         }
 
 

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
@@ -53,6 +53,22 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Empty(manager.GetValues());
         }
 
+        [Fact]
+        public async Task TryRemove_TelegramChat_RemovesFromTelegramChatIdsIndex()
+        {
+            const long knownChatId = 42L;
+            var manager = BuildManager();
+            var chat = BuildTelegramChat(knownChatId);
+            await manager.TryAdd(chat);
+
+            Assert.NotNull(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(knownChatId)));
+
+            var removed = await manager.TryRemove(new RemoveRequest(chat.Id, InitiatorInfo.System));
+
+            Assert.True(removed);
+            Assert.Null(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(knownChatId)));
+        }
+
 
         private static ChatsManager BuildManager()
         {

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
@@ -69,6 +69,57 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Null(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(knownChatId)));
         }
 
+        [Fact]
+        public async Task TryUpdate_TelegramChatIdChange_RekeysTelegramChatIdsIndex()
+        {
+            const long oldChatId = 100L;
+            const long newChatId = 200L;
+            var manager = BuildManager();
+            var chat = BuildTelegramChat(oldChatId);
+            await manager.TryAdd(chat);
+
+            var updated = await manager.TryUpdate(new ChatUpdate
+            {
+                Id = chat.Id,
+                TelegramChatId = newChatId,
+            });
+
+            Assert.True(updated);
+            Assert.Null(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(oldChatId)));
+            Assert.Same(chat, manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(newChatId)));
+        }
+
+        [Fact]
+        public async Task MigrateToSupergroup_RekeysTelegramChatIdsIndex()
+        {
+            const long oldChatId = 100L;
+            const long newChatId = 200L;
+            var manager = BuildManager();
+            var chat = BuildTelegramChat(oldChatId);
+            await manager.TryAdd(chat);
+
+            await manager.MigrateToSupergroup(oldChatId, newChatId);
+
+            Assert.Null(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(oldChatId)));
+            Assert.Same(chat, manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(newChatId)));
+        }
+
+        [Fact]
+        public void Chat_BuiltFromPublicCtor_PersistsTelegramFieldsThroughToEntity()
+        {
+            // Ctor must default TelegramType — ToEntity() gates Telegram persistence on it.
+            var chat = new Chat(new Telegram.Bot.Types.ChatId(42L));
+
+            var entity = chat.ToEntity();
+
+            Assert.Equal((byte)ConnectedChatType.TelegramPrivate, entity.TelegramType);
+            Assert.Equal(42L, entity.TelegramChatId);
+
+            var reloaded = new Chat(entity);
+            Assert.Equal(42L, reloaded.TelegramChatId?.Identifier);
+            Assert.Equal(ConnectedChatType.TelegramPrivate, reloaded.TelegramType);
+        }
+
 
         private static ChatsManager BuildManager()
         {

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Authentication;
+using HSMServer.ConcurrentStorage;
+using HSMServer.Core.DataLayer;
+using HSMServer.Core.TableOfChanges;
+using HSMServer.Notifications;
+using HSMServer.Notifications.Chats;
+using HSMServer.ServerConfiguration;
+using Moq;
+using Xunit;
+
+namespace HSMServer.Core.Tests.Notifications
+{
+    public class ChatsManagerTests
+    {
+        [Fact]
+        public async Task TryAdd_SlackOnlyChat_DoesNotPolluteTelegramChatIdsIndex()
+        {
+            var manager = BuildManager();
+            var slackOnly = BuildSlackOnlyChat();
+
+            var added = await manager.TryAdd(slackOnly);
+
+            Assert.True(added);
+            Assert.Single(manager.GetValues());
+            Assert.Null(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(0L)));
+        }
+
+        [Fact]
+        public async Task TryAdd_TelegramChat_RegistersInTelegramChatIdsIndex()
+        {
+            var manager = BuildManager();
+            var telegramChat = BuildTelegramChat(chatId: 12345L);
+
+            await manager.TryAdd(telegramChat);
+
+            Assert.NotNull(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(12345L)));
+        }
+
+        [Fact]
+        public async Task TryRemove_SlackOnlyChat_DoesNotThrowOnMissingTelegramIndex()
+        {
+            var manager = BuildManager();
+            var slackOnly = BuildSlackOnlyChat();
+            await manager.TryAdd(slackOnly);
+
+            var removed = await manager.TryRemove(new RemoveRequest(slackOnly.Id, InitiatorInfo.System));
+
+            Assert.True(removed);
+            Assert.Empty(manager.GetValues());
+        }
+
+
+        private static ChatsManager BuildManager()
+        {
+            var db = new Mock<IDatabaseCore>(MockBehavior.Loose);
+            db.Setup(d => d.GetChats()).Returns(new List<ChatEntity>());
+
+            var users = new Mock<IUserManager>(MockBehavior.Loose);
+            var config = new Mock<IServerConfig>(MockBehavior.Loose);
+            config.SetupGet(c => c.Telegram).Returns(new TelegramConfig { BotName = "test_bot", BotToken = "test_token" });
+
+            return new ChatsManager(db.Object, users.Object, config.Object);
+        }
+
+        private static Chat BuildSlackOnlyChat() => new()
+        {
+            // Slack-only chat: no TelegramChatId/TelegramType set
+        };
+
+        private static Chat BuildTelegramChat(long chatId) => new(new Telegram.Bot.Types.ChatId(chatId))
+        {
+            TelegramType = ConnectedChatType.TelegramPrivate,
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
Foundation PR for the Unified Chat refactor (epic #1259). Introduces the new `Chat` entity, manager, and LevelDB migration alongside the legacy `TelegramChat` / `SlackDestination` types. No consumer is switched yet — `NotificationsCenter` still reads from the old managers. Removal of legacy types and consumer rewiring lands in (2/4) #1261.

What's in this PR:
- **New**: `ChatEntity`, `Chat`, `ChatUpdate`, `IChatsManager`, `ChatsManager` (namespace `HSMServer.Notifications.Chats`, mirrors `TelegramChatsManager` surface area incl. auth flow, supergroup migration, folder handlers).
- **Wired**: `"Chats"` LevelDB key + full CRUD on `EnvironmentDatabaseWorker` / `DatabaseCore` / `IDatabaseCore` / `IEnvironmentDatabase`.
- **Registered**: `IChatsManager` in DI alongside the legacy managers.
- **Migration**: new `HSMServer.Migrations.ChatMigrator` runs once at startup (in `InitStorages`, before any storage `Initialize()`). **Additive only** — reads `TelegramChats` + `SlackDestinations` and writes unified `ChatEntity` records under the **same Guids**, but leaves the legacy id-list keys untouched so existing consumers keep working. Per-id idempotent: an interrupted run resumes and writes only the missing chats.

The legacy `TelegramChats` / `SlackDestinations` keys are intentionally **not** deleted in this PR. Their removal moves to (2/4) #1261, together with the consumer switchover that makes them safe to drop.

## Design notes
- `TokensManager` is **copied** into `ChatsManager`, not moved — `TelegramChatsManager.TokenManager` is still consumed by `NotificationsCenter.RecalculateState` and the Telegram auth flow. Full absorption happens in (2/4).
- New `Chat` lives in `HSMServer.Notifications.Chats` sub-namespace to avoid collision with `Telegram.Bot.Types.Chat`.
- `Chat.TelegramChatId` / `TelegramType` / `AuthorizationTime` / `SlackWebhookUrl` / `MattermostWebhookUrl` are nullable optional fields (Mattermost fields exist but channel is not implemented — separate epic).
- `ChatUpdate` carries only fields `ApplyUpdate` actually consumes (SendMessages, MessagesAggregationTimeSec, TelegramChatId, SlackWebhookUrl, MattermostWebhookUrl). `TelegramType` and `AuthorizationTime` are init-only on `Chat`, so they're not in the update DTO.

## Test plan
- [x] `dotnet build` succeeds with both old and new managers present.
- [x] `ChatMigrationTests` (4 scenarios): empty DB, 3 TG + 2 Slack → 5 Chats with correct optional-field population (incl. `AuthorizationTime`), idempotent re-run (all legacy ids already present), and partial-run self-healing (1 of 3 TG ids already written → migrator writes only the 4 missing chats).
- [x] `ChatsManagerTests` (4 scenarios): TryAdd Slack-only, TryAdd Telegram-bound, TryRemove Slack-only, TryRemove Telegram-bound. Covers the `_telegramChatIds` reverse-index behavior that the nullable `TelegramChatId` enables.
- [ ] Manual (fixture DB): start server on a fixture with legacy data; logs report `wrote N chats, skipped 0 already-present entries`; `"Chats"` key populated, legacy `"TelegramChats"` / `"SlackDestinations"` keys still present (intentional — removed in #1261).
- [ ] Manual (clean DB): server starts, logs report `wrote 0 chats, skipped 0 already-present entries`.
- [ ] Manual (restart after partial migration): stop server mid-migration, restart; logs report `wrote N chats, skipped M already-present entries` with no duplicate writes.

## Out of scope
- Deleting the legacy `TelegramChats` / `SlackDestinations` LevelDB keys → (2/4).
- Removing `TelegramChat` / `SlackDestination` entities → (2/4).
- Switching consumers (`NotificationsCenter`, `TelegramNotificationChannel`, `SlackNotificationChannel`) to `IChatsManager` → (2/4).
- Frontend / view models → (3/4).

Closes #1260

🤖 Generated with [Claude Code](https://claude.com/claude-code)