### PR TITLE
hsm-collector: release guardrails + documented release procedure

### DIFF
--- a/.github/workflows/hsm-collector-registry-publish.yml
+++ b/.github/workflows/hsm-collector-registry-publish.yml
@@ -74,6 +74,7 @@ jobs:
         id: sha
         env:
           TAG: ${{ steps.v.outputs.tag }}
+          VER: ${{ steps.v.outputs.ver }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -86,6 +87,15 @@ jobs:
           if [ "${#sha}" -ne 128 ] || [ "$sha" = "$empty" ]; then
             echo "::error::bad SHA512 for $url (does the tag exist?)"; exit 1
           fi
+
+          # The tagged source must actually declare the version being published, otherwise the registry
+          # would advertise a version the library doesn't identify as (see scripts/check-collector-version.py).
+          srcver=$(tar -xzOf source.tgz --wildcards '*/src/native/collector/CMakeLists.txt' 2>/dev/null \
+                   | sed -nE 's/.*project\(HsmCollectorNative VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -1)
+          if [ "$srcver" != "$VER" ]; then
+            echo "::error::tag $TAG points at source declaring version '${srcver:-<unreadable>}', not $VER"; exit 1
+          fi
+
           rm -f source.tgz
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
@@ -106,9 +116,14 @@ jobs:
           sed -i -E "s|SHA512 [0-9a-f]{128}|SHA512 ${SHA}|" ports/hsm-collector/portfile.cmake
           sed -i -E "s|(\"version\"[[:space:]]*:[[:space:]]*\")[0-9]+\.[0-9]+\.[0-9]+(\")|\1${VER}\2|" ports/hsm-collector/vcpkg.json
 
-          # Commit the port first so the recorded git-tree is the NEW port content.
+          # Commit the port first so the recorded git-tree is the NEW port content. --allow-empty because
+          # re-publishing an already-current version leaves the port byte-identical (a legitimate no-op
+          # re-run, and what a dry_run of the current version does) - `git commit` would otherwise abort.
           git add ports/hsm-collector
-          git commit -q -m "vcpkg registry: publish hsm-collector ${VER}"
+          if git diff --cached --quiet; then
+            echo "::notice::ports/hsm-collector already matches ${VER} - nothing to change."
+          fi
+          git commit -q --allow-empty -m "vcpkg registry: publish hsm-collector ${VER}"
           tree=$(git rev-parse "HEAD:ports/hsm-collector")
 
           VER="$VER" TREE="$tree" python3 - <<'PY'

--- a/.github/workflows/hsm-collector-registry-publish.yml
+++ b/.github/workflows/hsm-collector-registry-publish.yml
@@ -89,14 +89,14 @@ jobs:
           fi
 
           # The tagged source must actually declare the version being published, otherwise the registry
-          # would advertise a version the library doesn't identify as (see scripts/check-collector-version.py).
-          srcver=$(tar -xzOf source.tgz --wildcards '*/src/native/collector/CMakeLists.txt' 2>/dev/null \
-                   | sed -nE 's/.*project\(HsmCollectorNative VERSION ([0-9]+\.[0-9]+\.[0-9]+).*/\1/p' | head -1)
-          if [ "$srcver" != "$VER" ]; then
-            echo "::error::tag $TAG points at source declaring version '${srcver:-<unreadable>}', not $VER"; exit 1
-          fi
+          # would advertise a version the library doesn't identify as. Reuse the very checker the
+          # version-check lane runs (against the unpacked tarball) so both gates agree on what a valid
+          # declaration looks like - a second, subtly different parser here would drift.
+          mkdir -p srcx && tar -xzf source.tgz -C srcx
+          srcroot=$(find srcx -mindepth 1 -maxdepth 1 -type d | head -1)
+          python3 scripts/check-collector-version.py --root "$srcroot" --tag "$TAG"
 
-          rm -f source.tgz
+          rm -rf srcx source.tgz
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
 
       - name: Prepare registry update

--- a/.github/workflows/hsm-collector-version-check.yml
+++ b/.github/workflows/hsm-collector-version-check.yml
@@ -1,0 +1,29 @@
+name: hsm-collector version check
+
+# The native collector's version is declared in four hand-maintained places that must move together
+# (CMakeLists project VERSION, the C ABI header, the overlay vcpkg port, the conan recipe). Forgetting
+# one silently ships a mismatched package - it already happened once (port + conan stuck at 0.4.0 while
+# the library was 0.6.2), so gate it in CI instead of relying on memory.
+#
+# See docs/releasing-hsm-collector.md for the release procedure.
+
+on:
+  push:
+    paths:
+      - 'src/native/collector/**'
+      - 'scripts/check-collector-version.py'
+      - '.github/workflows/hsm-collector-version-check.yml'
+  pull_request:
+    paths:
+      - 'src/native/collector/**'
+      - 'scripts/check-collector-version.py'
+      - '.github/workflows/hsm-collector-version-check.yml'
+  workflow_dispatch:
+
+jobs:
+  version-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Collector version is consistent across all declarations
+        run: python3 scripts/check-collector-version.py

--- a/docs/releasing-hsm-collector.md
+++ b/docs/releasing-hsm-collector.md
@@ -1,0 +1,112 @@
+# Releasing the native C++ collector (`hsm-collector`)
+
+How to publish a new version of the native collector (`src/native/collector`) so downstream projects
+can consume it. This is the **maintainer** procedure; consumers only need the wiki page
+[C++ Data Collector](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/wiki/Cpp-Data-Collector).
+
+> **A release here is a git tag + a registry entry — not a GitHub Release with binaries.** This
+> repository *is* a [vcpkg registry](https://learn.microsoft.com/vcpkg/produce/publish-to-a-git-registry):
+> consumers run `vcpkg install hsm-collector`, and vcpkg builds it from the tagged source. There is
+> nothing to upload.
+
+---
+
+## The version lives in four places
+
+They must always move together. CI enforces it (`hsm-collector version check`), and you can check
+locally at any time:
+
+```bash
+python scripts/check-collector-version.py
+```
+
+| File | Declaration |
+|---|---|
+| `src/native/collector/CMakeLists.txt` | `project(HsmCollectorNative VERSION X.Y.Z …)` |
+| `src/native/collector/include/hsm_collector/hsm_collector.h` | `HSM_COLLECTOR_VERSION_MAJOR/MINOR/PATCH` (the C ABI semver) |
+| `src/native/collector/vcpkg-port/vcpkg.json` | overlay port used by CI |
+| `src/native/collector/conanfile.py` | conan recipe |
+
+`ports/hsm-collector/` and `versions/` (the registry itself) are **not** in that list — the publish
+automation rewrites them for you.
+
+---
+
+## Procedure
+
+### 1. Change the code and bump the version
+
+Make your change in `src/native/collector/`, then bump all four declarations above in the *same* PR.
+Semver against the **C ABI**: patch = fixes, minor = additive API, major = breaking ABI.
+
+### 2. Merge to `master`
+
+Normal PR flow. The version-check lane fails the PR if the four declarations disagree.
+
+### 3. Tag the merged commit
+
+```bash
+git fetch origin master
+git tag collector-v0.6.3 origin/master     # tag name must match the version you just bumped to
+git push origin collector-v0.6.3
+```
+
+### 4. The automation opens a registry PR
+
+Pushing the tag triggers
+[`hsm-collector-registry-publish`](../.github/workflows/hsm-collector-registry-publish.yml), which:
+
+1. downloads the tag's source tarball and computes its SHA512,
+2. verifies the tagged source really declares that version,
+3. rewrites `ports/hsm-collector/` (`REF`, `SHA512`, `version`),
+4. updates `versions/` (baseline + `version` → `git-tree`), advancing the baseline only,
+5. builds and installs the updated port (`hsm-collector[http]`) to prove it resolves, and
+6. opens a PR.
+
+### 5. Run the Windows check, then merge that PR
+
+The auto-PR is opened with `GITHUB_TOKEN`, so GitHub will **not** auto-trigger the consumer check on
+it. Run it by hand before merging:
+
+**Actions → `hsm-collector vcpkg registry` → Run workflow → pick the `registry/hsm-collector-<ver>`
+branch.** (The publish run itself only validated on Linux; this lane is the Windows/MSVC path.)
+
+Merge once it is green. **The version is live for consumers at that moment.**
+
+### 6. Tell consumers (optional)
+
+They pick it up with:
+
+```bash
+vcpkg x-update-baseline    # moves their registry baseline to your newest commit
+vcpkg install hsm-collector[http]
+```
+
+---
+
+## Doing it manually (if the automation is unavailable)
+
+The automation only saves typing; the same result by hand:
+
+1. `curl -fsSL https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/archive/collector-v0.6.3.tar.gz | sha512sum`
+2. In `ports/hsm-collector/portfile.cmake` set `REF collector-v0.6.3` and that `SHA512`; set `version`
+   in `ports/hsm-collector/vcpkg.json`.
+3. Commit the port, then record its tree: `git rev-parse HEAD:ports/hsm-collector`.
+4. Add `{ "version": "0.6.3", "git-tree": "<that tree>" }` to the **front** of
+   `versions/h-/hsm-collector.json`, and set `baseline` in `versions/baseline.json`.
+5. PR it, and run the `hsm-collector vcpkg registry` check.
+
+(Equivalent to `vcpkg x-add-version hsm-collector`, if you have vcpkg to hand.)
+
+---
+
+## Notes and limits
+
+- **Port-only fixes** (changing the portfile without a source change) need a `port-version` bump and
+  are done by hand — the automation publishes source versions only.
+- **Re-running for an already-published version** is a safe no-op, *unless* the source content changed:
+  vcpkg treats a `version` → `git-tree` mapping as immutable, so the run refuses rather than rewriting
+  history. Bump the version instead.
+- **Two publishes open at once** will conflict in `versions/` — merge the first, rebase the second.
+- **Never move or delete a `collector-v*` tag.** Consumers' pinned SHA512 is computed from that exact
+  tarball; recreating the tag breaks every pinned install.

--- a/scripts/check-collector-version.py
+++ b/scripts/check-collector-version.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Check that the native collector's version is declared consistently everywhere.
+
+The version lives in four hand-maintained places that must move together; forgetting one publishes a
+mismatched package (this already happened once: the vcpkg port and conan recipe sat at 0.4.0 while the
+library was 0.6.2). The registry port and version database are NOT checked here — those are rewritten
+by the hsm-collector-registry-publish workflow.
+
+    python scripts/check-collector-version.py
+    python scripts/check-collector-version.py --tag collector-v0.6.3   # also assert a release tag
+"""
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+COLLECTOR = Path(__file__).resolve().parents[1] / "src" / "native" / "collector"
+
+
+def from_cmake():
+    text = (COLLECTOR / "CMakeLists.txt").read_text(encoding="utf-8")
+    m = re.search(r"project\(HsmCollectorNative\s+VERSION\s+(\d+\.\d+\.\d+)", text)
+    return m.group(1) if m else None
+
+
+def from_abi_header():
+    text = (COLLECTOR / "include" / "hsm_collector" / "hsm_collector.h").read_text(encoding="utf-8")
+    parts = []
+    for component in ("MAJOR", "MINOR", "PATCH"):
+        m = re.search(rf"#define\s+HSM_COLLECTOR_VERSION_{component}\s+(\d+)", text)
+        if not m:
+            return None
+        parts.append(m.group(1))
+    return ".".join(parts)
+
+
+def from_overlay_port():
+    return json.loads((COLLECTOR / "vcpkg-port" / "vcpkg.json").read_text(encoding="utf-8")).get("version")
+
+
+def from_conanfile():
+    text = (COLLECTOR / "conanfile.py").read_text(encoding="utf-8")
+    m = re.search(r'^\s*version\s*=\s*"(\d+\.\d+\.\d+)"', text, re.M)
+    return m.group(1) if m else None
+
+
+SOURCES = {
+    "CMakeLists.txt (project VERSION)": from_cmake,
+    "include/hsm_collector/hsm_collector.h (HSM_COLLECTOR_VERSION_*)": from_abi_header,
+    "vcpkg-port/vcpkg.json (overlay port)": from_overlay_port,
+    "conanfile.py (conan recipe)": from_conanfile,
+}
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--tag", help="release tag (collector-vX.Y.Z) that must match the source version")
+    args = parser.parse_args()
+
+    found, unreadable = {}, []
+    for label, read in SOURCES.items():
+        try:
+            value = read()
+        except OSError as ex:
+            value, _ = None, print(f"::error::cannot read {label}: {ex}")
+        if value:
+            found[label] = value
+        else:
+            unreadable.append(label)
+
+    for label, value in found.items():
+        print(f"  {value}\t<- {label}")
+    for label in unreadable:
+        print(f"::error::could not parse a version from {label}")
+    if unreadable:
+        return 1
+
+    distinct = sorted(set(found.values()))
+    if len(distinct) != 1:
+        print(f"::error::collector version is out of sync: {distinct}. Bump every location listed above together.")
+        return 1
+
+    version = distinct[0]
+    print(f"collector version is consistent: {version}")
+
+    if args.tag:
+        expected = args.tag[len("collector-v"):] if args.tag.startswith("collector-v") else args.tag
+        if expected != version:
+            print(f"::error::tag '{args.tag}' does not match the source version {version} - "
+                  f"tag the commit that declares {expected}, or bump the sources first.")
+            return 1
+        print(f"tag '{args.tag}' matches the source version.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check-collector-version.py
+++ b/scripts/check-collector-version.py
@@ -3,11 +3,15 @@
 
 The version lives in four hand-maintained places that must move together; forgetting one publishes a
 mismatched package (this already happened once: the vcpkg port and conan recipe sat at 0.4.0 while the
-library was 0.6.2). The registry port and version database are NOT checked here — those are rewritten
+library was 0.6.2). The registry port and version database are NOT checked here - those are rewritten
 by the hsm-collector-registry-publish workflow.
 
     python scripts/check-collector-version.py
     python scripts/check-collector-version.py --tag collector-v0.6.3   # also assert a release tag
+    python scripts/check-collector-version.py --root /tmp/extracted    # check another checkout
+
+--root lets the publish workflow point this at an unpacked release tarball, so the CI gate and the
+release gate share one definition of "a valid version declaration".
 """
 import argparse
 import json
@@ -15,17 +19,15 @@ import re
 import sys
 from pathlib import Path
 
-COLLECTOR = Path(__file__).resolve().parents[1] / "src" / "native" / "collector"
 
-
-def from_cmake():
-    text = (COLLECTOR / "CMakeLists.txt").read_text(encoding="utf-8")
+def from_cmake(collector):
+    text = (collector / "CMakeLists.txt").read_text(encoding="utf-8")
     m = re.search(r"project\(HsmCollectorNative\s+VERSION\s+(\d+\.\d+\.\d+)", text)
     return m.group(1) if m else None
 
 
-def from_abi_header():
-    text = (COLLECTOR / "include" / "hsm_collector" / "hsm_collector.h").read_text(encoding="utf-8")
+def from_abi_header(collector):
+    text = (collector / "include" / "hsm_collector" / "hsm_collector.h").read_text(encoding="utf-8")
     parts = []
     for component in ("MAJOR", "MINOR", "PATCH"):
         m = re.search(rf"#define\s+HSM_COLLECTOR_VERSION_{component}\s+(\d+)", text)
@@ -35,12 +37,12 @@ def from_abi_header():
     return ".".join(parts)
 
 
-def from_overlay_port():
-    return json.loads((COLLECTOR / "vcpkg-port" / "vcpkg.json").read_text(encoding="utf-8")).get("version")
+def from_overlay_port(collector):
+    return json.loads((collector / "vcpkg-port" / "vcpkg.json").read_text(encoding="utf-8")).get("version")
 
 
-def from_conanfile():
-    text = (COLLECTOR / "conanfile.py").read_text(encoding="utf-8")
+def from_conanfile(collector):
+    text = (collector / "conanfile.py").read_text(encoding="utf-8")
     m = re.search(r'^\s*version\s*=\s*"(\d+\.\d+\.\d+)"', text, re.M)
     return m.group(1) if m else None
 
@@ -56,14 +58,24 @@ SOURCES = {
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--tag", help="release tag (collector-vX.Y.Z) that must match the source version")
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parents[1],
+                        help="repository root to inspect (default: this checkout)")
     args = parser.parse_args()
+
+    collector = args.root / "src" / "native" / "collector"
+    if not collector.is_dir():
+        print(f"::error::no collector sources under {collector}")
+        return 1
 
     found, unreadable = {}, []
     for label, read in SOURCES.items():
         try:
-            value = read()
-        except OSError as ex:
-            value, _ = None, print(f"::error::cannot read {label}: {ex}")
+            value = read(collector)
+        except (OSError, ValueError) as ex:
+            # ValueError covers json.JSONDecodeError: a corrupt manifest must report cleanly, not
+            # crash this gate with a traceback.
+            print(f"::error::cannot read {label}: {ex}")
+            value = None
         if value:
             found[label] = value
         else:


### PR DESCRIPTION
Follow-up to #1267 (vcpkg registry) and #1268 (publish automation). Makes releasing the collector a documented, guarded procedure instead of tribal knowledge.

## Why
The collector version is declared in **four** hand-maintained places and nothing enforced that they agree — they had already drifted (the vcpkg port and conan recipe sat at `0.4.0` while the library was `0.6.2`, fixed in #1267). Forgetting one silently publishes a mismatched package.

## What's here
- **`scripts/check-collector-version.py`** — reads all four declarations (CMakeLists `project VERSION`, the C ABI header, the overlay port, the conan recipe), fails on drift, and with `--tag` asserts a release tag matches the source. Runnable locally; verified it catches the exact historical `0.4.0` vs `0.6.2` drift.
- **`hsm-collector-version-check` workflow** — runs it on any collector change.
- **Publish workflow fixes:**
  - verify the **tagged source actually declares the version being published** (a mistagged commit would otherwise advertise a wrong version);
  - tolerate a **no-op re-publish** — an identical version leaves the port byte-identical, so `git commit` aborted with *"nothing to commit"*. This also blocked `dry_run` runs, i.e. the automation could not be tested at all.
- **`docs/releasing-hsm-collector.md`** — the end-to-end procedure (bump 4 places → merge → tag → automation opens a registry PR → run the Windows check → merge), the manual fallback, and the limits (port-only bumps, immutable tags, concurrent publishes).

## Note on "release"
A release here is a **git tag + registry entry**, not a GitHub Release with binaries — consumers `vcpkg install hsm-collector` and vcpkg builds from the tagged source. Nothing to upload. (Also: there is nothing to release right now — the library is unchanged since `collector-v0.6.2`, which the registry already serves.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)