### PR TITLE
fix(EditChat): align webhook label with input, move help link to next row

### DIFF
--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -184,7 +184,11 @@
                             </div>
                             <div class="col-12 col-md-7">
                                 <input type="url" class="form-control" asp-for="SlackWebhookUrl" placeholder="https://hooks.slack.com/services/..." />
-                                <a href="javascript:showSlackHelpModal();" class="btn btn-link p-0 mt-2 d-inline-block">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-12 col-md-7 offset-md-3">
+                                <a href="javascript:showSlackHelpModal();" class="btn btn-link p-0 d-inline-block">
                                     <i class="fas fa-question-circle"></i> Show setup help
                                 </a>
                             </div>
@@ -201,14 +205,18 @@
                     <div class="tab-pane fade @(defaultTab == "mattermost" ? "show active" : "")" id="mattermost"
                          role="tabpanel" aria-labelledby="mattermost-tab">
                         @await Html.PartialAsync("_MattermostHelpModal.cshtml")
-                        <div class="row align-items-center mb-3">
+                        <div class="row align-items-start mb-3">
                             <div class="col-12 col-md-3 text-md-end">
                                 <label class="chat-form-label col-form-label" for="MattermostWebhookUrl">Mattermost Webhook URL</label>
                             </div>
                             <div class="col-12 col-md-7">
                                 <input type="url" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." disabled />
                                 <small class="text-muted d-block mt-1">Mattermost delivery is not yet implemented — the URL saved here will be used once delivery ships.</small>
-                                <a href="javascript:showMattermostHelpModal();" class="btn btn-link p-0 mt-2 d-inline-block">
+                            </div>
+                        </div>
+                        <div class="row mb-3">
+                            <div class="col-12 col-md-7 offset-md-3">
+                                <a href="javascript:showMattermostHelpModal();" class="btn btn-link p-0 d-inline-block">
                                     <i class="fas fa-question-circle"></i> Show setup help
                                 </a>
                             </div>


### PR DESCRIPTION
## Summary
In the EditChat Slack/Mattermost tabs, the webhook URL label was vertically misaligned with the input — it floated mid-height against the input+help-link stack instead of aligning with the input itself. Cause: a single Bootstrap row with \`align-items-center\` plus the help link stacked inside \`col-md-7\` below the input (mt-2), making the input column taller than the label column.

Fix:
- Slack: help link moved to its own row (\`offset-md-3\` keeps it aligned under the input column). Row keeps \`align-items-center\` because both columns are now the same height (label vs input).
- Mattermost: same help-link move, plus \`align-items-center\` → \`align-items-start\` because the \`<small>\` caveat still stacks under the input inside \`col-md-7\` — start-align keeps the label pinned to the top where the input sits.

## Test plan
- [ ] Open EditChat for an existing chat (or Add new chat), Slack tab: \"Slack Webhook URL\" label sits on the same baseline as the input; \"Show setup help\" link is on a separate row below.
- [ ] Mattermost tab: same alignment, with the \"delivery is not yet implemented\" caveat staying directly under the input.
- [ ] Narrow viewport (mobile): label stacks above input as before, help link stays below input.
- [ ] \`dotnet build\` clean (verified locally: 0 errors, 33 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)