### PR TITLE
Fix flaky TreeValuesCacheTests: stop counting the sensor history loader's notifications

### DIFF
--- a/src/tests/HSMServer.Core.Tests/Infrastructure/ModelsTester.cs
+++ b/src/tests/HSMServer.Core.Tests/Infrastructure/ModelsTester.cs
@@ -307,7 +307,13 @@ namespace HSMServer.Core.Tests.Infrastructure
             return value;
         }
 
-        private static void TestImmutableSensorData(BaseSensorModel expected, BaseSensorModel actual)
+        /// <summary>
+        /// Everything that identifies a sensor and that no update may change. Status is
+        /// deliberately left out: it is derived from the last value, which the cache
+        /// loads on a background task, so it cannot be compared against a snapshot
+        /// taken at an arbitrary point in that load.
+        /// </summary>
+        internal static void TestSensorIdentity(BaseSensorModel expected, BaseSensorModel actual)
         {
             Assert.NotNull(actual.RootProductName);
             Assert.NotNull(actual.Path);
@@ -322,6 +328,12 @@ namespace HSMServer.Core.Tests.Infrastructure
             Assert.Equal(expected.RootProductName, actual.RootProductName);
             Assert.Equal(expected.Path, actual.Path);
             Assert.Equal(expected.Type, actual.Type);
+        }
+
+        private static void TestImmutableSensorData(BaseSensorModel expected, BaseSensorModel actual)
+        {
+            TestSensorIdentity(expected, actual);
+
             AssertModels(expected.Status, actual.Status);
         }
 

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -13,6 +13,7 @@ using HSMServer.Model.Authentication;
 using HSMServer.Model.TreeViewModel;
 using Moq;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -425,31 +426,53 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         [Trait("Category", "Update sensor(s)")]
         public async Task UpdateSensorsTest()
         {
-            var sensor = GetClonedSensorModel(GetSensorByNameFromCache("sensor0"));
+            // The fixture seeds a "sensor0" under every product and GetSensors() enumerates
+            // a ConcurrentDictionary, so "the first sensor0" is whichever namesake the hash
+            // order happens to yield — name the subject of the test instead.
+            var cachedSensor = _valuesCache.GetSensors()
+                                           .Single(s => s.DisplayName == "sensor0" && s.Parent?.DisplayName == "product0");
+
+            var sensor = GetClonedSensorModel(cachedSensor);
             var sensorUpdate = SensorModelFactory.BuildSensorUpdate(sensor.Id);
 
-            int updatedSensorsCount = 0;
+            // The cache loads sensor history in a fire-and-forget task started by its
+            // constructor (TreeValuesCache.FillSensorsData), and that task raises
+            // ChangeSensorEvent for every sensor it initializes. Keep only the
+            // notifications for the sensor under test, in a concurrent collection:
+            // they arrive from the updates queue and from the loader alike.
+            var notifications = new ConcurrentQueue<ActionType>();
             void UpdateSensorEventHandler(BaseSensorModel updatedSensor, ActionType type)
             {
-                Assert.NotNull(updatedSensor);
-                Assert.Equal(ActionType.Update, type);
-
-                if (updatedSensorsCount > 1) //skip first ttl update
-                    ModelsTester.TestSensorModel(sensorUpdate, updatedSensor);
-
-                updatedSensorsCount++;
+                if (updatedSensor?.Id == sensorUpdate.Id)
+                    notifications.Enqueue(type);
             }
 
             _valuesCache.ChangeSensorEvent += UpdateSensorEventHandler;
 
-            await _valuesCache.UpdateSensorAsync(sensorUpdate);
-
-            await Task.Delay(100);
+            // UpdateSensorAsync completes only once its request has been taken off the
+            // updates queue and handled, so every notification the update raises has
+            // already been delivered by the time it returns — no delay to wait out.
+            var result = await _valuesCache.UpdateSensorAsync(sensorUpdate);
 
             _valuesCache.ChangeSensorEvent -= UpdateSensorEventHandler;
 
-            Assert.Equal(1, updatedSensorsCount / 2); //TTL generate one more request
+            Assert.True(result.IsOk, result.Error);
+
+            // Deliberately not an exact count. An update announces itself once, and the
+            // TTL check in BaseNodeModel.Update announces it a second time — but only
+            // when the sensor's history is already loaded, so the total races the
+            // background loader. What the cache guarantees is that the update is
+            // announced, and only ever as an Update.
+            Assert.NotEmpty(notifications);
+            Assert.All(notifications, type => Assert.Equal(ActionType.Update, type));
+
             TestSensorUpdates(sensor, sensorUpdate);
+
+            // An update must not touch the sensor's history: the value seeded by the
+            // fixture is still the only one stored. Asserted against the database,
+            // because the in-memory LastValue is filled in by the background loader
+            // and so cannot be compared against a snapshot taken before the update.
+            Assert.Single(await GetAllSensorValues(cachedSensor));
         }
 
         //[Fact]
