### PR TITLE
Telegram: split synced title/description into dedicated fields

### DIFF
--- a/aicontext/features/server/notifications/feature.md
+++ b/aicontext/features/server/notifications/feature.md
@@ -14,7 +14,7 @@ Notifications are how evaluated alerts reach people. Delivery is organized behin
 1. **Real-time delivery** — `ITreeValuesCache.NewAlertMessageEvent` fires when an alert message is produced. `NotificationsCenter.DispatchAlertMessage` forwards the `AlertMessage` to every channel's `DeliverAsync`. Every channel iterates the same `AlertDestination.Chats` ids and resolves each against the single `IChatsManager`. Each channel then guards on its own channel-specific field (`TelegramChatId` for Telegram, `SlackWebhookUrl` for Slack) so that a unified `Chat` carrying one channel is silently skipped by the other channel's sender.
 2. **Periodic flush** — `NotificationsBackgroundService` calls `NotificationsCenter.SendAllMessagesAsync`, which calls `FlushAsync` on every channel (e.g. draining Telegram's per-chat message aggregation).
 
-Telegram-specific concerns (bot lifecycle, inbound update polling, chat-name sync, invitation tokens, per-chat aggregation) stay internal to `TelegramBot`. Only outbound delivery is exposed through `TelegramNotificationChannel`, a thin facade that delegates to `TelegramBot`.
+Telegram-specific concerns (bot lifecycle, inbound update polling, Telegram title/description sync, invitation tokens, per-chat aggregation) stay internal to `TelegramBot`. Only outbound delivery is exposed through `TelegramNotificationChannel`, a thin facade that delegates to `TelegramBot`.
 
 ## Invariants
 
@@ -255,3 +255,18 @@ The alert picker filter is enforced by `ActionViewModel.AvailableChats` (populat
 ### Send test message
 
 `NotificationsController.SendTestSlackMessage([FromQuery] Guid id)` is admin-gated and loads the unified `Chat` via `ChatsManager.TryGetValue`. It calls `SlackNotificationChannel.SendTestAsync(Chat)`, which builds a fixed `{"text":"Test message from HSM"}` payload via `SlackMessageBuilder.BuildPayload(string)` and POSTs through the same retry path as `DeliverAsync`. The folder Chats tab and Configuration → Chats tab both surface this action per chat row. `SendTestTelegramMessage(long chatId)` (Telegram channel id, not Guid) is exposed separately because Telegram delivery requires the native bot chat id rather than the unified Chat guid.
+
+### Telegram title/description sync (split from admin Name/Description)
+
+Post-#1283 the unified `Chat` carries four distinct name-adjacent fields:
+
+- `Name` / `Description` — admin-owned via `EditChat`. Round-tripped through `ChatViewModel.ToUpdate()` → `ChatUpdate.Name` / `Description` → `BaseServerModel.Update` (`?? current`). Never overwritten by anything other than an admin action.
+- `TelegramChatTitle` / `TelegramChatDescription` — written by `TelegramBot.ChatNamesSynchronization()` (`src/server/HSMServer/Notifications/Telegram/TelegramBot.cs`) on every bot start. Source: `ChatFullInfo.Title` for groups, `ChatFullInfo.Username` for private chats (matching `ConnectedChatType.TelegramPrivate`), and `ChatFullInfo.Description` for the description.
+
+The sync update carries only `Id` + `TelegramChatTitle` + `TelegramChatDescription`. Because `BaseServerModel.Update` uses `?? current` for the base `Name` / `Description`, omitting them from the sync update preserves the admin-set values — admins can finally give a Telegram-bound chat a custom display name like "On-call alerts" and it survives bot restarts. Pre-#1283 sync clobbered `Name` / `Description` wholesale and `EditChat.cshtml` worked around this by marking them readonly for Telegram-bound chats; that workaround is gone.
+
+`ChatMigrator` is intentionally untouched. Legacy `TelegramChatEntity.Name` still maps to `ChatEntity.Name` on first-time migration. Existing unified rows pre-#1283 simply have null `TelegramChatTitle` / `TelegramChatDescription`; the first `ChatNamesSynchronization` pass after deploy populates them naturally (no explicit backfill).
+
+Storage: `ChatEntity.TelegramChatTitle` / `TelegramChatDescription` are nullable string columns on the JSON-serialized `ChatEntity` record (System.Text.Json in `HSMDatabase.LevelDB/.../EnvironmentDatabaseWorker.cs`). Legacy rows deserialize read-tolerant to null — additive, no schema migration code.
+
+UI: `EditChat.cshtml` Name/Description inputs are now editable for every chat. The Telegram tab surfaces `TelegramChatTitle` / `TelegramChatDescription` as read-only info rows (next to ChatId / Connected) when the chat is Telegram-bound, with an em-dash when the bot has not yet run a sync.

--- a/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/ChatEntity.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/ChatEntity.cs
@@ -18,6 +18,12 @@ namespace HSMDatabase.AccessManager.DatabaseEntities
         public long? AuthorizationTime { get; set; }
 
 
+        // Telegram (synced from bot on every start; not admin-editable)
+        public string TelegramChatTitle { get; set; }
+
+        public string TelegramChatDescription { get; set; }
+
+
         // Slack (optional)
         public string SlackWebhookUrl { get; set; }
 

--- a/src/server/HSMServer/Model/Notifications/ChatViewModel.cs
+++ b/src/server/HSMServer/Model/Notifications/ChatViewModel.cs
@@ -30,6 +30,10 @@ namespace HSMServer.Model.Notifications
 
         public ConnectedChatType? TelegramType { get; set; }
 
+        public string TelegramChatTitle { get; set; }
+
+        public string TelegramChatDescription { get; set; }
+
 
         [Url(ErrorMessage = "Slack webhook URL must be a valid URL")]
         public string SlackWebhookUrl { get; set; }
@@ -82,6 +86,8 @@ namespace HSMServer.Model.Notifications
             AuthorizationTime = chat.AuthorizationTime;
             TelegramChatId = chat.TelegramChatId?.Identifier;
             TelegramType = chat.TelegramType;
+            TelegramChatTitle = chat.TelegramChatTitle;
+            TelegramChatDescription = chat.TelegramChatDescription;
             SlackWebhookUrl = chat.SlackWebhookUrl;
             MattermostWebhookUrl = chat.MattermostWebhookUrl;
             MessagesDelay = chat.MessagesAggregationTimeSec;

--- a/src/server/HSMServer/Notifications/Chats/Chat.cs
+++ b/src/server/HSMServer/Notifications/Chats/Chat.cs
@@ -38,6 +38,14 @@ namespace HSMServer.Notifications.Chats
         public DateTime? AuthorizationTime { get; internal set; }
 
 
+        // Telegram title/description mirrored from the bot on every start (see
+        // TelegramBot.ChatNamesSynchronization). Distinct from Name/Description, which are
+        // admin-owned via EditChat and never overwritten by sync.
+        public string TelegramChatTitle { get; private set; }
+
+        public string TelegramChatDescription { get; private set; }
+
+
         // Slack (optional)
         public string SlackWebhookUrl { get; private set; }
 
@@ -84,6 +92,9 @@ namespace HSMServer.Notifications.Chats
                     : null;
             }
 
+            TelegramChatTitle = entity.TelegramChatTitle;
+            TelegramChatDescription = entity.TelegramChatDescription;
+
             SlackWebhookUrl = entity.SlackWebhookUrl;
             MattermostWebhookUrl = entity.MattermostWebhookUrl;
         }
