### PR TITLE
Inline Mattermost brand SVG (replace dead fa-mattermost)

### DIFF
--- a/src/server/HSMServer/Extensions/ChatIcons.cs
+++ b/src/server/HSMServer/Extensions/ChatIcons.cs
@@ -12,27 +12,30 @@ namespace HSMServer.Extensions
 
         public const string SlackBrandClass = "fab fa-slack";
 
-        public const string MattermostBrandClass = "fab fa-" + "mattermost"; // Font Awesome lacks an official Mattermost brand; consumers can override.
+        // Font Awesome Free lacks an official Mattermost brand icon, so we inline the brand
+        // mark from Simple Icons (CC0-1.0). Sized with em units and currentColor so it inherits
+        // font-size/color just like the surrounding <i class='fab fa-...'> tags.
+        public const string MattermostBrandIconSvg =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' " +
+            "width='1em' height='1em' fill='currentColor' aria-hidden='true' " +
+            "role='img' focusable='false' style='vertical-align:-.125em'>" +
+            "<title>Mattermost</title>" +
+            "<path d='M12.081 0C7.048-.034 2.339 3.125.637 8.153c-2.125 6.276 1.24 13.086 7.516 15.21 6.276 2.125 13.086-1.24 15.21-7.516 1.727-5.1-.172-10.552-4.311-13.557l.126 2.547c2.065 2.282 2.88 5.512 1.852 8.549-1.534 4.532-6.594 6.915-11.3 5.321-4.708-1.593-7.28-6.559-5.745-11.092 1.031-3.046 3.655-5.121 6.694-5.67l1.642-1.94A4.87 4.87 0 0 0 12.08 0zm3.528 1.094a.284.284 0 0 0-.123.024l-.004.001a.33.33 0 0 0-.109.071c-.145.142-.657.828-.657.828L13.6 3.4l-1.3 1.585-2.232 2.776s-1.024 1.278-.798 2.851c.226 1.574 1.396 2.34 2.304 2.648.907.307 2.302.408 3.438-.704 1.135-1.112 1.098-2.75 1.098-2.75l-.087-3.56-.07-2.05-.047-1.775s.01-.856-.02-1.057a.33.33 0 0 0-.035-.107l-.006-.012-.007-.011a.277.277 0 0 0-.229-.14z'/>" +
+            "</svg>";
 
-
-        public static string ChatBrandClass(this Chat chat)
-        {
-            if (chat.TelegramChatId is not null)
-                return TelegramBrandClass;
-
-            if (!string.IsNullOrEmpty(chat.SlackWebhookUrl))
-                return SlackBrandClass;
-
-            if (!string.IsNullOrEmpty(chat.MattermostWebhookUrl))
-                return MattermostBrandClass;
-
-            return null;
-        }
 
         public static string ChatBrandIcon(this Chat chat)
         {
-            var brand = chat.ChatBrandClass();
-            return string.IsNullOrEmpty(brand) ? null : $"<i class='{brand}'></i>";
+            if (chat.TelegramChatId is not null)
+                return $"<i class='{TelegramBrandClass}'></i>";
+
+            if (!string.IsNullOrEmpty(chat.SlackWebhookUrl))
+                return $"<i class='{SlackBrandClass}'></i>";
+
+            if (!string.IsNullOrEmpty(chat.MattermostWebhookUrl))
+                return MattermostBrandIconSvg;
+
+            return null;
         }
 
         public static string ChatBrandIcons(this Chat chat)
@@ -46,7 +49,7 @@ namespace HSMServer.Extensions
                 icons.Add($"<i class='{SlackBrandClass}'></i>");
 
             if (!string.IsNullOrEmpty(chat.MattermostWebhookUrl))
-                icons.Add($"<i class='{MattermostBrandClass}'></i>");
+                icons.Add(MattermostBrandIconSvg);
 
             if (icons.Count == 0)
                 return null;

