### PR TITLE
Promote Chats to top-level Configuration menu entry

### DIFF
--- a/src/server/HSMServer/Controllers/ConfigurationController.cs
+++ b/src/server/HSMServer/Controllers/ConfigurationController.cs
@@ -2,7 +2,6 @@
 using HSMServer.BackgroundServices;
 using HSMServer.Model.Configuration;
 using HSMServer.Notifications;
-using HSMServer.Notifications.Chats;
 using HSMServer.ServerConfiguration;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -20,14 +19,14 @@ namespace HSMServer.Controllers
     [Authorize]
     [AuthorizeIsAdmin]
     [ResponseCache(NoStore = true, Location = ResponseCacheLocation.None)]
-    public class ConfigurationController(IServerConfig config, NotificationsCenter notifications, BackupDatabaseService backupService, IDatabaseCore database, IChatsManager chats) : Controller
+    public class ConfigurationController(IServerConfig config, NotificationsCenter notifications, BackupDatabaseService backupService, IDatabaseCore database) : Controller
     {
         private readonly TelegramBot _telegramBot = notifications.TelegramBot;
 
         protected readonly Logger _logger = LogManager.GetLogger(typeof(ConfigurationController).Name);
 
 
-        public IActionResult Index() => View(new ConfigurationViewModel(config, _telegramBot.IsBotRunning, database, chats));
+        public IActionResult Index() => View(new ConfigurationViewModel(config, _telegramBot.IsBotRunning, database));
 
         [HttpPost]
         public IActionResult SaveServerSettings(ServerSettingsViewModel settings)

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -6,6 +6,7 @@ using HSMServer.Filters.TelegramRoleFilters;
 using HSMServer.Folders;
 using HSMServer.Model.Authentication;
 using HSMServer.Model.Folders;
+using HSMServer.Model.Configuration;
 using HSMServer.Model.Notifications;
 using HSMServer.Notifications;
 using HSMServer.Notifications.Chats;
@@ -61,6 +62,10 @@ namespace HSMServer.Controllers
 
         [HttpGet]
         [AuthorizeIsAdmin]
+        public IActionResult Index() => View(nameof(Index), new ChatsSettingsViewModel(ChatsManager));
+
+        [HttpGet]
+        [AuthorizeIsAdmin]
         public IActionResult AddChat() => View(nameof(EditChat), new ChatViewModel { EnableMessages = true });
 
         [HttpPost]
@@ -78,7 +83,7 @@ namespace HSMServer.Controllers
                 await SyncFolders(model);
             }
 
-            return RedirectToAction(nameof(ConfigurationController.Index), ViewConstants.ConfigurationController);
+            return RedirectToAction(nameof(Index), ViewConstants.NotificationsController);
         }
 
         [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]

--- a/src/server/HSMServer/Helpers/UserRoleHelper.cs
+++ b/src/server/HSMServer/Helpers/UserRoleHelper.cs
@@ -35,6 +35,11 @@ namespace HSMServer.Helpers
             return user.IsAdmin;
         }
 