@@ -96,6 +107,9 @@ namespace HSMServer.Notifications.Chats
         {
             SendMessages = update.SendMessages ?? SendMessages;
             MessagesAggregationTimeSec = update.MessagesAggregationTimeSec ?? MessagesAggregationTimeSec;
+
+            TelegramChatTitle = update.TelegramChatTitle ?? TelegramChatTitle;
+            TelegramChatDescription = update.TelegramChatDescription ?? TelegramChatDescription;
 
             SlackWebhookUrl = update.SlackWebhookUrl ?? SlackWebhookUrl;
             MattermostWebhookUrl = update.MattermostWebhookUrl ?? MattermostWebhookUrl;
@@ -130,6 +144,9 @@ namespace HSMServer.Notifications.Chats
                 entity.TelegramChatId = TelegramChatId?.Identifier;
                 entity.AuthorizationTime = AuthorizationTime?.Ticks;
             }
+
+            entity.TelegramChatTitle = TelegramChatTitle;
+            entity.TelegramChatDescription = TelegramChatDescription;
 
             entity.SlackWebhookUrl = SlackWebhookUrl;
             entity.MattermostWebhookUrl = MattermostWebhookUrl;

--- a/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
+++ b/src/server/HSMServer/Notifications/Chats/ChatUpdate.cs
@@ -14,6 +14,13 @@ namespace HSMServer.Notifications.Chats
         public long? TelegramChatId { get; init; }
 
 