@@ -747,7 +770,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             ModelsTester.TestSensorModel(sensorUpdate, actualSensorFromCache);
             ModelsTester.TestSensorModel(sensorUpdate, actualSensorFromDb);
-            ModelsTester.TestSensorModelWithoutUpdatedMetadata(actualSensorFromCache, sensor);
+
+            // Identity only for the cached model: the model-to-model overload also
+            // compares LastValue/HasData/Status against the pre-update clone, and those
+            // are owned by the background history loader, not by the update under test.
+            ModelsTester.TestSensorIdentity(actualSensorFromCache, sensor);
             ModelsTester.TestSensorModelWithoutUpdatedMetadata(actualSensorFromDb, sensor);
 
             //TODO: return checking TTL after adding an ability to update it

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/TreeValuesCacheTests.cs
@@ -541,18 +541,18 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         [Trait("Category", "Remove sensor(s) data")]
         public async Task RemoveSensorsDataTest()
         {
-            int clearedSensorsCount = 0;
-            void UpdateSensorEventHandler(BaseSensorModel clearedSensor, ActionType type)
-            {
-                Assert.NotNull(clearedSensor);
-                Assert.Equal(ActionType.Update, type);
-
-                clearedSensorsCount++;
-            }
-
-
             var product = GetProductByName("product0");
             var sensors = GetAllSensorIdsInBranch(product);
+
+            // Only the branch being cleared: the cache also loads sensor history on a
+            // fire-and-forget task (TreeValuesCache.FillSensorsData) that announces every
+            // sensor it initializes, so a cache-wide count counts the loader's work too.
+            var clearedSensors = new ConcurrentQueue<(Guid Id, ActionType Type)>();
+            void UpdateSensorEventHandler(BaseSensorModel clearedSensor, ActionType type)
+            {
+                if (clearedSensor is not null && sensors.Contains(clearedSensor.Id))
+                    clearedSensors.Enqueue((clearedSensor.Id, type));
+            }
 
             _valuesCache.ChangeSensorEvent += UpdateSensorEventHandler;
 
@@ -560,7 +560,8 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             _valuesCache.ChangeSensorEvent -= UpdateSensorEventHandler;
 
-            Assert.Equal(4, clearedSensorsCount);
+            Assert.All(clearedSensors, n => Assert.Equal(ActionType.Update, n.Type));
+            Assert.Equal(sensors.OrderBy(id => id), clearedSensors.Select(n => n.Id).Distinct().OrderBy(id => id));
             foreach (var sensorId in sensors)
                 await TestClearedSensor(sensorId);
         }
@@ -601,16 +602,25 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                     updatedProductsCount++;
             }
 
-            int addedSensorsCount = 0;
-            int updatedSensorsCount = 0;
+            const string subProductName = "new_subProduct";
+            const string subSubProductName = "new_subSubProduct";
+            const string sensorName = "new_sensor";
+            const string productPath = $"{subProductName}/{subSubProductName}/{sensorName}";
+
+            // Only the sensor this test adds: the cache also loads sensor history on a
+            // fire-and-forget task (TreeValuesCache.FillSensorsData) that announces every
+            // sensor it initializes, so a cache-wide count counts the loader's work too.
+            var addedSensors = new ConcurrentQueue<Guid>();
+            var updatedSensors = new ConcurrentQueue<Guid>();
             void ChangeSensorEventHandler(BaseSensorModel sensor, ActionType type)
             {
-                Assert.NotNull(sensor);
+                if (sensor?.DisplayName != sensorName)
+                    return;
 
                 if (type == ActionType.Add)
-                    addedSensorsCount++;
+                    addedSensors.Enqueue(sensor.Id);
                 else if (type == ActionType.Update)
-                    updatedSensorsCount++;
+                    updatedSensors.Enqueue(sensor.Id);
             }
 
 
@@ -619,17 +629,15 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             var product = _valuesCache.GetProduct(productId);
 
-            const string subProductName = "new_subProduct";
-            const string subSubProductName = "new_subSubProduct";
-            const string sensorName = "new_sensor";
-            const string productPath = $"{subProductName}/{subSubProductName}/{sensorName}";
             var storeInfo = SensorValuesFactory.BuildSensorValue(type, productPath, DateTime.UtcNow);
 
             _valuesCache.ChangeProductEvent += ChangeProductEventHandler;
             _valuesCache.ChangeSensorEvent += ChangeSensorEventHandler;
 
+            // AddSensorValueAsync completes only once its request has been handled, so
+            // every notification it raises has already been delivered by the time it
+            // returns - there is nothing left to wait out.
             await _valuesCache.AddSensorValueAsync(accessKey, TestProductsManager.ProductId, storeInfo);
