### PR TITLE
feat(chats): align EditChat form + add per-channel Remove buttons (#1271)

### DIFF
--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -119,6 +119,35 @@ namespace HSMServer.Controllers
             return Ok();
         }
 
+        [HttpPost]
+        [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]
+        public async Task<IActionResult> RemoveTelegramBinding(Guid id) =>
+            await ClearChannel(id, clearTelegram: true);
+
+        [HttpPost]
+        [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]
+        public async Task<IActionResult> ClearSlackWebhook(Guid id) =>
+            await ClearChannel(id, clearSlack: true);
+
+        [HttpPost]
+        [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]
+        public async Task<IActionResult> ClearMattermostWebhook(Guid id) =>
+            await ClearChannel(id, clearMattermost: true);
+
+
+        private async Task<IActionResult> ClearChannel(Guid id, bool clearTelegram = false, bool clearSlack = false, bool clearMattermost = false)
+        {
+            var update = new ChatUpdate
+            {
+                Id = id,
+                ClearTelegramBinding = clearTelegram,
+                ClearSlackWebhook = clearSlack,
+                ClearMattermostWebhook = clearMattermost,
+            };
+
+            return await ChatsManager.TryUpdate(update) ? Ok() : NotFound();
+        }
+
 
         private ChatFoldersViewModel BuildChatFolders(Chat chat)
         {

--- a/src/server/HSMServer/Notifications/Chats/Chat.cs
+++ b/src/server/HSMServer/Notifications/Chats/Chat.cs
@@ -29,9 +29,13 @@ namespace HSMServer.Notifications.Chats
         // Telegram (optional)
         public ChatId? TelegramChatId { get; private set; }
 
-        public ConnectedChatType? TelegramType { get; init; }
+        // init would block the ClearTelegramBinding path — ApplyUpdate needs to null these out so
+        // ToEntity() drops them on the next round-trip. internal set keeps existing object
+        // initializers in ChatsManager.TryConnect and ChatsManagerTests working; outside this
+        // assembly the surface is effectively read-only.
+        public ConnectedChatType? TelegramType { get; internal set; }
 
-        public DateTime? AuthorizationTime { get; init; }
+        public DateTime? AuthorizationTime { get; internal set; }
 
 
         // Slack (optional)
@@ -98,6 +102,19 @@ namespace HSMServer.Notifications.Chats
 
             if (update.TelegramChatId.HasValue)
                 TelegramChatId = new ChatId(update.TelegramChatId.Value);
+
+            if (update.ClearTelegramBinding is true)
+            {
+                TelegramChatId = null;
+                TelegramType = null;
+                AuthorizationTime = null;
+            }
+
+            if (update.ClearSlackWebhook is true)
+                SlackWebhookUrl = null;
+
+            if (update.ClearMattermostWebhook is true)
+                MattermostWebhookUrl = null;
         }
 
         public override ChatEntity ToEntity()

--- a/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
@@ -20,5 +20,17 @@ namespace HSMServer.Notifications.Chats
 
         // Mattermost (optional)
         public string MattermostWebhookUrl { get; init; }
+
+
+        // Negative-clear flags. Chat.ApplyUpdate uses `?? current` for SlackWebhookUrl /
+        // MattermostWebhookUrl, so a null update value means "don't change" and submitting an
+        // empty string through EditChat cannot clear a saved webhook. Telegram binding is even
+        // stricter — TelegramType / AuthorizationTime are private-set and only mutable here.
+        // These flags route around both issues by explicitly signalling "set this channel to null".
+        public bool? ClearTelegramBinding { get; init; }
+
+        public bool? ClearSlackWebhook { get; init; }
+
+        public bool? ClearMattermostWebhook { get; init; }
     }
 }

--- a/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
@@ -25,7 +25,7 @@ namespace HSMServer.Notifications.Chats
         // Negative-clear flags. Chat.ApplyUpdate uses `?? current` for SlackWebhookUrl /
         // MattermostWebhookUrl, so a null update value means "don't change" and submitting an
         // empty string through EditChat cannot clear a saved webhook. Telegram binding is even
-        // stricter — TelegramType / AuthorizationTime are private-set and only mutable here.
+        // stricter — TelegramType / AuthorizationTime are internal-set and only mutable here.
         // These flags route around both issues by explicitly signalling "set this channel to null".
         public bool? ClearTelegramBinding { get; init; }
 

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -122,7 +122,7 @@
                 </li>
             </ul>
 