+        public static bool IsChatsPageAllowed(User user)
+        {
+            return user.IsAdmin;
+        }
+
         public static bool IsManager(User user)
         {
             return user.ProductsRoles.Any(x => x.Item2 == ProductRoleEnum.ProductManager);

--- a/src/server/HSMServer/Model/Configuration/ConfigurationViewModel.cs
+++ b/src/server/HSMServer/Model/Configuration/ConfigurationViewModel.cs
@@ -1,5 +1,4 @@
-﻿using HSMServer.Core.DataLayer;
-using HSMServer.Notifications.Chats;
+using HSMServer.Core.DataLayer;
 using HSMServer.ServerConfiguration;
 using System;
 using System.Collections.Generic;
@@ -7,15 +6,13 @@ using System.Linq;
 
 namespace HSMServer.Model.Configuration
 {
-    public class ConfigurationViewModel(IServerConfig config, bool isBotRunning, IDatabaseCore database, IChatsManager chats)
+    public class ConfigurationViewModel(IServerConfig config, bool isBotRunning, IDatabaseCore database)
     {
         public ServerSettingsViewModel Server { get; } = new(config);
 
         public BackupSettingsViewModel Backup { get; } = new(config);
 
         public TelegramSettingsViewModel Telegram { get; } = new(config, isBotRunning);
-
-        public ChatsSettingsViewModel Chats { get; } = new(chats);
 
         public MonitoringSettingsViewModel Monitoring { get; } = new(config);
 

--- a/src/server/HSMServer/Views/Configuration/Index.cshtml
+++ b/src/server/HSMServer/Views/Configuration/Index.cshtml
@@ -28,9 +28,6 @@
                 <button class="nav-link" id="telegram-tab" data-bs-toggle="tab" data-bs-target="#telegram" type="button" role="tab" aria-controls="telegram" aria-selected="false">Telegram</button>
             </li>
             <li class="nav-item" role="presentation">
-                <button class="nav-link" id="chats-tab" data-bs-toggle="tab" data-bs-target="#chats" type="button" role="tab" aria-controls="chats" aria-selected="false">Chats</button>
-            </li>
-            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="database-tab" data-bs-toggle="tab" data-bs-target="#database" type="button" role="tab" aria-controls="database" aria-selected="false">Database</button>
             </li>
             <li class="nav-item" role="presentation">
@@ -60,10 +57,6 @@
                 <form id="telegramSettings_form" asp-action="@nameof(ConfigurationController.SaveTelegramSettings)">
                     @await Html.PartialAsync("_Telegram", Model.Telegram)
                 </form>
-            </div>
-
-            <div class="tab-pane fade" id="chats" role="tabpanel" aria-labelledby="chats-tab">
-                @await Html.PartialAsync("_Chats", Model.Chats)
             </div>
 
             <div class="tab-pane fade" id="database" role="tabpanel" aria-labelledby="database-tab">

--- a/src/server/HSMServer/Views/Notifications/Index.cshtml
+++ b/src/server/HSMServer/Views/Notifications/Index.cshtml
@@ -1,0 +1,20 @@
+@using HSMServer.Constants
+@using HSMServer.Controllers
+@using HSMServer.Model.Configuration
+
+@model ChatsSettingsViewModel
+
+@{
+    ViewData["Title"] = "Notification chats";
+}
+
+
+<div class="container">
+    <div class="row w-100 justify-content-center">
+        <div class="d-flex justify-content-start my-3 p-0">
+            <h5>Notification chats</h5>
+        </div>
+
+        @await Html.PartialAsync("~/Views/Configuration/_Chats.cshtml", Model)
+    </div>
+</div>

--- a/src/server/HSMServer/Views/Notifications/Index.cshtml
+++ b/src/server/HSMServer/Views/Notifications/Index.cshtml
@@ -1,5 +1,3 @@
-@using HSMServer.Constants
-@using HSMServer.Controllers
 @using HSMServer.Model.Configuration
 
 @model ChatsSettingsViewModel
@@ -11,10 +9,6 @@
 
 <div class="container">
     <div class="row w-100 justify-content-center">
-        <div class="d-flex justify-content-start my-3 p-0">
-            <h5>Notification chats</h5>
-        </div>
-
         @await Html.PartialAsync("~/Views/Configuration/_Chats.cshtml", Model)
     </div>
 </div>

--- a/src/server/HSMServer/Views/Shared/_Layout.cshtml
+++ b/src/server/HSMServer/Views/Shared/_Layout.cshtml
@@ -112,6 +112,14 @@
                                                         </a>
                                                     </li>
                                                 }
+                                                @if (UserRoleHelper.IsChatsPageAllowed((User)Context.User))
+                                                {
+                                                    <li>
+                                                        <a class="dropdown-item" href="@Url.Action(ViewConstants.IndexAction, ViewConstants.NotificationsController)">
+                                                            <i class="fas fa-comments me-2"></i>Chats
+                                                        </a>
+                                                    </li>
+                                                }
                                                 <li><hr class="dropdown-divider"></li>
                                                 @if (UserRoleHelper.IsConfigurationPageAllowed((User)Context.User))
                                                 {

--- a/src/tests/Autotests/fixtures.ts
+++ b/src/tests/Autotests/fixtures.ts
@@ -69,11 +69,11 @@ export const cleanup = {
 
   async chat(page: Page, chatName: string): Promise<void> {
     try {
-      // Chats are listed under Configuration → Chats. The remove handler shows a window.confirm()
-      // dialog; waitForEvent('dialog') accepts it inline so we don't leak a page.on listener
-      // across multiple cleanup.chat calls in the same afterEach.
-      await page.goto('/Configuration');
-      await page.getByRole('tab', { name: 'Chats' }).click();
+      // Chats live on the top-level /Notifications page (promoted from a Settings tab in #1273).
+      // The remove handler shows a window.confirm() dialog; waitForEvent('dialog') accepts it
+      // inline so we don't leak a page.on listener across multiple cleanup.chat calls in the
+      // same afterEach.
+      await page.goto('/Notifications');
       const row = page.getByRole('row').filter({ hasText: chatName });
       if (await row.count() === 0) return;
       await row.first().locator('#actionButton').click();

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -69,8 +69,8 @@ test('Folder Chats tab: Add-chat dropdown offers Telegram help and Slack webhook
   await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/test');
   await page.getByRole('button', { name: 'Save' }).click();
 
-  // AddChat POST redirects to Configuration. Verify the chat landed in the unified Chats list.
-  await page.getByRole('tab', { name: 'Chats' }).click();
+  // AddChat POST redirects to /Notifications (the top-level Chats page from #1273). Verify the
+  // chat landed in the unified Chats list — no tab click needed, the list IS the page.
   await expect(page.getByRole('row').filter({ hasText: slackChatName })).toBeVisible();
 
   // --- Logout ---
@@ -92,8 +92,9 @@ test('Folder Chats picker renders chat.Name as inert text (XSS lock-down)', asyn
 
   // --- Create a Slack chat whose Name is an XSS payload ---
   // Slack path is used because EditChat.cshtml leaves Name editable for non-Telegram-bound chats.
+  // Chats was promoted to a top-level Configuration dropdown entry in #1273 (was a Settings tab).
   await page.getByRole('link', { name: 'Configuration' }).click();
-  await page.getByRole('tab', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
   await page.getByRole('link', { name: 'Add new chat' }).click();
   await page.locator('#Name').fill(xssChatName);
   await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/xss');

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -93,8 +93,11 @@ test('Folder Chats picker renders chat.Name as inert text (XSS lock-down)', asyn
   // --- Create a Slack chat whose Name is an XSS payload ---
   // Slack path is used because EditChat.cshtml leaves Name editable for non-Telegram-bound chats.
   // Chats was promoted to a top-level Configuration dropdown entry in #1273 (was a Settings tab).
-  await page.getByRole('link', { name: 'Configuration' }).click();
+  // Configuration toggle uses role="button" (Bootstrap dropdown-toggle pattern, see users.ts:4);
+  // getByRole('link') would miss it because the explicit ARIA role wins over the <a> tag default.
+  await page.getByRole('button', { name: 'Configuration' }).click();
   await page.getByRole('link', { name: 'Chats' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
   await page.getByRole('link', { name: 'Add new chat' }).click();
   await page.locator('#Name').fill(xssChatName);
   await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/xss');

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -69,8 +69,10 @@ test('Folder Chats tab: Add-chat dropdown offers Telegram help and Slack webhook
   await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/test');
   await page.getByRole('button', { name: 'Save' }).click();
 
-  // AddChat POST redirects to /Notifications (the top-level Chats page from #1273). Verify the
-  // chat landed in the unified Chats list — no tab click needed, the list IS the page.
+  // AddChat POST redirects to /Notifications (the top-level Chats page from #1273). Assert the URL
+  // first — if TryAdd silently fails or the redirect changes, the row check below would surface as
+  // an opaque "row not found" instead of a clear URL mismatch.
+  await expect(page).toHaveURL(/.*Notifications/);
   await expect(page.getByRole('row').filter({ hasText: slackChatName })).toBeVisible();
 
   // --- Logout ---


### PR DESCRIPTION
## Summary

Chats was the 5th tab inside Configuration/Settings, even though Users and Access keys already have their own top-level entries in the Configuration dropdown. This PR moves Chats to `/Notifications` (`NotificationsController.Index`) and links to it from the Configuration dropdown right after Users, above the divider. Settings (server config) and API (docs) stay below.

The new `Index` view renders the existing `Configuration/_Chats.cshtml` partial — same table layout, row actions, and Add-new-chat link as before. `Folders/EditFolder` keeps its own folder-scoped Chats tab (different partial at `Views/Folders/_Chats.cshtml`) untouched.

## Changes

- `NotificationsController.Index` — new `[HttpGet][AuthorizeIsAdmin]` action returning `View(new ChatsSettingsViewModel(ChatsManager))`.
- `Views/Notifications/Index.cshtml` — new wrapper view rendering the partial.
- `Views/Shared/_Layout.cshtml` — new Chats `<li>` in Configuration dropdown after Users, gated by `IsChatsPageAllowed`.
- `UserRoleHelper.IsChatsPageAllowed` — new helper mirroring `IsUsersPageAllowed` / `IsConfigurationPageAllowed` (admin-only).
- `Configuration/Index.cshtml` — chats-tab button + pane removed.
- `ConfigurationViewModel` — `Chats` property + `IChatsManager chats` ctor param dropped.
- `ConfigurationController` — `IChatsManager chats` DI param + `using` dropped.
- `NotificationsController.AddChat` POST — redirect target switched from `ConfigurationController.Index` → `nameof(Index)`.
- Playwright: `fixtures.ts` `cleanup.chat` now navigates to `/Notifications`; `modify_folder_chat.spec.ts` test 2 selector switched from tab to dropdown link; test 1 post-Save tab click removed (redirect lands on the chats list directly).

## Test plan

- [ ] `dotnet build src/server/HSMServer/HSMServer.csproj` — 0 errors (verified locally).
- [ ] Login as admin → Configuration dropdown shows: Access keys, Users, **Chats**, divider, Settings, API.
- [ ] Click Chats → URL is `/Notifications`, chats table renders, Add-new-chat + per-row action dropdown work.
- [ ] Settings page (`/Configuration`) no longer has a Chats tab.
- [ ] Add new chat → after Save, lands on `/Notifications` with the new chat in the list.
- [ ] Folder edit page → Chats tab still renders the folder-scoped picker (unchanged).
- [ ] Non-admin user does not see the Chats menu entry.
- [ ] `npx playwright test modify_folder_chat.spec.ts` — both tests green.

Closes #1273

🤖 Generated with [Claude Code](https://claude.com/claude-code)