--- a/src/server/HSMServer/Model/Notifications/ChatViewModel.cs
+++ b/src/server/HSMServer/Model/Notifications/ChatViewModel.cs
@@ -68,7 +68,7 @@ namespace HSMServer.Model.Notifications
             if (HasSlack)
                 icons += $"<i class='{ChatIcons.SlackBrandClass}'></i> ";
             if (HasMattermost)
-                icons += $"<i class='{ChatIcons.MattermostBrandClass}'></i> ";
+                icons += $"{ChatIcons.MattermostBrandIconSvg} ";
 
             return string.IsNullOrEmpty(icons) ? null : icons.TrimEnd();
         }

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -126,7 +126,7 @@
                         <button class="nav-link @(defaultTab == "mattermost" ? "active" : "")" id="mattermost-tab"
                                 data-bs-toggle="tab" data-bs-target="#mattermost" type="button" role="tab"
                                 aria-controls="mattermost" aria-selected="@(defaultTab == "mattermost" ? "true" : "false")">
-                            <i class="fab fa-mattermost"></i> Mattermost
+                            @Html.Raw(HSMServer.Extensions.ChatIcons.MattermostBrandIconSvg) Mattermost
                         </button>
                     </li>
                 </ul>

--- a/src/server/HSMServer/Views/Notifications/_MattermostHelpModal.cshtml
+++ b/src/server/HSMServer/Views/Notifications/_MattermostHelpModal.cshtml
@@ -1,8 +1,10 @@
+@using HSMServer.Extensions
+
 <div class="modal fade" tabindex="-1" role="dialog" id="mattermostHelp_modal">
     <div class="modal-dialog modal-dialog-centered modal-lg" role="document">
         <div class="modal-content">
             <div class="modal-header">
-                <h5 class="modal-title"><i class="fab fa-mattermost"></i> How to create a Mattermost incoming webhook</h5>
+                <h5 class="modal-title">@Html.Raw(ChatIcons.MattermostBrandIconSvg) How to create a Mattermost incoming webhook</h5>
                 <button type="button" class="btn-close" data-bs-dismiss="modal" onclick="hideMattermostHelpModal()" aria-label="Close"></button>
             </div>
 


### PR DESCRIPTION
## Summary

`fab fa-mattermost` rendered as a blank box because Font Awesome Free 6.2.1 ships no Mattermost brand. Replaced the dead CSS-class constant with an inline SVG built from the official Mattermost logo published by Simple Icons (CC0-1.0). The SVG inherits `font-size`/`color` via `width='1em'`/`height='1em'`/`fill='currentColor'`, so it scales and colors alongside the adjacent `fab fa-telegram`/`fab fa-slack` icons.

Touched surfaces:
- `ChatIcons.MattermostBrandIconSvg` — new inline-SVG constant (was `MattermostBrandClass = "fab fa-mattermost"`).
- `ChatIcons.ChatBrandIcon` — folds in the old `ChatBrandClass` helper now that Mattermost can no longer be expressed as a class.
- `ChatViewModel.ChatBrandIcons` — picks up the SVG for the list/options path.
- `EditChat.cshtml` Mattermost tab + `_MattermostHelpModal.cshtml` title — render `@Html.Raw(ChatIcons.MattermostBrandIconSvg)`.

No npm dependency, no font payload — just the one `<path>`.

## Test plan

- [ ] Build clean (`dotnet build src/server/HSMServer/HSMServer.csproj`) — confirmed locally: 0 errors.
- [ ] Open Configuration → Chats list; for a chat bound only to Mattermost, the brand-icon cluster shows the Mattermost mark (not a blank box).
- [ ] For a chat bound to Telegram + Mattermost (or Slack + Mattermost), both icons render side by side at the same baseline.
- [ ] EditChat → Mattermost tab header shows the icon.
- [ ] Click `Show setup help` on the Mattermost tab — modal title shows the icon.
- [ ] Bootstrap-select chat dropdown (e.g. Folders → edit, Alert Templates) renders the Mattermost mark in the option markup.
- [ ] Color check: the icon inherits text color — appears muted inside `.text-secondary` rows and default inside `.fw-medium` rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)