+        // Telegram title/description — written by TelegramBot.ChatNamesSynchronization on every
+        // bot start. Admin-owned Name/Description on the same chat are never touched by sync.
+        public string TelegramChatTitle { get; init; }
+
+        public string TelegramChatDescription { get; init; }
+
+
         // Slack (optional)
         public string SlackWebhookUrl { get; init; }
 

--- a/src/server/HSMServer/Notifications/Telegram/TelegramBot.cs
+++ b/src/server/HSMServer/Notifications/Telegram/TelegramBot.cs
@@ -288,7 +288,7 @@ namespace HSMServer.Notifications
                     }
                     catch (Exception ex)
                     {
-                        _logger.Error($"Telegram chat title '{chat.TelegramChatTitle}' updating is failed - {ex}");
+                        _logger.Error($"Telegram chat '{chat.Id}' (title='{chat.TelegramChatTitle}') sync failed - {ex}");
                     }
                 }
             }

--- a/src/server/HSMServer/Notifications/Telegram/TelegramBot.cs
+++ b/src/server/HSMServer/Notifications/Telegram/TelegramBot.cs
@@ -274,13 +274,13 @@ namespace HSMServer.Notifications
                         var chatName = chat.TelegramType is ConnectedChatType.TelegramPrivate ? telegramChat.Username : telegramChat.Title;
                         var chatDescription = telegramChat.Description;
 
-                        if (chat.Name != chatName || chat.Description != chatDescription)
+                        if (chat.TelegramChatTitle != chatName || chat.TelegramChatDescription != chatDescription)
                         {
                             var update = new ChatUpdate()
                             {
                                 Id = chat.Id,
-                                Name = chatName,
-                                Description = chatDescription,
+                                TelegramChatTitle = chatName,
+                                TelegramChatDescription = chatDescription,
                             };
 
                             await _chatsManager.TryUpdate(update);
@@ -288,7 +288,7 @@ namespace HSMServer.Notifications
                     }
                     catch (Exception ex)
                     {
-                        _logger.Error($"Telegram chat name '{chat.Name}' updating is failed - {ex}");
+                        _logger.Error($"Telegram chat title '{chat.TelegramChatTitle}' updating is failed - {ex}");
                     }
                 }
             }

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -150,22 +150,8 @@
                                     </span>
                                     <small class="text-muted d-block">ChatId: @Model.TelegramChatId</small>
                                     <small class="text-muted d-block">Connected: @Model.AuthorizationTime?.ToLocalTime().ToString("g")</small>