-            await Task.Delay(100);
 
             _valuesCache.ChangeProductEvent -= ChangeProductEventHandler;
             _valuesCache.ChangeSensorEvent -= ChangeSensorEventHandler;
@@ -649,8 +657,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             ModelsTester.TestProductModel(_databaseCoreManager.GetProduct(subProduct.Id), subProduct);
             ModelsTester.TestProductModel(_databaseCoreManager.GetProduct(subSubProduct.Id), subSubProduct);
 
-            Assert.Equal(1, addedSensorsCount);
-            Assert.Equal(1, updatedSensorsCount / 2); // TTL generate one more request
+            Assert.Single(addedSensors);
+
+            // Not an exact count: the sensor announces itself once and the TTL check adds
+            // another, but only once its history is loaded (see UpdateSensorsTest).
+            Assert.NotEmpty(updatedSensors);
 
             ModelsTester.TestSensorModel(storeInfo, sensor, parentProduct: subSubProduct);
             ModelsTester.TestSensorModel(GetSensorByIdFromDb(sensor.Id), sensor);
@@ -677,19 +688,20 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         [Trait("Category", "Add new sensor value")]
         public async Task AddNewSensorValue_UpdateData_Test(SensorType type)
         {
-            int updatedSensorsCount = 0;
+            const string sensorName = "new_sensor";
+
+            // Only the sensor this test writes to: the cache also loads sensor history on
+            // a fire-and-forget task (TreeValuesCache.FillSensorsData) that announces every
+            // sensor it initializes, so a cache-wide count counts the loader's work too.
+            var notifications = new ConcurrentQueue<ActionType>();
             void ChangeSensorEventHandler(BaseSensorModel sensor, ActionType type)
             {
-                Assert.NotNull(sensor);
-                Assert.Equal(ActionType.Update, type);
-
-                updatedSensorsCount++;
+                if (sensor?.DisplayName == sensorName)
+                    notifications.Enqueue(type);
             }
 
             Guid accessKey = Guid.Parse(TestProductsManager.TestProductKey.Id);
             Guid productId = TestProductsManager.ProductId;
-
-            const string sensorName = "new_sensor";
 
             var timeCollected = DateTime.UtcNow;
 
@@ -709,7 +721,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             var sensor = GetSensorByNameFromCache(sensorName);
             var sensorDataFromDb = _databaseCoreManager.DatabaseCore.GetLatestValuesFromTo(new(1) { [sensor.Id] = (DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks) }).FirstOrDefault().Value;
 
-            Assert.Equal(1, updatedSensorsCount / 2); // TTL generate one more request
+            // Not an exact count: the sensor announces itself once and the TTL check adds
+            // another, but only once its history is loaded (see UpdateSensorsTest).
+            Assert.NotEmpty(notifications);
+            Assert.All(notifications, t => Assert.Equal(ActionType.Update, t));
+
             Assert.NotEmpty(product.Sensors);
 
             ModelsTester.TestSensorModel(storeInfo, sensor, parentProduct: product);


### PR DESCRIPTION
## The flake

`HSMServer.Core.Tests.TreeValuesCacheTests.UpdateSensorsTest` fails intermittently on `master` and takes the whole **HSMServer build** lane down with it — no server artifact, no release. It failed on the merge of #1241 ([run 29743049307](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/actions/runs/29743049307)) with `Failed: 1, Passed: 507`, while the runs immediately before ([29740299629](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/actions/runs/29740299629)) and after ([29744240269](https://github.com/SoftFx/Hierarchical-Sensor-Monitoring/actions/runs/29744240269)) were green on the same suite:

```
HSMServer.Core.Tests.TreeValuesCacheTests.TreeValuesCacheTests.UpdateSensorsTest [FAIL]
Assert.Equal() Failure: Values differ
Expected: 1
Actual:   0
   at ...TreeValuesCacheTests.UpdateSensorsTest() in TreeValuesCacheTests.cs:line 451
```

Line 451 was `Assert.Equal(1, updatedSensorsCount / 2); //TTL generate one more request` — an exact count of the `ChangeSensorEvent` notifications raised by a single `UpdateSensorAsync`, sampled after `await Task.Delay(100)`.

## Root cause

The count is not deterministic, because the test races the cache's background history loader.

1. `TreeValuesCache.ApplySensors` kicks the history load off as fire-and-forget: `Task.Run(() => FillSensorsData()).Forget(_logger)`, which calls `sensor.Initialize()` on every sensor.
2. `BaseSensorModel<T>.Initialize()` latches `_isInitialized = true` **before** it reads the history out of LevelDB, and the fast-path `if (_isInitialized) return;` is outside the lock. A concurrent caller can therefore see the sensor as initialized while its `Storage` is still empty.
3. When the update lands in that window, `TryUpdateSensor` → `BaseNodeModel.Update` → `CheckTimeout()` → `Policies.SensorTimeout(LastValue)` returns early on a `null` value, *before* `SensorExpired?.Invoke(...)`. The "TTL" notification (`SetExpiredSnapshot` → `SensorUpdateView`) never fires, only the one from `TryUpdateSensor` does, and `1 / 2 == 0`.

The window is a single LevelDB read wide, which is why it needs a busy CI machine and 500 sibling tests to show up. There was a second, opposite failure mode too: the same background task raises `ChangeSensorEvent` for *other* sensors it initializes, and those landed in the handler during the 100 ms sleep, inflating the count.

Proof rather than inference — with the window forced open (temporary patch making `Initialize()` return right after latching, i.e. exactly the state a concurrent caller can observe), the old test reproduces the CI failure on demand:

```
--- old test, race simulated ---   Expected: 1 / Actual: 0        -> Failed!
--- old test, normal ---                                          -> Passed!
--- new test, race simulated ---                                  -> Passed!
```

## The fix

No reruns, no retry attributes, no sleeps — the assertions no longer depend on scheduling:

- **Await the real completion signal.** `UpdateSensorAsync` returns only after its request has been taken off the updates queue and handled, so every notification it raises has already been delivered. `Task.Delay(100)` is gone.
- **Assert an order-independent projection instead of a count.** Notifications for the sensor under test are collected (in a `ConcurrentQueue` — they can arrive from the loader thread as well as the queue thread) and asserted as "at least one, all of them `ActionType.Update`". That is what the cache actually guarantees; whether the TTL path adds a second one is the loader's business.
- **Name the subject.** The fixture seeds a `sensor0` under every product and `GetSensors()` enumerates a `ConcurrentDictionary`, so `FirstOrDefault(s => s.DisplayName == "sensor0")` picked a different namesake depending on hash order. It is now `Single(sensor0 of product0)`.
- **Check the update result.** `Assert.True(result.IsOk, result.Error)` — assertions raised inside the event handler are swallowed by the updates queue's `try/catch`, so the old in-handler asserts could not fail the test anyway. A failed update now fails loudly.
- **Compare the history against the database.** "An update must not touch the sensor's data" was asserted by comparing the live model's `LastValue`/`HasData`/`Status` against a clone snapshotted before the update — same race, since the loader decides when those get filled in. It is now `Assert.Single(await GetAllSensorValues(...))` against the DB, which is a stronger claim and a stable one. `ModelsTester.TestImmutableSensorData` was split so the identity half (`TestSensorIdentity`) can be reused without the data-derived `Status` comparison; existing callers are unchanged.

## The same defect in three sibling tests (second commit)

Verifying the fix ran the whole class 20 times, and a *different* test failed once — `AddNewSensorValueTest(type: Double)`, with `Expected: 1, Actual: 4` on its own `updatedSensorsCount / 2`. It is the same defect from the other side: these handlers count `ChangeSensorEvent` **cache-wide**, and the history loader announces every sensor it initializes. The sensor under test can raise at most two notifications, so the other six or seven were the loader's — a pre-existing flake on `master` that would keep this lane red on its own.

Same treatment, each handler now keeps only the notifications for the sensor(s) its test is about:

- `AddNewSensorValueTest` — filter by the added sensor, drop its own `Task.Delay(100)`, assert one Add and at least one Update.
- `AddNewSensorValue_UpdateData_Test` — same filter, assert the sensor was announced and only ever as an `Update`.
- `RemoveSensorsDataTest` — count only the branch being cleared, and compare the *set* of announced sensors against that branch instead of the literal `4`.

`RemoveSensorsTest` and `RemoveProductTest` also count cache-wide, but only `Delete` notifications, and the loader only ever raises `Update` — they are left alone.

## Verification

- `dotnet vstest --TestCaseFilter:"FullyQualifiedName~UpdateSensorsTest"` — **50/50 passes**.
- Whole `TreeValuesCacheTests` class — **60/60 passes** after the sibling fixes (20 runs before them caught the `AddNewSensorValueTest` flake; the loader is busiest in this class).
- Whole `HSMServer.Core.Tests` suite — 508/508 green (`ModelsTester` is shared).

## Not in this PR

The production race in `BaseSensorModel<T>.Initialize()` is real but out of scope here: a value arriving during startup can be processed against an empty history (`IsSingleton`, EMA statistics, the `isLastValue` decision, skipped TTL notifications). Moving the latch is not a one-liner — it doubles as a re-entrancy guard for `Initialize` → `TryValidate` → `SensorTimeout` → `SetExpiredSnapshot` → `TryAddValue` → `Initialize`. Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