-            <div class="tab-content" id="channelTabsContent">
+            <div class="tab-content">
                 <div class="tab-pane fade @(defaultTab == "telegram" ? "show active" : "")" id="telegram"
                      role="tabpanel" aria-labelledby="telegram-tab">
                     @if (isTelegramBound)

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -19,11 +19,12 @@
 
     // First configured channel wins; for a brand-new chat we land on Slack because Telegram can
     // only be added through the bot-invite flow (Show setup help), so Slack is the only fillable
-    // field. An existing chat with no channels configured falls back to Telegram (shows the help).
+    // field. An existing chat with no channels configured (e.g. right after ClearSlackWebhook)
+    // also falls back to Slack — landing on Telegram would surprise the user, who just acted on
+    // the Slack webhook. Mattermost only wins if it's the sole configured channel.
     var defaultTab = isTelegramBound ? "telegram"
-                   : (Model.HasSlack || isNewChat) ? "slack"
-                   : Model.HasMattermost ? "mattermost"
-                   : "telegram";
+                   : Model.HasMattermost && !Model.HasSlack ? "mattermost"
+                   : "slack";
 }
 
 

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -16,6 +16,14 @@
     var icons = Model.ChatBrandIcons();
     var isNewChat = Model.Id == Guid.Empty;
     var formAction = isNewChat ? nameof(NotificationsController.AddChat) : nameof(NotificationsController.EditChat);
+
+    // First configured channel wins; for a brand-new chat we land on Slack because Telegram can
+    // only be added through the bot-invite flow (Show setup help), so Slack is the only fillable
+    // field. An existing chat with no channels configured falls back to Telegram (shows the help).
+    var defaultTab = isTelegramBound ? "telegram"
+                   : (Model.HasSlack || isNewChat) ? "slack"
+                   : Model.HasMattermost ? "mattermost"
+                   : "telegram";
 }
 
 
@@ -90,69 +98,107 @@
                 </div>
             </div>
 
-            @if (isTelegramBound)
-            {
-                <div class="row mt-2">
-                    <label class="col-2 col-form-label">Telegram</label>
-                    <div class="col-6">
-                        <span class="badge bg-secondary">
-                            <i class="fab fa-telegram"></i>
-                            @Model.TelegramType?.GetDisplayName()
-                        </span>
-                        <small class="text-muted d-block">ChatId: @Model.TelegramChatId</small>
-                        <small class="text-muted d-block">Connected: @Model.AuthorizationTime?.ToLocalTime().ToString("g")</small>
-                    </div>
-                </div>
-            }
-            else
-            {
-                @await Html.PartialAsync("_NewChatHelpModal.cshtml", Model.Id)
-                <div class="row mt-2">
-                    <label class="col-2 col-form-label">Telegram</label>
-                    <div class="col-6">
-                        <a href="javascript:showAddChatHelpModal();" class="btn btn-link p-0">
-                            <i class="fab fa-telegram"></i> Show setup help
-                        </a>
-                    </div>
-                </div>
-            }
+            <ul class="nav nav-tabs mt-3" role="tablist">
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link @(defaultTab == "telegram" ? "active" : "")" id="telegram-tab"
+                            data-bs-toggle="tab" data-bs-target="#telegram" type="button" role="tab"
+                            aria-controls="telegram" aria-selected="@(defaultTab == "telegram" ? "true" : "false")">
+                        <i class="fab fa-telegram"></i> Telegram
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link @(defaultTab == "slack" ? "active" : "")" id="slack-tab"
+                            data-bs-toggle="tab" data-bs-target="#slack" type="button" role="tab"
+                            aria-controls="slack" aria-selected="@(defaultTab == "slack" ? "true" : "false")">
+                        <i class="fa-brands fa-slack"></i> Slack
+                    </button>
+                </li>
+                <li class="nav-item" role="presentation">
+                    <button class="nav-link @(defaultTab == "mattermost" ? "active" : "")" id="mattermost-tab"
+                            data-bs-toggle="tab" data-bs-target="#mattermost" type="button" role="tab"
+                            aria-controls="mattermost" aria-selected="@(defaultTab == "mattermost" ? "true" : "false")">
+                        <i class="fa-brands fa-mattermost"></i> Mattermost
+                    </button>
+                </li>
+            </ul>
 