-                                </div>
-                            </div>
-                            <div class="row align-items-center mb-3">
-                                <div class="col-12 col-md-3 text-md-end">
-                                    <label class="chat-form-label col-form-label">Telegram title</label>
-                                </div>
-                                <div class="col-12 col-md-7">
-                                    <small class="text-muted d-block">@(string.IsNullOrEmpty(Model.TelegramChatTitle) ? "—" : Model.TelegramChatTitle)</small>
-                                </div>
-                            </div>
-                            <div class="row align-items-center mb-3">
-                                <div class="col-12 col-md-3 text-md-end">
-                                    <label class="chat-form-label col-form-label">Telegram description</label>
-                                </div>
-                                <div class="col-12 col-md-7">
-                                    <small class="text-muted d-block">@(string.IsNullOrEmpty(Model.TelegramChatDescription) ? "—" : Model.TelegramChatDescription)</small>
+                                    <small class="text-muted d-block">Title: @(string.IsNullOrEmpty(Model.TelegramChatTitle) ? "—" : Model.TelegramChatTitle)</small>
+                                    <small class="text-muted d-block">Description: @(string.IsNullOrEmpty(Model.TelegramChatDescription) ? "—" : Model.TelegramChatDescription)</small>
                                 </div>
                             </div>
                             <div class="d-flex gap-2">

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -67,11 +67,7 @@
                         <label class="chat-form-label col-form-label" asp-for="Name"></label>
                     </div>
                     <div class="col-12 col-md-7">
-                        <input type="text" class="form-control" asp-for="Name" readonly="@isTelegramBound" />
-                        @if (isTelegramBound)
-                        {
-                            <small class="text-muted">Telegram-bound chat: name is synchronized from the bot.</small>
-                        }
+                        <input type="text" class="form-control" asp-for="Name" />
                     </div>
                 </div>
 
@@ -80,7 +76,7 @@
                         <label class="chat-form-label col-form-label" asp-for="Description"></label>
                     </div>
                     <div class="col-12 col-md-7">
-                        <input type="text" class="form-control" asp-for="Description" readonly="@isTelegramBound" />
+                        <input type="text" class="form-control" asp-for="Description" />
                     </div>
                 </div>
 