-            <div class="row mt-2">
-                <div class="col-2 d-flex align-items-center">
-                    <label class="col-form-label" asp-for="SlackWebhookUrl"></label>
+            <div class="tab-content" id="channelTabsContent">
+                <div class="tab-pane fade @(defaultTab == "telegram" ? "show active" : "")" id="telegram"
+                     role="tabpanel" aria-labelledby="telegram-tab">
+                    @if (isTelegramBound)
+                    {
+                        <div class="row mt-2">
+                            <label class="col-2 col-form-label">Telegram</label>
+                            <div class="col-6">
+                                <span class="badge bg-secondary">
+                                    <i class="fab fa-telegram"></i>
+                                    @Model.TelegramType?.GetDisplayName()
+                                </span>
+                                <small class="text-muted d-block">ChatId: @Model.TelegramChatId</small>
+                                <small class="text-muted d-block">Connected: @Model.AuthorizationTime?.ToLocalTime().ToString("g")</small>
+                            </div>
+                        </div>
+                        <div class="d-flex gap-2 mt-2">
+                            <a id="sendTestTelegram" data-chat-id="@Model.TelegramChatId" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Telegram message</a>
+                            <a id="removeTelegram" class="btn btn-outline-danger" style="cursor: pointer;">Remove Telegram</a>
+                        </div>
+                    }
+                    else
+                    {
+                        @await Html.PartialAsync("_NewChatHelpModal.cshtml", Model.Id)
+                        <div class="row mt-2">
+                            <label class="col-2 col-form-label">Telegram</label>
+                            <div class="col-6">
+                                <a href="javascript:showAddChatHelpModal();" class="btn btn-link p-0">
+                                    <i class="fab fa-telegram"></i> Show setup help
+                                </a>
+                            </div>
+                        </div>
+                    }
                 </div>
-                <div class="col-6">
-                    <input type="url" class="form-control" asp-for="SlackWebhookUrl" placeholder="https://hooks.slack.com/services/..." />
-                </div>
-            </div>
 
-            <div class="row mt-2">
-                <div class="col-2 d-flex align-items-center">
-                    <label class="col-form-label" asp-for="MattermostWebhookUrl"></label>
+                <div class="tab-pane fade @(defaultTab == "slack" ? "show active" : "")" id="slack"
+                     role="tabpanel" aria-labelledby="slack-tab">
+                    <div class="row mt-2">
+                        <div class="col-2 d-flex align-items-center">
+                            <label class="col-form-label" asp-for="SlackWebhookUrl"></label>
+                        </div>
+                        <div class="col-6">
+                            <input type="url" class="form-control" asp-for="SlackWebhookUrl" placeholder="https://hooks.slack.com/services/..." />
+                        </div>
+                    </div>
+                    @if (Model.HasSlack)
+                    {
+                        <div class="d-flex gap-2 mt-2">
+                            <a id="sendTestSlack" data-chat-id="@Model.Id" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Slack message</a>
+                            <a id="removeSlack" class="btn btn-outline-danger" style="cursor: pointer;">Remove Slack</a>
+                        </div>
+                    }
                 </div>
-                <div class="col-6">
-                    <input type="url" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." disabled />
-                    <small class="text-muted">Mattermost delivery is not yet implemented.</small>
+
+                <div class="tab-pane fade @(defaultTab == "mattermost" ? "show active" : "")" id="mattermost"
+                     role="tabpanel" aria-labelledby="mattermost-tab">
+                    <div class="row mt-2">
+                        <div class="col-2 d-flex align-items-center">
+                            <label class="col-form-label" asp-for="MattermostWebhookUrl"></label>
+                        </div>
+                        <div class="col-6">
+                            <input type="url" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." disabled />
+                            <small class="text-muted">Mattermost delivery is not yet implemented.</small>
+                        </div>
+                    </div>
+                    @if (Model.HasMattermost)
+                    {
+                        <div class="d-flex gap-2 mt-2">
+                            <a id="removeMattermost" class="btn btn-outline-danger" style="cursor: pointer;">Remove Mattermost</a>
+                        </div>
+                    }
                 </div>
             </div>
 
             <partial name="_ChatFolders" for="Folders" />
 
-            <div class="d-flex justify-content-end my-2 gap-2">
-                @if (isTelegramBound)
-                {
-                    <a id="sendTestTelegram" data-chat-id="@Model.TelegramChatId" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Telegram message</a>
-                    <a id="removeTelegram" class="btn btn-outline-danger" style="cursor: pointer;">Remove Telegram</a>
-                }
-                @if (Model.HasSlack)
-                {
-                    <a id="sendTestSlack" data-chat-id="@Model.Id" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Slack message</a>
-                    <a id="removeSlack" class="btn btn-outline-danger" style="cursor: pointer;">Remove Slack</a>
-                }
-                @if (Model.HasMattermost)
-                {
-                    <a id="removeMattermost" class="btn btn-outline-danger" style="cursor: pointer;">Remove Mattermost</a>
-                }
+            <div class="d-flex justify-content-end my-2">
                 <button type="submit" class="btn btn-primary independentSizeButton my-1">Save</button>
             </div>
         </form>

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -140,16 +140,16 @@
                 @if (isTelegramBound)
                 {
                     <a id="sendTestTelegram" data-chat-id="@Model.TelegramChatId" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Telegram message</a>
-                    <a id="removeTelegram" data-chat-id="@Model.Id" class="btn btn-outline-danger" style="cursor: pointer;">Remove Telegram</a>
+                    <a id="removeTelegram" class="btn btn-outline-danger" style="cursor: pointer;">Remove Telegram</a>
                 }
                 @if (Model.HasSlack)
                 {
                     <a id="sendTestSlack" data-chat-id="@Model.Id" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Slack message</a>
-                    <a id="removeSlack" data-chat-id="@Model.Id" class="btn btn-outline-danger" style="cursor: pointer;">Remove Slack</a>
+                    <a id="removeSlack" class="btn btn-outline-danger" style="cursor: pointer;">Remove Slack</a>
                 }
                 @if (Model.HasMattermost)
                 {
-                    <a id="removeMattermost" data-chat-id="@Model.Id" class="btn btn-outline-danger" style="cursor: pointer;">Remove Mattermost</a>
+                    <a id="removeMattermost" class="btn btn-outline-danger" style="cursor: pointer;">Remove Mattermost</a>
                 }
                 <button type="submit" class="btn btn-primary independentSizeButton my-1">Save</button>
             </div>

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -110,14 +110,14 @@
                     <button class="nav-link @(defaultTab == "slack" ? "active" : "")" id="slack-tab"
                             data-bs-toggle="tab" data-bs-target="#slack" type="button" role="tab"
                             aria-controls="slack" aria-selected="@(defaultTab == "slack" ? "true" : "false")">
-                        <i class="fa-brands fa-slack"></i> Slack
+                        <i class="fab fa-slack"></i> Slack
                     </button>
                 </li>
                 <li class="nav-item" role="presentation">
                     <button class="nav-link @(defaultTab == "mattermost" ? "active" : "")" id="mattermost-tab"
                             data-bs-toggle="tab" data-bs-target="#mattermost" type="button" role="tab"
                             aria-controls="mattermost" aria-selected="@(defaultTab == "mattermost" ? "true" : "false")">
-                        <i class="fa-brands fa-mattermost"></i> Mattermost
+                        <i class="fab fa-mattermost"></i> Mattermost
                     </button>
                 </li>
             </ul>

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -70,8 +70,10 @@
                     <label class="col-form-label" asp-for="EnableMessages"></label>
                     <i class='fas fa-question-circle ms-2' title='True means that alert notifications for this chat is enabled.'></i>
                 </div>
-                <div class="col-6 form-check form-switch mt-2">
-                    <input id="messages-settings" class="form-check-input" type="checkbox" asp-for="EnableMessages">
+                <div class="col-6">
+                    <div class="form-check form-switch mt-2">
+                        <input id="messages-settings" class="form-check-input" type="checkbox" asp-for="EnableMessages">
+                    </div>
                 </div>
             </div>
 
@@ -80,7 +82,7 @@
                     <label class="col-form-label" asp-for="MessagesDelay"></label>
                     <i class='fas fa-question-circle ms-2' title='Alert notifications aggregation period in seconds.'></i>
                 </div>
-                <div class="col-6 p-0">
+                <div class="col-6">
                     <div class="input-group">
                         <input type="number" class="form-control" asp-for="MessagesDelay">
                         <span class="input-group-text">sec</span>

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -191,7 +191,8 @@
                     url: actionUrl + `?id=@Model.Id`,
                     cache: false,
                     async: true,
-                    success: function () { window.location.reload(); }
+                    success: function () { window.location.reload(); },
+                    error: function () { showToast(`Failed to remove ${channelName.toLowerCase()} from chat.`); }
                 });
             }
         );

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -31,7 +31,7 @@
             </h5>
 
             <a href="javascript:removeChat();">