@@ -141,7 +137,7 @@
                         @if (isTelegramBound)
                         {
                             <div class="alert alert-secondary small mb-3 py-2">
-                                Telegram-bound fields are read-only — they sync from the bot.
+                                Name and Description are admin-editable. Telegram title and description sync from the bot.
                             </div>
                             <div class="row align-items-center mb-3">
                                 <div class="col-12 col-md-3 text-md-end">
@@ -154,6 +150,22 @@
                                     </span>
                                     <small class="text-muted d-block">ChatId: @Model.TelegramChatId</small>
                                     <small class="text-muted d-block">Connected: @Model.AuthorizationTime?.ToLocalTime().ToString("g")</small>
+                                </div>
+                            </div>
+                            <div class="row align-items-center mb-3">
+                                <div class="col-12 col-md-3 text-md-end">
+                                    <label class="chat-form-label col-form-label">Telegram title</label>
+                                </div>
+                                <div class="col-12 col-md-7">
+                                    <small class="text-muted d-block">@(string.IsNullOrEmpty(Model.TelegramChatTitle) ? "—" : Model.TelegramChatTitle)</small>
+                                </div>
+                            </div>
+                            <div class="row align-items-center mb-3">
+                                <div class="col-12 col-md-3 text-md-end">
+                                    <label class="chat-form-label col-form-label">Telegram description</label>
+                                </div>
+                                <div class="col-12 col-md-7">
+                                    <small class="text-muted d-block">@(string.IsNullOrEmpty(Model.TelegramChatDescription) ? "—" : Model.TelegramChatDescription)</small>
                                 </div>
                             </div>
                             <div class="d-flex gap-2">

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using HSMDatabase.AccessManager.DatabaseEntities;
 using HSMServer.Core.DataLayer;
 using HSMServer.Migrations;
+using HSMServer.Notifications.Chats;
 using Moq;
 using Xunit;
 
@@ -160,6 +161,67 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Contains(slack2Id, writtenIds);
 
             db.Verify(d => d.AddChat(It.IsAny<ChatEntity>()), Times.Exactly(4));
+        }
+
+        [Fact]
+        public void Chat_LoadedFromLegacyEntity_HasNullTelegramTitleAndDescription()
+        {
+            // Simulates a legacy LevelDB row written before #1283: the TelegramChatTitle /
+            // TelegramChatDescription JSON keys are absent and System.Text.Json deserializes
+            // them to null. Additive migration — no breaking schema change.
+            var legacyEntity = new ChatEntity
+            {
+                Id = Guid.NewGuid().ToByteArray(),
+                Author = Guid.NewGuid().ToByteArray(),
+                CreationDate = DateTime.UtcNow.Ticks,
+                Name = "On-call alerts",
+                Description = "primary",
+                SendMessages = true,
+                MessagesAggregationTimeSec = 60,
+            };
+
+            var chat = new Chat(legacyEntity);
+
+            Assert.Null(chat.TelegramChatTitle);
+            Assert.Null(chat.TelegramChatDescription);
+            Assert.Equal("On-call alerts", chat.Name);
+            Assert.Equal("primary", chat.Description);
+        }
+
+        [Fact]
+        public void Chat_SyncUpdate_UpdatesTelegramFieldsAndLeavesNameAndDescriptionUntouched()
+        {
+            // Pins the contract TelegramBot.ChatNamesSynchronization relies on: the sync
+            // update carries only TelegramChatTitle / TelegramChatDescription, so admin-set
+            // Name / Description survive bot restarts. Mocking the Telegram.Bot client is
+            // not worth the complexity for this contract pin.
+            var chat = new Chat(new ChatEntity
+            {
+                Id = Guid.NewGuid().ToByteArray(),
+                Author = Guid.NewGuid().ToByteArray(),
+                CreationDate = DateTime.UtcNow.Ticks,
+                Name = "On-call alerts",
+                Description = "primary",
+                SendMessages = true,
+                MessagesAggregationTimeSec = 60,
+            });
+
+            chat.Update(new ChatUpdate
+            {
+                Id = chat.Id,
+                TelegramChatTitle = "Actual Telegram Group",
+                TelegramChatDescription = "Telegram-side description",
+            });
+
+            Assert.Equal("Actual Telegram Group", chat.TelegramChatTitle);
+            Assert.Equal("Telegram-side description", chat.TelegramChatDescription);
+            Assert.Equal("On-call alerts", chat.Name);
+            Assert.Equal("primary", chat.Description);
+
+            var roundTripped = new Chat(chat.ToEntity());
+            Assert.Equal("Actual Telegram Group", roundTripped.TelegramChatTitle);
+            Assert.Equal("Telegram-side description", roundTripped.TelegramChatDescription);
+            Assert.Equal("On-call alerts", roundTripped.Name);
         }
 
 

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using HSMDatabase.AccessManager.DatabaseEntities;
 using HSMServer.Core.DataLayer;
 using HSMServer.Migrations;
@@ -164,12 +166,14 @@ namespace HSMServer.Core.Tests.Notifications
         }
 
         [Fact]