-                <i class='fas fa-trash-alt'></i> Remove
+                <i class='fas fa-trash-alt'></i> Remove chat
             </a>
         </div>
 
@@ -70,7 +70,7 @@
                     <label class="col-form-label" asp-for="EnableMessages"></label>
                     <i class='fas fa-question-circle ms-2' title='True means that alert notifications for this chat is enabled.'></i>
                 </div>
-                <div class="col-4 form-check form-switch mt-2">
+                <div class="col-6 form-check form-switch mt-2">
                     <input id="messages-settings" class="form-check-input" type="checkbox" asp-for="EnableMessages">
                 </div>
             </div>
@@ -80,7 +80,7 @@
                     <label class="col-form-label" asp-for="MessagesDelay"></label>
                     <i class='fas fa-question-circle ms-2' title='Alert notifications aggregation period in seconds.'></i>
                 </div>
-                <div class="col-4 p-0">
+                <div class="col-6 p-0">
                     <div class="input-group">
                         <input type="number" class="form-control" asp-for="MessagesDelay">
                         <span class="input-group-text">sec</span>
@@ -140,10 +140,16 @@
                 @if (isTelegramBound)
                 {
                     <a id="sendTestTelegram" data-chat-id="@Model.TelegramChatId" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Telegram message</a>
+                    <a id="removeTelegram" data-chat-id="@Model.Id" class="btn btn-outline-danger" style="cursor: pointer;">Remove Telegram</a>
                 }
                 @if (Model.HasSlack)
                 {
                     <a id="sendTestSlack" data-chat-id="@Model.Id" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Slack message</a>
+                    <a id="removeSlack" data-chat-id="@Model.Id" class="btn btn-outline-danger" style="cursor: pointer;">Remove Slack</a>
+                }
+                @if (Model.HasMattermost)
+                {
+                    <a id="removeMattermost" data-chat-id="@Model.Id" class="btn btn-outline-danger" style="cursor: pointer;">Remove Mattermost</a>
                 }
                 <button type="submit" class="btn btn-primary independentSizeButton my-1">Save</button>
             </div>
@@ -173,6 +179,24 @@
         );
     }
 
+    // Per-channel Remove buttons. Each clears only its channel; the Chat row and the other
+    // channels stay intact. Form reloads to reflect the post-clear state.
+    function removeChannel(channelName, actionUrl, confirmText) {
+        showConfirmationModal(
+            `Removing ${channelName} from chat '@Model.Name'`,
+            confirmText,
+            function () {
+                $.ajax({
+                    type: 'POST',
+                    url: actionUrl + `?id=@Model.Id`,
+                    cache: false,
+                    async: true,
+                    success: function () { window.location.reload(); }
+                });
+            }
+        );
+    }
+
     $(function () {
         $("#sendTestTelegram").off("click").on("click", function () {
             var chatId = $(this).data("chat-id");
@@ -186,6 +210,30 @@
             $.get("@Url.Action(nameof(NotificationsController.SendTestSlackMessage), ViewConstants.NotificationsController)", { id: id })
                 .done(function () { showToast("Test Slack message sent."); })
                 .fail(function () { showToast("Failed to send test Slack message."); });
+        });
+
+        $("#removeTelegram").off("click").on("click", function () {
+            removeChannel(
+                "Telegram binding",
+                "@Url.Action(nameof(NotificationsController.RemoveTelegramBinding), ViewConstants.NotificationsController)",
+                `Telegram binding will be removed from chat '@Model.Name'. The chat itself, its folder bindings, and other channels stay intact.`
+            );
+        });
+
+        $("#removeSlack").off("click").on("click", function () {
+            removeChannel(
+                "Slack webhook",
+                "@Url.Action(nameof(NotificationsController.ClearSlackWebhook), ViewConstants.NotificationsController)",
+                `Slack webhook will be removed from chat '@Model.Name'. The chat itself and other channels stay intact.`
+            );
+        });
+
+        $("#removeMattermost").off("click").on("click", function () {
+            removeChannel(
+                "Mattermost webhook",
+                "@Url.Action(nameof(NotificationsController.ClearMattermostWebhook), ViewConstants.NotificationsController)",
+                `Mattermost webhook will be removed from chat '@Model.Name'. The chat itself and other channels stay intact.`
+            );
         });
     });
 </script>

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -5,6 +5,7 @@ import { uniqueName, cleanup } from '../fixtures.ts';
 
 const folderName = uniqueName('Fldr');
 const slackChatName = uniqueName('SlackChat');