-        public void Chat_LoadedFromLegacyEntity_HasNullTelegramTitleAndDescription()
+        public void Chat_DeserializedFromLegacyJson_HasNullTelegramTitleAndDescription()
         {
-            // Simulates a legacy LevelDB row written before #1283: the TelegramChatTitle /
-            // TelegramChatDescription JSON keys are absent and System.Text.Json deserializes
-            // them to null. Additive migration — no breaking schema change.
-            var legacyEntity = new ChatEntity
+            // Real LevelDB read path: EnvironmentDatabaseWorker.GetChat calls
+            // JsonSerializer.Deserialize<ChatEntity>. Legacy rows pre-#1283 lack the
+            // TelegramChatTitle / TelegramChatDescription keys — System.Text.Json must
+            // deserialize them as null (default behavior for missing properties).
+            // Additive migration — no breaking schema change.
+            var entity = new ChatEntity
             {
                 Id = Guid.NewGuid().ToByteArray(),
                 Author = Guid.NewGuid().ToByteArray(),
@@ -180,7 +184,13 @@ namespace HSMServer.Core.Tests.Notifications
                 MessagesAggregationTimeSec = 60,
             };
 
-            var chat = new Chat(legacyEntity);
+            var json = JsonNode.Parse(JsonSerializer.Serialize(entity)).AsObject();
+            json.Remove(nameof(ChatEntity.TelegramChatTitle));
+            json.Remove(nameof(ChatEntity.TelegramChatDescription));
+            var legacyJson = json.ToJsonString();
+
+            var deserialized = JsonSerializer.Deserialize<ChatEntity>(legacyJson);
+            var chat = new Chat(deserialized);
 
             Assert.Null(chat.TelegramChatTitle);
             Assert.Null(chat.TelegramChatDescription);
@@ -222,8 +232,8 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Equal("Actual Telegram Group", roundTripped.TelegramChatTitle);
             Assert.Equal("Telegram-side description", roundTripped.TelegramChatDescription);
             Assert.Equal("On-call alerts", roundTripped.Name);
+            Assert.Equal("primary", roundTripped.Description);
         }
-
 
         private static TelegramChatEntity BuildTelegram(Guid id, string name, byte type, long chatId) => new()
         {

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs
@@ -185,6 +185,11 @@ namespace HSMServer.Core.Tests.Notifications
             };
 
             var json = JsonNode.Parse(JsonSerializer.Serialize(entity)).AsObject();
+            // Precondition: the new keys must be present in the serialized JSON for the
+            // removal below to prove anything. Without this guard, a future [JsonIgnore]
+            // on the new fields would turn this test into a silent no-op.
+            Assert.True(json.ContainsKey(nameof(ChatEntity.TelegramChatTitle)), "serialized JSON should include TelegramChatTitle");
+            Assert.True(json.ContainsKey(nameof(ChatEntity.TelegramChatDescription)), "serialized JSON should include TelegramChatDescription");
             json.Remove(nameof(ChatEntity.TelegramChatTitle));
             json.Remove(nameof(ChatEntity.TelegramChatDescription));
             var legacyJson = json.ToJsonString();


### PR DESCRIPTION
## Summary

Stop `TelegramBot.ChatNamesSynchronization` from overwriting admin-set `Chat.Name` / `Chat.Description` on every bot start. Introduces dedicated `TelegramChatTitle` / `TelegramChatDescription` fields on `Chat` / `ChatEntity` / `ChatUpdate`, routes the sync to those, and surfaces them as read-only info rows in the EditChat Telegram tab. Name / Description are now freely admin-editable for every chat (the `readonly=isTelegramBound` workaround is gone).

Additive LevelDB migration — legacy JSON rows deserialize the new fields to `null`; the first sync pass after deploy populates them. `ChatMigrator` is untouched.

## Test plan

- [ ] `dotnet build` clean (verified locally for `HSMDatabase.AccessManager` + `HSMServer.Core`; `HSMServer` itself compiles clean but its post-build copy into `bin/Debug/net8.0` is blocked by a locally running HSMServer process — CI will cover the full build).
- [ ] `dotnet test src/tests/HSMServer.Core.Tests` green, including the two new `ChatMigrationTests` cases (`Chat_LoadedFromLegacyEntity_HasNullTelegramTitleAndDescription`, `Chat_SyncUpdate_UpdatesTelegramFieldsAndLeavesNameAndDescriptionUntouched`).
- [ ] Manual: open `EditChat` for a Telegram-bound chat — Name and Description inputs are editable; Telegram tab shows read-only "Telegram title" / "Telegram description" rows with em-dash when the bot has not synced yet.
- [ ] Manual: set a custom Name on a Telegram-bound chat, restart the bot, confirm Name survives (only Telegram title/description update).

Closes #1283

🤖 Generated with [Claude Code](https://claude.com/claude-code)