+const slackRemoveChatName = uniqueName('SlackRm');
 // XSS payload used as chat Name. Cleanup by text still works because Razor default-encodes
 // @chat.Name into the Configuration/_Chats.cshtml row's first td, so the literal payload text
 // appears in the DOM. The onerror handler would set window.__xss=1 if it ever executed.
@@ -17,6 +18,7 @@ test.afterEach(async ({ browser }) => {
   try {
     await login(page, testConfig.admin_user, testConfig.admin_user_password, testConfig.apiUrl);
     await cleanup.chat(page, slackChatName);
+    await cleanup.chat(page, slackRemoveChatName);
     await cleanup.chat(page, xssChatName);
     await cleanup.folder(page, folderName);
   } finally {
@@ -130,6 +132,58 @@ test('Folder Chats picker renders chat.Name as inert text (XSS lock-down)', asyn
   // the payload is text-only and the property stays undefined.
   const xssMarker = await page.evaluate(() => (window as any).__xss);
   expect(xssMarker).toBeUndefined();
+
+  // --- Logout ---
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+
+
+// Covers issue #1271: per-channel Remove buttons on the EditChat form. The Slack "Remove" button
+// must clear only the Slack webhook and leave the Chat row intact. Pre-#1271 the only destructive
+// action was the header-level "Remove chat" link, which deletes the whole record.
+test('EditChat: per-channel Remove clears Slack webhook without deleting the chat', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password } = testConfig;
+
+  // --- Login ---
+  await login(page, admin_user, admin_user_password, apiUrl);
+
+  // --- Create a Slack chat via the unified Chats tab ---
+  await page.getByRole('link', { name: 'Configuration' }).click();
+  await page.getByRole('tab', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(slackRemoveChatName);
+  await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/remove-test');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // AddChat POST redirects to Configuration. Reopen the Chats tab and click into EditChat via
+  // the row's action dropdown (matches the row pattern in _Chats.cshtml:53-86).
+  await page.getByRole('tab', { name: 'Chats' }).click();
+  const chatRow = page.getByRole('row').filter({ hasText: slackRemoveChatName });
+  await expect(chatRow).toBeVisible();
+  await chatRow.locator('#actionButton').click();
+  await page.getByRole('link', { name: 'View/Edit' }).click();
+
+  // EditChat should show the populated webhook and a "Remove Slack" button alongside the
+  // existing "Send test Slack message" button.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/remove-test');
+  await expect(page.locator('#removeSlack')).toBeVisible();
+
+  // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and the
+  // page reloads (EditChat.cshtml removeChannel success handler).
+  await page.locator('#removeSlack').click();
+  await page.getByRole('button', { name: 'OK' }).click();
+
+  // After reload, the webhook field is empty and the per-channel Remove button is gone
+  // (HasSlack is now false). The chat still exists — only the webhook was cleared.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('');
+  await expect(page.locator('#removeSlack')).toHaveCount(0);
+  await expect(page.getByRole('heading', { name: /Edit chat/ })).toBeVisible();
+
+  // The Chats list must still contain the row — channel clear ≠ chat delete (acceptance #4).
+  await page.getByRole('link', { name: 'Configuration' }).click();
+  await page.getByRole('tab', { name: 'Chats' }).click();
+  await expect(page.getByRole('row').filter({ hasText: slackRemoveChatName })).toBeVisible();
 
   // --- Logout ---
   await page.getByRole('link', { name: 'Logout' }).click();

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -170,9 +170,12 @@ test('EditChat: per-channel Remove clears Slack webhook without deleting the cha
   await expect(page.locator('#removeSlack')).toBeVisible();
 
   // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and the
-  // page reloads (EditChat.cshtml removeChannel success handler).
+  // page reloads (EditChat.cshtml removeChannel success handler). Wait for the reload to land
+  // before asserting — otherwise the auto-waiting toHaveValue('') can race against the
+  // still-rendering previous DOM and flake.
   await page.locator('#removeSlack').click();
   await page.getByRole('button', { name: 'OK' }).click();
+  await page.waitForLoadState('domcontentloaded');
 
   // After reload, the webhook field is empty and the per-channel Remove button is gone
   // (HasSlack is now false). The chat still exists — only the webhook was cleared.

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs
@@ -144,6 +144,88 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Equal(ConnectedChatType.TelegramPrivate, reloaded.TelegramType);
         }
 
+        // ApplyUpdate uses `?? current` for SlackWebhookUrl, so a null update value means "don't
+        // change" — submitting an empty webhook through EditChat cannot clear a saved value. The
+        // ClearSlackWebhook flag routes around that. Pinned because the EditChat "Remove Slack"
+        // button depends on it (issue #1271).
+        [Fact]
+        public async Task TryUpdate_ClearSlackWebhook_FlagSetsFieldToNull()
+        {
+            var manager = BuildManager();
+            var chat = BuildSlackOnlyChat();
+            await manager.TryAdd(chat);
+            await manager.TryUpdate(new ChatUpdate
+            {
+                Id = chat.Id,
+                SlackWebhookUrl = "https://hooks.slack.com/services/test",
+            });
+
+            var cleared = await manager.TryUpdate(new ChatUpdate { Id = chat.Id, ClearSlackWebhook = true });
+
+            Assert.True(cleared);
+            Assert.Null(manager[chat.Id].SlackWebhookUrl);
+        }
+
+        [Fact]
+        public async Task TryUpdate_ClearMattermostWebhook_FlagSetsFieldToNull()
+        {
+            var manager = BuildManager();
+            var chat = BuildSlackOnlyChat();
+            await manager.TryAdd(chat);
+            await manager.TryUpdate(new ChatUpdate
+            {
+                Id = chat.Id,
+                MattermostWebhookUrl = "https://mattermost.example/hooks/test",
+            });
+
+            var cleared = await manager.TryUpdate(new ChatUpdate { Id = chat.Id, ClearMattermostWebhook = true });
+
+            Assert.True(cleared);
+            Assert.Null(manager[chat.Id].MattermostWebhookUrl);
+        }
+
+        // ClearTelegramBinding must null all three Telegram fields and drop the chat from the
+        // _telegramChatIds index — otherwise GetChatByChatId would still return the chat and the
+        // next bot invite for the same Telegram chat would collide with the ghost entry.
+        [Fact]
+        public async Task TryUpdate_ClearTelegramBinding_FlagClearsFieldsAndRekeysIndex()
+        {
+            const long knownChatId = 42L;
+            var manager = BuildManager();
+            var chat = BuildTelegramChat(knownChatId);
+            await manager.TryAdd(chat);
+
+            Assert.NotNull(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(knownChatId)));
+
+            var cleared = await manager.TryUpdate(new ChatUpdate { Id = chat.Id, ClearTelegramBinding = true });
+
+            Assert.True(cleared);
+            Assert.Null(manager[chat.Id].TelegramChatId);
+            Assert.Null(manager[chat.Id].TelegramType);
+            Assert.Null(manager[chat.Id].AuthorizationTime);
+            Assert.Null(manager.GetChatByChatId(new Telegram.Bot.Types.ChatId(knownChatId)));
+        }
+
+        // ToEntity() gates the Telegram block on `TelegramType.HasValue` — so after ClearTelegramBinding
+        // the entity round-trip must omit TelegramType / TelegramChatId / AuthorizationTime entirely.
+        // Without this, reloading the chat from storage would resurrect the cleared binding.
+        [Fact]
+        public async Task Chat_AfterClearTelegramBinding_ToEntityOmitsTelegramFields()
+        {
+            const long knownChatId = 99L;
+            var manager = BuildManager();
+            var chat = BuildTelegramChat(knownChatId);
+            await manager.TryAdd(chat);
+
+            await manager.TryUpdate(new ChatUpdate { Id = chat.Id, ClearTelegramBinding = true });
+
+            var entity = manager[chat.Id].ToEntity();
+
+            Assert.Null(entity.TelegramType);
+            Assert.Null(entity.TelegramChatId);
+            Assert.Null(entity.AuthorizationTime);
+        }
+
 
         private static ChatsManager BuildManager()
         {


### PR DESCRIPTION
## Summary

Closes #1271. Two rough edges in the unified `EditChat` form shipped in #1262:

1. **Field alignment** — `EnableMessages` switch and `MessagesDelay` input used `col-4` while every sibling row used `col-6`, causing them to render shifted left. Both changed to `col-6` in `EditChat.cshtml:73,83`.

2. **Per-channel Remove buttons** — previously the only destructive action was the header "Remove chat" link, which deletes the whole `Chat`. Now each configured channel (Telegram / Slack / Mattermost) has its own Remove button in the footer button group on the right, next to the existing Send-test buttons. Each button clears only its channel; the `Chat` row, folder bindings, and other channels stay intact.

### Backend

- `ChatUpdate` gains `ClearTelegramBinding` / `ClearSlackWebhook` / `ClearMattermostWebhook` nullable-bool flags. The existing `??` coalescing in `Chat.ApplyUpdate` swallows nulls (a null update value means "don't change"), so submitting an empty webhook through EditChat cannot clear a saved value today — these explicit flags route around that.
- `Chat.TelegramType` and `Chat.AuthorizationTime` move from `init` to `internal set` so `ApplyUpdate` can null them on clear (existing object initializers in `ChatsManager.TryConnect` and `ChatsManagerTests` still compile via `InternalsVisibleTo`). `Chat.ToEntity()` already gated the Telegram block on `TelegramType.HasValue`, so the cleared fields drop from the entity on round-trip.
- Three new `NotificationsController` endpoints (`RemoveTelegramBinding` / `ClearSlackWebhook` / `ClearMattermostWebhook`), each `[HttpPost]` + `[TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]` (same auth as `RemoveChat`). Routes through `ChatsManager.TryUpdate` so the `Updated` event fires for `NotificationsCenter`/`SlackNotificationChannel` subscribers and `_telegramChatIds` index is rekeyed by the existing override.

### Frontend (`EditChat.cshtml`)

- Alignment fix at lines 73, 83 (`col-4` → `col-6`).
- Header "Remove" link relabeled to "Remove chat" to clarify vs. the new per-channel buttons.
- Footer button group extended with `Remove Telegram` / `Remove Slack` / `Remove Mattermost` buttons (channel-grouped with their Send-test sibling; `btn-outline-danger` to distinguish from `btn-outline-secondary`). Each is gated by `isTelegramBound` / `Model.HasSlack` / `Model.HasMattermost` so it only renders for configured channels.
- Single `removeChannel(channelName, actionUrl, confirmText)` JS helper mirrors the existing `removeChat()` pattern: `showConfirmationModal()` → AJAX POST → `window.location.reload()`.
- `HasMattermost` already existed on `ChatViewModel.cs:55` — issue body was wrong about needing to add it.

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.csproj` — 0 errors (33 pre-existing warnings)
- [x] `dotnet test --filter ChatsManagerTests` — 12/12 pass (8 existing + 4 new):
  - `TryUpdate_ClearSlackWebhook_FlagSetsFieldToNull`
  - `TryUpdate_ClearMattermostWebhook_FlagSetsFieldToNull`
  - `TryUpdate_ClearTelegramBinding_FlagClearsFieldsAndRekeysIndex`
  - `Chat_AfterClearTelegramBinding_ToEntityOmitsTelegramFields`
- [x] Full `HSMServer.Core.Tests` suite — 506/508 pass (the 2 failures are `AgentInstallerBundleTests.StaticUninstallScript_MatchesGenerated`, unrelated to this PR — they fail only when running from isolated `-o /tmp/...` output because `RepoFile()` can't walk up to the repo root; pass in normal CI)
- [ ] Playwright `modify_folder_chat.spec.ts` — 3 tests (existing 2 + new `EditChat: per-channel Remove clears Slack webhook without deleting the chat`). CI must confirm.
- [ ] Manual smoke (run server locally):
  - Open EditChat for a Slack-only chat → observe `EnableMessages` switch and `MessagesDelay` input align horizontally with `Name`/`Description`/`SlackWebhookUrl`/`MattermostWebhookUrl`
  - Click "Remove Slack" → confirm modal → form reloads with empty webhook field, "Remove Slack" button gone, chat row still present in Chats list
  - Open EditChat for a Telegram-bound chat → "Remove Telegram" clears Telegram binding; re-invite via bot works afterward
  - Header "Remove chat" still deletes the whole record

## Out of scope (noted in issue)

- **Accumulator flush on channel clear** — when a webhook is cleared, the per-channel `ChannelAccumulator` may still hold buffered alerts. `Chat.SlackAccumulator`/`TelegramAccumulator` return `null` when the channel is cleared (`Chat.cs:49-51`), so dispatch already skips them; no incorrect delivery. Buffer is memory-only and bounded by the aggregation period. Defer to a follow-up.
- **Mattermost notification channel implementation** — the Remove-Mattermost button is wired and gated behind `HasMattermost` so it appears only if legacy/test data has the field set; stays hidden in normal use until the channel ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)