### PR TITLE
feat(notifications): ship Mattermost delivery

### DIFF
--- a/aicontext/features/server/notifications/feature.md
+++ b/aicontext/features/server/notifications/feature.md
@@ -138,7 +138,7 @@ NotificationsBackgroundService (timer) -> NotificationsCenter.SendAllMessagesAsy
 
 ### Storage
 
-Unified `ChatEntity` rows under the `"Chats"` LevelDB key, accessed via the single `IChatsManager`. The channel resolves webhook URLs and names from the same registry that Telegram uses — one chat can deliver through both channels. `IChatsManager.GetChatName(Guid)` is the only name resolver and is wired directly to `IFolderManager.GetChatName`.
+Unified `ChatEntity` rows under the `"Chats"` LevelDB key, accessed via the single `IChatsManager`. The channel resolves webhook URLs and names from the same registry that Telegram uses — one chat can deliver through any combination of Telegram, Slack, and Mattermost simultaneously. `IChatsManager.GetChatName(Guid)` is the only name resolver and is wired directly to `IFolderManager.GetChatName`.
 
 ## Mattermost delivery
 

--- a/aicontext/features/server/notifications/feature.md
+++ b/aicontext/features/server/notifications/feature.md
@@ -20,7 +20,7 @@ Telegram-specific concerns (bot lifecycle, inbound update polling, Telegram titl
 
 - `NotificationsCenter` is the only subscriber to `ITreeValuesCache.NewAlertMessageEvent` (it unsubscribes in `DisposeAsync`). Individual channels must not subscribe to the cache event directly.
 - A channel's `DeliverAsync` must not throw — Telegram's implementation keeps the historical internal `try/catch` that logs and swallows errors. Diagnostics surface via the concrete `TelegramBot` events (`MessageSending`, `MessageSended`, `ErrorHandled`), which `DataCollectorWrapper` subscribes to directly; the interface itself carries no events in this revision.
-- `INotificationChannel.Kind` is informational metadata (`NotificationKind.Telegram = 0`, `NotificationKind.Slack = 1`) used by diagnostics sensors and future channel-list UIs. It is no longer load-bearing for routing — each channel resolves ids against the single `IChatsManager` and then filters by its own channel field, so ids for a chat that doesn't carry this channel are skipped without an error event.
+- `INotificationChannel.Kind` is informational metadata (`NotificationKind.Telegram = 0`, `NotificationKind.Slack = 1`, `NotificationKind.Mattermost = 2`) used by diagnostics sensors and future channel-list UIs. It is no longer load-bearing for routing — each channel resolves ids against the single `IChatsManager` and then filters by its own channel field, so ids for a chat that doesn't carry this channel are skipped without an error event.
 - Telegram delivery, the "Telegram Bot" diagnostics sensors, and the existing folder↔chat event wiring are unchanged end-to-end by the seam introduction.
 
 ## API / Public Contracts
@@ -88,16 +88,21 @@ Alert evaluated -> TreeValuesCache raises NewAlertMessageEvent(AlertMessage)
                  (for each chatId in AlertDestination.Chats:
                     _chats.TryGetValue(chatId, out chat)
                       && !string.IsNullOrEmpty(chat.SlackWebhookUrl) ? POST/buffer : skip)
+            -> MattermostNotificationChannel.DeliverAsync
+                 (for each chatId in AlertDestination.Chats:
+                    _chats.TryGetValue(chatId, out chat)
+                      && !string.IsNullOrEmpty(chat.MattermostWebhookUrl) ? POST/buffer : skip)
 
 NotificationsBackgroundService (timer) -> NotificationsCenter.SendAllMessagesAsync
   -> for each INotificationChannel: await FlushAsync()
        -> TelegramNotificationChannel -> TelegramBot.SendMessagesAsync (drain TelegramAccumulator)
        -> SlackNotificationChannel.FlushAsync (drain SlackAccumulator)
+       -> MattermostNotificationChannel.FlushAsync (drain MattermostAccumulator)
 ```
 
 ## Tests
 
-- `src/tests/HSMServer.Core.Tests/Notifications/ChatFolderBindingTests.cs` — consolidated post-#1261 coverage of `IChatsManager` folder binding. Pins: (a) `RemoveFolderFromChats_DoesNotDeleteChatAtZeroFolders` — a chat transitions to global and stays in the manager; (b) `GetAvailableChats_IncludesZeroFolderChat` / `GetAvailableChats_BoundChatExcludedFromOtherFolder` — global-default picker behavior and narrowing; (c) `AddFolderToChats_AddsFolderIdToChatFolders` / `AddFolderToChats_SingleInvocation_AddsFolderOnce` — single-event fan-out post-merge (regression for the #1261 manager merge that collapsed the Telegram + Slack subscriber pair into one); (d) `RemoveChatHandler_PrunesIdFromAllFolders` — the merged handler prunes the removed chat id from every folder.Chats reference (regression for the dual→single handler merge); (e) `Chat_WithSlackWebhookOnly_HasNoTelegramChatId` / `Chat_WithTelegramOnly_HasNoSlackWebhook` / `Chat_WithBothChannels_KeepsTelegramAndSlackFields` — pin the optional-channel invariants that let each sender null-guard its own field; (f) `Chat_MultiChannel_AccumulatorsAreIndependent` — regression for the shared-buffer bug fixed in PR #1265 (pre-fix, draining Telegram bumped the shared timer and starved Slack; per-channel `ChannelAccumulator` isolates state).
+- `src/tests/HSMServer.Core.Tests/Notifications/ChatFolderBindingTests.cs` — consolidated post-#1261 coverage of `IChatsManager` folder binding. Pins: (a) `RemoveFolderFromChats_DoesNotDeleteChatAtZeroFolders` — a chat transitions to global and stays in the manager; (b) `GetAvailableChats_IncludesZeroFolderChat` / `GetAvailableChats_BoundChatExcludedFromOtherFolder` — global-default picker behavior and narrowing; (c) `AddFolderToChats_AddsFolderIdToChatFolders` / `AddFolderToChats_SingleInvocation_AddsFolderOnce` — single-event fan-out post-merge (regression for the #1261 manager merge that collapsed the Telegram + Slack subscriber pair into one); (d) `RemoveChatHandler_PrunesIdFromAllFolders` — the merged handler prunes the removed chat id from every folder.Chats reference (regression for the dual→single handler merge); (e) `Chat_WithSlackWebhookOnly_HasNoTelegramChatId` / `Chat_WithTelegramOnly_HasNoSlackWebhook` / `Chat_WithBothChannels_KeepsTelegramAndSlackFields` — pin the optional-channel invariants that let each sender null-guard its own field; (f) `Chat_MultiChannel_AccumulatorsAreIndependent` — regression for the shared-buffer bug fixed in PR #1265 (pre-fix, draining Telegram bumped the shared timer and starved Slack; per-channel `ChannelAccumulator` isolates state). Extended in #1288 to cover three channels (Telegram + Slack + Mattermost) — drains Telegram, then Slack, and asserts the third accumulator's next-send timer is still unchanged.
 - `src/tests/HSMServer.Core.Tests/Folders/FolderManagerPruningTests.cs` — covers the pruning-skip rule in `FolderManager.TryUpdate`: when a chat becomes global (last binding removed), `ITreeValuesCache.RemoveChatsFromPoliciesAsync` is NOT invoked and the chat survives; when a chat still has another folder binding, pruning IS invoked with that chat id.
 - `src/tests/HSMServer.Core.Tests/Notifications/ChatsManagerTests.cs` — round-trip, update, remove, and `TelegramChatId` null-handling on the unified manager.
 - `src/tests/HSMServer.Core.Tests/Notifications/ChatMigrationTests.cs` — LevelDB migration of legacy `TelegramChats` / `SlackDestinations` into unified `Chats`, including preservation of `AuthorizationTime` and the self-healing additive write-back on every boot.
@@ -135,18 +140,50 @@ NotificationsBackgroundService (timer) -> NotificationsCenter.SendAllMessagesAsy
 
 Unified `ChatEntity` rows under the `"Chats"` LevelDB key, accessed via the single `IChatsManager`. The channel resolves webhook URLs and names from the same registry that Telegram uses — one chat can deliver through both channels. `IChatsManager.GetChatName(Guid)` is the only name resolver and is wired directly to `IFolderManager.GetChatName`.
 
+## Mattermost delivery
+
+`MattermostNotificationChannel : INotificationChannel` (`src/server/HSMServer/Notifications/Mattermost/MattermostNotificationChannel.cs`) is a line-for-line port of the Slack stack (#1288). Mattermost's incoming-webhook contract is Slack-compatible — one POST per `(alert, destination)` with `{"text": "..."}` JSON — so the channel is wired into `NotificationsCenter._channels` alongside Telegram and Slack with no top-level discriminator. Each channel resolves its own `MattermostWebhookUrl` field on the unified `Chat`.
+
+### HTTP delivery contract
+
+- One `HttpClient` per channel instance, registered via `services.AddHttpClient<MattermostNotificationChannel>()` in `ApplicationServiceExtensions`. Default request timeout: 30 s.
+- Per-chat aggregation mirrors Telegram and Slack. When `chat.MessagesAggregationTimeSec > 0`, `DeliverAsync` calls `chat.MattermostAccumulator.AddMessage(alert, scheduled)`; the periodic `FlushAsync` drains `MattermostAccumulator` via `ShouldSend` / `GetNotifications` and POSTs one payload per aggregated notification. When `MessagesAggregationTimeSec == 0`, `DeliverAsync` POSTs immediately with no buffering.
+- Payload shape: `MattermostMessageBuilder.BuildPayload(alert)` (or `BuildPayload(string)` for the test message) produces `{"text":"<alert.ToString()>"}` (System.Text.Json, camelCase). Rich blocks / Mattermost overrides are explicitly out of scope for v1.
+- Retry policy: up to 3 attempts (1 initial + 2 retries). Transient failures (HTTP 5xx and `RequestTimeout`) are retried with exponential backoff (initial 2 s, doubled per retry). 4xx responses are terminal — Mattermost returns 200 on success and 4xx for malformed payloads or revoked webhooks, so retrying would not help. Network errors (`HttpRequestException`) and timeouts (`TaskCanceledException`) are retried like 5xx.
+- `DeliverAsync` does not throw — every terminal failure is funneled through `ErrorHandled` and logged, matching the Telegram + Slack contract.
+
+### Events (mirroring TelegramBot + SlackNotificationChannel)
+
+- `event Action MessageSending` — raised once per POST attempt.
+- `event Action<string, string> MessageSended` — `(destinationName, payload)` on HTTP 200.
+- `event Action<string> ErrorHandled` — `(message)` on terminal failure or per-retry warning.
+
+### Diagnostics
+
+`MattermostChannelStatistics` (`src/server/HSMServer/BackgroundServices/DatacollectorService/Nodes/MattermostChannelStatistics.cs`) mirrors `SlackChannelStatistics` under NodeName `"Mattermost"`:
+
+- `Mattermost/Errors` — string sensor aggregating error messages.
+- `Mattermost/Total` — per-minute rate of POST attempts.
+- `Mattermost/Messages/<destinationName>` — per-destination string sensor with the last delivered payload.
+
+`DataCollectorWrapper` instantiates `MattermostChannelStatistics` alongside `SlackChannelStatistics` and subscribes/unsubscribes the three channel events symmetrically to the Slack wiring.
+
+### Storage
+
+Unified `ChatEntity` rows under the `"Chats"` LevelDB key, accessed via the single `IChatsManager`. The `MattermostWebhookUrl` column is nullable and was already round-tripping end-to-end before delivery shipped (#1275 surfaced the field on the edit form with the input disabled). One chat can deliver through any combination of Telegram, Slack, and Mattermost simultaneously — each delivery channel independently decides whether to send by checking its own channel-specific field on the resolved `Chat`.
+
 ## Per-channel aggregation state
 
 A unified `Chat` may carry Telegram, Slack, or both at the same time. Each configured channel must aggregate and flush independently — sharing one buffer across channels double-buffers each alert and lets whichever channel flushes first drain the buffer + bump the shared next-send timer, starving every other channel on that chat.
 
 Post-#1265 each channel owns a dedicated `ChannelAccumulator` (`src/server/HSMServer/Notifications/Chats/ChannelAccumulator.cs`):
 
-- `Chat._telegramAccumulator` + `Chat._slackAccumulator` — separate instances, never aliased.
-- `Chat.TelegramAccumulator` returns `_telegramAccumulator` only when `TelegramChatId is not null`; otherwise null. `Chat.SlackAccumulator` mirrors for `SlackWebhookUrl`. The null return lets senders early-skip a channel without an extra flag check.
+- `Chat._telegramAccumulator` + `Chat._slackAccumulator` + `Chat._mattermostAccumulator` — separate instances, never aliased.
+- `Chat.TelegramAccumulator` returns `_telegramAccumulator` only when `TelegramChatId is not null`; otherwise null. `Chat.SlackAccumulator` mirrors for `SlackWebhookUrl`, `Chat.MattermostAccumulator` mirrors for `MattermostWebhookUrl`. The null return lets senders early-skip a channel without an extra flag check.
 - Each accumulator owns its own `MessageBuilder` + `ScheduleBuilder` + `_nextSendMessageTime`. `ShouldSend(aggregationSec)` checks the timer; `GetNotifications(aggregationSec)` drains both builders and advances the timer in a `try/finally` so a drain failure still resets the schedule.
-- Senders index the accumulator via the channel-specific property. `TelegramBot` uses `chat.TelegramAccumulator.AddMessage` / `ShouldSend` / `GetNotifications`; `SlackNotificationChannel` uses the Slack-named counterparts. When `MessagesAggregationTimeSec == 0`, senders skip the accumulator and POST/send immediately.
+- Senders index the accumulator via the channel-specific property. `TelegramBot` uses `chat.TelegramAccumulator.AddMessage` / `ShouldSend` / `GetNotifications`; `SlackNotificationChannel` and `MattermostNotificationChannel` use their channel-named counterparts. When `MessagesAggregationTimeSec == 0`, senders skip the accumulator and POST/send immediately.
 
-The invariant is pinned by `ChatFolderBindingTests.Chat_MultiChannel_AccumulatorsAreIndependent` — drain Telegram and assert `SlackAccumulator.ShouldSend` is still true. A pre-fix regression (shared buffer) would fail the second assertion because Telegram's drain would have bumped the shared timer into the future.
+The invariant is pinned by `ChatFolderBindingTests.Chat_MultiChannel_AccumulatorsAreIndependent` — drain Telegram and assert `SlackAccumulator.ShouldSend` / `MattermostAccumulator.ShouldSend` are still true. Extended in #1288 to also drain Slack and re-assert Mattermost's timer is intact. A pre-fix regression (shared buffer) would fail the assertions because the first drain would have bumped the shared timer into the future.
 
 ## Management UI
 
@@ -158,14 +195,14 @@ Post-#1261 there is a single `Chat` entity. `NotificationsController` exposes a 
 - `GET  AddChat()` / `POST AddChat(ChatViewModel)` — admin-only entry point for creating a Slack/Mattermost-only chat (Telegram chats are still bootstrapped via the bot invitation flow, not this route).
 - `POST EditChat(ChatViewModel)` — updates any updatable field on an existing chat (Slack/Mattermost webhooks, name, description, enable flag, aggregation delay). Telegram-bound fields are init-only.
 - `POST RemoveChat(Guid id)` — removes the chat; `FolderManager.RemoveChatHandler` prunes its id from every folder.
-- `GET  SendTestSlackMessage(Guid id)` / `GET  SendTestTelegramMessage(long chatId)` — per-channel test action, each gated by the role appropriate to that channel.
+- `GET  SendTestSlackMessage(Guid id)` / `GET  SendTestMattermostMessage(Guid id)` / `GET  SendTestTelegramMessage(long chatId)` — per-channel test action, each gated by the role appropriate to that channel.
 
 `ChatViewModel` is the form DTO. `ToUpdate()` produces the `ChatUpdate` record consumed by `IChatsManager.TryUpdate`.
 
 UI surface (global admin scope):
 - `Views/Notifications/Index.cshtml` is the top-level Chats page (promoted out of Configuration/Settings in #1273 / PR #1274). It renders `Views/Configuration/_Chats.cshtml` as a partial.
 - `Views/Configuration/_Chats.cshtml` is the Chats list. After the #1281 rebuild it follows the Members-layout pattern (`Views/Account/Users.cshtml`): a search-by-name input + a channel-filter `<select>` (Any channel / Telegram / Slack / Mattermost; single-select — pick one channel to filter by, or leave on Any to show all) above a `.chat-list` of rows. Each row shows brand icons + chat Name + an Enabled/Disabled badge, with inline Edit (`fa-pen-to-square`, links to `EditChat`) and Remove (`fa-trash-can`, opens `_ConfirmationModal` then POSTs to `RemoveChat`) buttons. Each row also carries a folder-bindings badge cluster between the Name/Enabled badge and the action buttons — up to three `.chat-folder-badge` anchors (click → `FoldersController.EditFolder`) plus a `+N more` popover link when the chat is bound to more than three folders, with a blue `Public` pill for chats with zero bindings (a zero-binding chat is global — appears in every folder's destination picker, see "Folder binding" below; mirrors the Users products-badge pattern, backed by `ChatFoldersViewModel.DisplayFolders` populated in `ChatsSettingsViewModel(IChatsManager, IFolderManager)` post-#1284). Author and Created are no longer shown. Send-test-message actions were removed from the list — they already live on the `EditChat` form (`EditChat.cshtml`) per channel, so Edit is the single entry point for test sends. "Add new chat" links to `AddChat` (admin-only).
-- `Views/Notifications/EditChat.cshtml` is the unified multi-channel edit form (Common section: Name, Description, EnableMessages, MessagesDelay; tabs for Telegram / Slack / Mattermost — first configured channel wins, see issue #1271 / PR #1272). Telegram tab: bound chat id, type, authorization time — read-only for bot-connected chats, with invitation-link helpers for brand-new chats. Slack tab: webhook URL input with a "Show setup help" link that opens the `_SlackHelpModal.cshtml` modal — a 17-step incoming-webhook setup guide (copy carried over from #1256, retargeted to the unified form in #1275). Mattermost tab: webhook URL input (disabled — delivery not yet implemented) with a parallel "Show setup help" link opening `_MattermostHelpModal.cshtml` — a 12-step Mattermost guide for when delivery ships (#1275). Per-channel Send-test and Remove buttons live inside each tab pane and are shown only for channels the chat actually carries. Whole-chat deletion is **not** exposed from this form — the header used to carry a `Remove chat` link but it was dropped in #1275; per-channel clear (Telegram binding / Slack webhook / Mattermost webhook) stays inside the form. Whole-chat delete lives on the Chats list as an inline Remove button (`Configuration/_Chats.cshtml`, modal-confirmed — see #1281).
+- `Views/Notifications/EditChat.cshtml` is the unified multi-channel edit form (Common section: Name, Description, EnableMessages, MessagesDelay; tabs for Telegram / Slack / Mattermost — first configured channel wins, see issue #1271 / PR #1272). Telegram tab: bound chat id, type, authorization time — read-only for bot-connected chats, with invitation-link helpers for brand-new chats. Slack tab: webhook URL input with a "Show setup help" link that opens the `_SlackHelpModal.cshtml` modal — a 17-step incoming-webhook setup guide (copy carried over from #1256, retargeted to the unified form in #1275). Mattermost tab: webhook URL input with a parallel "Show setup help" link opening `_MattermostHelpModal.cshtml` — a 12-step Mattermost incoming-webhook guide (carried over from #1275; the input was disabled pre-#1288 with a "delivery not yet implemented" caveat — both removed once `MattermostNotificationChannel` shipped). Per-channel Send-test and Remove buttons live inside each tab pane and are shown only for channels the chat actually carries. Whole-chat deletion is **not** exposed from this form — the header used to carry a `Remove chat` link but it was dropped in #1275; per-channel clear (Telegram binding / Slack webhook / Mattermost webhook) stays inside the form. Whole-chat delete lives on the Chats list as an inline Remove button (`Configuration/_Chats.cshtml`, modal-confirmed — see #1281).
 
 ### Unified destination picker
 

--- a/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/ChatEntity.cs
+++ b/src/database/HSMDatabase.AccessManager/DatabaseEntities/VisualEntity/ChatEntity.cs
@@ -28,7 +28,7 @@ namespace HSMDatabase.AccessManager.DatabaseEntities
         public string SlackWebhookUrl { get; set; }
 
 
-        // Mattermost (optional, channel not implemented yet)
+        // Mattermost (optional)
         public string MattermostWebhookUrl { get; set; }
     }
 }

--- a/src/server/HSMServer.Core/Notifications/NotificationKind.cs
+++ b/src/server/HSMServer.Core/Notifications/NotificationKind.cs
@@ -4,5 +4,6 @@ namespace HSMServer.Core.Notifications
     {
         Telegram = 0,
         Slack = 1,
+        Mattermost = 2,
     }
 }

--- a/src/server/HSMServer/BackgroundServices/DatacollectorService/DataCollectorWrapper.cs
+++ b/src/server/HSMServer/BackgroundServices/DatacollectorService/DataCollectorWrapper.cs
@@ -58,6 +58,8 @@ namespace HSMServer.BackgroundServices
 
         internal SlackChannelStatistics SlackChannelStatistics { get; }
 
+        internal MattermostChannelStatistics MattermostChannelStatistics { get; }
+
 
         public DataCollectorWrapper(ITreeValuesCache cache, IDatabaseCore db, IServerConfig config, IOptionsMonitor<MonitoringOptions> optionsMonitor, NotificationsCenter notificationCenter)
         {
@@ -95,6 +97,7 @@ namespace HSMServer.BackgroundServices
             TreeValueCacheStatistics = new TreeValueChacheStatistics(_collector);
             TelegramBotStatistics = new TelegramBotStatistics(_collector);
             SlackChannelStatistics = new SlackChannelStatistics(_collector);
+            MattermostChannelStatistics = new MattermostChannelStatistics(_collector);
 
             _cache.RequestProcessed += OnRequestProcessed;
 
@@ -106,6 +109,10 @@ namespace HSMServer.BackgroundServices
             _notificationsCenter.SlackChannel.MessageSended += OnSlackMessageSended;
             _notificationsCenter.SlackChannel.ErrorHandled += OnSlackErrorHandled;
             _notificationsCenter.SlackChannel.MessageSending += OnSlackMessageSending;
+
+            _notificationsCenter.MattermostChannel.MessageSended += OnMattermostMessageSended;
+            _notificationsCenter.MattermostChannel.ErrorHandled += OnMattermostErrorHandled;
+            _notificationsCenter.MattermostChannel.MessageSending += OnMattermostMessageSending;
 
 
         }
@@ -124,6 +131,12 @@ namespace HSMServer.BackgroundServices
 
         private void OnSlackErrorHandled(string message) => SlackChannelStatistics.RegisterError(message);
 
+        private void OnMattermostMessageSended(string destination, string message) => MattermostChannelStatistics.RegisterMessageSended(destination, message);
+
+        private void OnMattermostMessageSending() => MattermostChannelStatistics.RegisterMessageSending();
+
+        private void OnMattermostErrorHandled(string message) => MattermostChannelStatistics.RegisterError(message);
+
 
         public void Dispose()
         {
@@ -134,6 +147,9 @@ namespace HSMServer.BackgroundServices
             _notificationsCenter.SlackChannel.MessageSended -= OnSlackMessageSended;
             _notificationsCenter.SlackChannel.ErrorHandled -= OnSlackErrorHandled;
             _notificationsCenter.SlackChannel.MessageSending -= OnSlackMessageSending;
+            _notificationsCenter.MattermostChannel.MessageSended -= OnMattermostMessageSended;
+            _notificationsCenter.MattermostChannel.ErrorHandled -= OnMattermostErrorHandled;
+            _notificationsCenter.MattermostChannel.MessageSending -= OnMattermostMessageSending;
             _collector?.Dispose();
         }
 

--- a/src/server/HSMServer/BackgroundServices/DatacollectorService/Nodes/MattermostChannelStatistics.cs
+++ b/src/server/HSMServer/BackgroundServices/DatacollectorService/Nodes/MattermostChannelStatistics.cs
@@ -1,0 +1,69 @@
+using HSMDataCollector.Core;
+using HSMDataCollector.Options;
+using HSMDataCollector.PublicInterface;
+using HSMSensorDataObjects.SensorRequests;
+using System;
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+
+namespace HSMServer.BackgroundServices
+{
+    public class MattermostChannelStatistics
+    {
+        private const string MessagesNode = "Messages";
+        private const string Errors = "Errors";
+        private const string NodeName = "Mattermost";
+        private const string Rate = "Total";
+
+        private readonly IDataCollector _collector;
+
+        private readonly ConcurrentDictionary<string, IInstantValueSensor<string>> _notifications = new();
+        private readonly IInstantValueSensor<string> _errors;
+        private readonly IMonitoringRateSensor _messagesRate;
+
+        private static readonly Regex LineBreakRegex = new(@"\r\n|\n|\r", RegexOptions.Compiled);
+
+
+        public MattermostChannelStatistics(IDataCollector collector)
+        {
+            _collector = collector;
+
+            _errors = collector.CreateStringSensor($"{NodeName}/{Errors}", new InstantSensorOptions
+            {
+                Alerts = [],
+                TTL = TimeSpan.MaxValue,
+                EnableForGrafana = false,
+                AggregateData = true,
+                Description = $"The sensor sends information about {NodeName} errors."
+            });
+
+            _messagesRate = collector.CreateRateSensor($"{NodeName}/{Rate}", new RateSensorOptions()
+            {
+                Alerts = [],
+                TTL = TimeSpan.MaxValue,
+                EnableForGrafana = false,
+                DisplayUnit = RateDisplayUnit.PerMinute,
+                PostDataPeriod = TimeSpan.FromMinutes(1),
+                Description = $"The sensor sends information about sent notifications to {NodeName}.",
+            });
+        }
+
+
+        public void RegisterMessageSended(string destination, string message)
+        {
+            var sensor = _notifications.GetOrAdd(destination, id => _collector.CreateStringSensor($"{NodeName}/{MessagesNode}/{id}", new InstantSensorOptions
+            {
+                Alerts = [],
+                TTL = TimeSpan.MaxValue,
+                EnableForGrafana = false,
+                Description = $"The sensor sends information about {NodeName} notifications messages sended."
+            }));
+
+            sensor.AddValue(LineBreakRegex.Replace(message, "<br>"));
+        }
+
+        public void RegisterMessageSending() => _messagesRate.AddValue(1);
+
+        public void RegisterError(string message) => _errors.AddValue(message);
+    }
+}

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -124,6 +124,16 @@ namespace HSMServer.Controllers
             return Ok();
         }
 
+        [HttpGet]
+        [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]
+        public async Task<IActionResult> SendTestMattermostMessage([FromQuery] Guid id)
+        {
+            if (ChatsManager.TryGetValue(id, out var chat))
+                await _notifications.MattermostChannel.SendTestAsync(chat);
+
+            return Ok();
+        }
+
         [HttpPost]
         [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]
         public async Task<IActionResult> RemoveTelegramBinding(Guid id) =>

--- a/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
+++ b/src/server/HSMServer/Extensions/ApplicationServiceExtensions.cs
@@ -63,6 +63,7 @@ namespace HSMServer.ServiceExtensions
                     .AddSingleton<NotificationsCenter>();
 
             services.AddHttpClient<SlackNotificationChannel>();
+            services.AddHttpClient<MattermostNotificationChannel>();
 
             services.AddHostedService<TreeSnapshotService>()
                     .AddHostedService<ClearDatabaseService>()

--- a/src/server/HSMServer/Notifications/Chats/Chat.cs
+++ b/src/server/HSMServer/Notifications/Chats/Chat.cs
@@ -13,6 +13,7 @@ namespace HSMServer.Notifications.Chats
 
         private readonly ChannelAccumulator _telegramAccumulator = new();
         private readonly ChannelAccumulator _slackAccumulator = new();
+        private readonly ChannelAccumulator _mattermostAccumulator = new();
 
 
         internal HashSet<Guid> Folders { get; } = [];
@@ -50,7 +51,7 @@ namespace HSMServer.Notifications.Chats
         public string SlackWebhookUrl { get; private set; }
 
 
-        // Mattermost (optional, channel not implemented yet)
+        // Mattermost (optional)
         public string MattermostWebhookUrl { get; private set; }
 
 
@@ -61,6 +62,8 @@ namespace HSMServer.Notifications.Chats
         internal ChannelAccumulator TelegramAccumulator => TelegramChatId is null ? null : _telegramAccumulator;
 
         internal ChannelAccumulator SlackAccumulator => string.IsNullOrEmpty(SlackWebhookUrl) ? null : _slackAccumulator;
+
+        internal ChannelAccumulator MattermostAccumulator => string.IsNullOrEmpty(MattermostWebhookUrl) ? null : _mattermostAccumulator;
 
 
         public Chat(ChatId chatId) : base()

--- a/src/server/HSMServer/Notifications/Mattermost/MattermostMessageBuilder.cs
+++ b/src/server/HSMServer/Notifications/Mattermost/MattermostMessageBuilder.cs
@@ -1,0 +1,32 @@
+using HSMServer.Core.Managers;
+using HSMServer.Core.Model.Policies;
+using System.Text.Json;
+
+namespace HSMServer.Notifications
+{
+    internal static class MattermostMessageBuilder
+    {
+        private static readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web);
+
+        public static string BuildPayload(AlertResult alert)
+        {
+            var text = alert.ToString();
+
+            var payload = new MattermostWebhookPayload { Text = text };
+
+            return JsonSerializer.Serialize(payload, _options);
+        }
+
+        public static string BuildPayload(string text)
+        {
+            var payload = new MattermostWebhookPayload { Text = text };
+
+            return JsonSerializer.Serialize(payload, _options);
+        }
+
+        private sealed record MattermostWebhookPayload
+        {
+            public string Text { get; init; }
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/Mattermost/MattermostNotificationChannel.cs
+++ b/src/server/HSMServer/Notifications/Mattermost/MattermostNotificationChannel.cs
@@ -1,0 +1,185 @@
+using HSMServer.Core.Managers;
+using HSMServer.Core.Model.Policies;
+using HSMServer.Core.Notifications;
+using HSMServer.Notifications.Channels;
+using HSMServer.Notifications.Chats;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace HSMServer.Notifications
+{
+    public sealed class MattermostNotificationChannel : INotificationChannel
+    {
+        internal const int DefaultMaxRetryAttempts = 3;
+        internal static readonly TimeSpan DefaultInitialBackoff = TimeSpan.FromSeconds(2);
+        internal static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromSeconds(30);
+
+        private static readonly NLog.Logger _logger = NLog.LogManager.GetLogger(nameof(MattermostNotificationChannel));
+
+        private readonly IChatsManager _chats;
+        private readonly HttpClient _httpClient;
+        private readonly int _maxRetryAttempts;
+        private readonly TimeSpan _initialBackoff;
+
+        public NotificationKind Kind => NotificationKind.Mattermost;
+
+        public event Action MessageSending;
+        public event Action<string, string> MessageSended;
+        public event Action<string> ErrorHandled;
+
+
+        public MattermostNotificationChannel(IChatsManager chats, HttpClient httpClient)
+            : this(chats, httpClient, DefaultMaxRetryAttempts, DefaultInitialBackoff, DefaultRequestTimeout)
+        {
+        }
+
+        internal MattermostNotificationChannel(IChatsManager chats, HttpClient httpClient,
+            int maxRetryAttempts, TimeSpan initialBackoff, TimeSpan requestTimeout)
+        {
+            _chats = chats;
+            _httpClient = httpClient;
+            _httpClient.Timeout = requestTimeout;
+            _maxRetryAttempts = maxRetryAttempts;
+            _initialBackoff = initialBackoff;
+        }
+
+
+        public async Task DeliverAsync(AlertMessage message)
+        {
+            try
+            {
+                foreach (var alert in message)
+                {
+                    foreach (var chatId in alert.Destination.Chats)
+                    {
+                        if (!_chats.TryGetValue(chatId, out var chat))
+                            continue;
+
+                        if (string.IsNullOrEmpty(chat.MattermostWebhookUrl))
+                            continue;
+
+                        if (!chat.SendMessages)
+                            continue;
+
+                        if (chat.MessagesAggregationTimeSec == 0)
+                        {
+                            var payload = MattermostMessageBuilder.BuildPayload(alert);
+                            await PostWithRetryAsync(chat.MattermostWebhookUrl, payload, chat.Name);
+                        }
+                        else
+                        {
+                            chat.MattermostAccumulator.AddMessage(alert, message is ScheduleAlertMessage);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Mattermost DeliverAsync failed");
+            }
+        }
+
+        public async Task FlushAsync()
+        {
+            foreach (var chat in _chats.GetValues())
+            {
+                if (string.IsNullOrEmpty(chat.MattermostWebhookUrl))
+                    continue;
+
+                try
+                {
+                    if (!chat.MattermostAccumulator.ShouldSend(chat.MessagesAggregationTimeSec))
+                        continue;
+
+                    foreach (var notification in chat.MattermostAccumulator.GetNotifications(chat.MessagesAggregationTimeSec))
+                    {
+                        if (string.IsNullOrWhiteSpace(notification))
+                            continue;
+
+                        var payload = MattermostMessageBuilder.BuildPayload(notification);
+                        await PostWithRetryAsync(chat.MattermostWebhookUrl, payload, chat.Name);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, $"Mattermost FlushAsync: error for chat {chat.Name}");
+                }
+            }
+        }
+
+
+        public async Task SendTestAsync(Chat chat)
+        {
+            if (string.IsNullOrEmpty(chat.MattermostWebhookUrl))
+                return;
+
+            var payload = MattermostMessageBuilder.BuildPayload("Test message from HSM");
+
+            await PostWithRetryAsync(chat.MattermostWebhookUrl, payload, chat.Name);
+        }
+
+
+        private async Task PostWithRetryAsync(string webhookUrl, string payload, string destinationName)
+        {
+            var backoff = _initialBackoff;
+
+            for (var attempt = 1; attempt <= _maxRetryAttempts; attempt++)
+            {
+                try
+                {
+                    MessageSending?.Invoke();
+
+                    using var content = new StringContent(payload, Encoding.UTF8, "application/json");
+                    using var response = await _httpClient.PostAsync(webhookUrl, content);
+
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        MessageSended?.Invoke(destinationName, payload);
+                        return;
+                    }
+
+                    if (IsTransient(response.StatusCode) && attempt < _maxRetryAttempts)
+                    {
+                        OnError($"Mattermost POST to {destinationName} returned {response.StatusCode}; retrying (attempt {attempt}/{_maxRetryAttempts})");
+                        await Task.Delay(backoff);
+                        backoff *= 2;
+                        continue;
+                    }
+
+                    OnError($"Mattermost POST to {destinationName} returned terminal status {response.StatusCode}; giving up");
+                    return;
+                }
+                catch (HttpRequestException ex) when (attempt < _maxRetryAttempts)
+                {
+                    OnError($"Mattermost POST to {destinationName} failed (attempt {attempt}/{_maxRetryAttempts}): {ex.Message}");
+                    await Task.Delay(backoff);
+                    backoff *= 2;
+                }
+                catch (TaskCanceledException) when (attempt < _maxRetryAttempts)
+                {
+                    OnError($"Mattermost POST to {destinationName} timed out (attempt {attempt}/{_maxRetryAttempts})");
+                    await Task.Delay(backoff);
+                    backoff *= 2;
+                }
+                catch (Exception ex)
+                {
+                    OnError($"Mattermost POST to {destinationName} failed terminally: {ex.Message}");
+                    return;
+                }
+            }
+        }
+
+        private static bool IsTransient(HttpStatusCode statusCode) =>
+            statusCode >= HttpStatusCode.InternalServerError || statusCode == HttpStatusCode.RequestTimeout;
+
+        private void OnError(string message)
+        {
+            _logger.Error(message);
+            ErrorHandled?.Invoke(message);
+        }
+    }
+}

--- a/src/server/HSMServer/Notifications/NotificationsCenter.cs
+++ b/src/server/HSMServer/Notifications/NotificationsCenter.cs
@@ -22,9 +22,11 @@ namespace HSMServer.Notifications
 
         public SlackNotificationChannel SlackChannel { get; }
 
+        public MattermostNotificationChannel MattermostChannel { get; }
+
 
         public NotificationsCenter(IChatsManager chats, IFolderManager folderManager, ITreeValuesCache cache, IServerConfig config,
-                                   SlackNotificationChannel slackChannel)
+                                   SlackNotificationChannel slackChannel, MattermostNotificationChannel mattermostChannel)
         {
             _chatsManager = chats;
             _folderManager = folderManager;
@@ -34,7 +36,8 @@ namespace HSMServer.Notifications
 
             TelegramBot = new(_chatsManager, folderManager, config.Telegram);
             SlackChannel = slackChannel;
-            _channels = [new TelegramNotificationChannel(TelegramBot), SlackChannel];
+            MattermostChannel = mattermostChannel;
+            _channels = [new TelegramNotificationChannel(TelegramBot), SlackChannel, MattermostChannel];
 
             _cache.NewAlertMessageEvent += DispatchAlertMessage;
         }

--- a/src/server/HSMServer/Views/Folders/_Chats.cshtml
+++ b/src/server/HSMServer/Views/Folders/_Chats.cshtml
@@ -130,6 +130,14 @@
                                             </a>
                                         </li>
                                     }
+                                    @if (!string.IsNullOrEmpty(chat.MattermostWebhookUrl))
+                                    {
+                                        <li>
+                                            <a id="sendMattermostMessage_@chat.Id" name="@chat.Id" class='dropdown-item text-decoration-none fw-normal' style="cursor: pointer;">
+                                                Send test Mattermost message
+                                            </a>
+                                        </li>
+                                    }
                                     @if (chat.TelegramChatId is not null && chat.TelegramType == ConnectedChatType.TelegramGroup)
                                     {
                                         <li>
@@ -216,6 +224,17 @@
         let chatId = this.name;
 
         let url = `@Url.Action(nameof(NotificationsController.SendTestSlackMessage), ViewConstants.NotificationsController)?id=${chatId}`;
+
+        $.ajax({ url: url });
+    });
+
+    $('[id^=sendMattermostMessage_]').on('click', function () {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+
+        let chatId = this.name;
+
+        let url = `@Url.Action(nameof(NotificationsController.SendTestMattermostMessage), ViewConstants.NotificationsController)?id=${chatId}`;
 
         $.ajax({ url: url });
     });

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -210,8 +210,7 @@
                                 <label class="chat-form-label col-form-label" for="MattermostWebhookUrl">Mattermost Webhook URL</label>
                             </div>
                             <div class="col-12 col-md-7">
-                                <input type="url" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." disabled />
-                                <small class="text-muted d-block mt-1">Mattermost delivery is not yet implemented — the URL saved here will be used once delivery ships.</small>
+                                <input type="url" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." />
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -224,6 +223,7 @@
                         @if (Model.HasMattermost)
                         {
                             <div class="d-flex gap-2">
+                                <a id="sendTestMattermost" data-chat-id="@Model.Id" class="btn btn-outline-secondary" style="cursor: pointer;">Send test Mattermost message</a>
                                 <a id="removeMattermost" class="btn btn-outline-danger" style="cursor: pointer;">Remove Mattermost</a>
                             </div>
                         }
@@ -283,6 +283,13 @@
             $.get("@Url.Action(nameof(NotificationsController.SendTestSlackMessage), ViewConstants.NotificationsController)", { id: id })
                 .done(function () { showToast("Test Slack message sent."); })
                 .fail(function () { showToast("Failed to send test Slack message."); });
+        });
+
+        $("#sendTestMattermost").off("click").on("click", function () {
+            var id = $(this).data("chat-id");
+            $.get("@Url.Action(nameof(NotificationsController.SendTestMattermostMessage), ViewConstants.NotificationsController)", { id: id })
+                .done(function () { showToast("Test Mattermost message sent."); })
+                .fail(function () { showToast("Failed to send test Mattermost message."); });
         });
 
         $("#removeTelegram").off("click").on("click", function () {

--- a/src/server/HSMServer/Views/Notifications/_MattermostHelpModal.cshtml
+++ b/src/server/HSMServer/Views/Notifications/_MattermostHelpModal.cshtml
@@ -7,7 +7,6 @@
             </div>
 
             <div class="modal-body">
-                <p><em>Mattermost delivery is not yet implemented.</em> The URL saved here will be used once delivery ships. The guide below describes how to obtain the URL ahead of time.</p>
                 <p>A Mattermost incoming webhook is a private URL that lets HSM post alert messages into one selected Mattermost channel. Create this URL in your Mattermost server, then paste it into the Webhook URL field in HSM.</p>
                 <ol>
                     <li>You need a Mattermost account with permission to create integrations, or ask a System Admin for help.</li>

--- a/src/tests/HSMServer.Core.Tests/Notifications/ChatFolderBindingTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/ChatFolderBindingTests.cs
@@ -188,7 +188,7 @@ namespace HSMServer.Core.Tests.Notifications
         // configured, the alert was double-buffered and the first channel to flush bumped the
         // shared timer, so the second channel was skipped. ChannelAccumulator gives each channel
         // its own state — this test pins that contract by draining Telegram and confirming the
-        // Slack timer is unchanged.
+        // Slack/Mattermost timers are unchanged. Extended in #1288 to cover the third channel.
         [Fact]
         public void Chat_MultiChannel_AccumulatorsAreIndependent()
         {
@@ -197,19 +197,28 @@ namespace HSMServer.Core.Tests.Notifications
 
             Assert.NotNull(chat.TelegramAccumulator);
             Assert.NotNull(chat.SlackAccumulator);
+            Assert.NotNull(chat.MattermostAccumulator);
             Assert.NotSame(chat.TelegramAccumulator, chat.SlackAccumulator);
+            Assert.NotSame(chat.TelegramAccumulator, chat.MattermostAccumulator);
+            Assert.NotSame(chat.SlackAccumulator, chat.MattermostAccumulator);
 
-            // Both ready to send initially — _nextSendMessageTime defaults to DateTime.MinValue.
+            // All ready to send initially — _nextSendMessageTime defaults to DateTime.MinValue.
             Assert.True(chat.TelegramAccumulator.ShouldSend(aggregation));
             Assert.True(chat.SlackAccumulator.ShouldSend(aggregation));
+            Assert.True(chat.MattermostAccumulator.ShouldSend(aggregation));
 
-            // Drain Telegram (mirrors NotificationsCenter flush order [Telegram, Slack]). Even
-            // with no buffered alerts, GetNotifications bumps Telegram's timer to the future.
+            // Drain Telegram (mirrors NotificationsCenter flush order [Telegram, Slack, Mattermost]).
+            // Even with no buffered alerts, GetNotifications bumps Telegram's timer to the future.
             _ = chat.TelegramAccumulator.GetNotifications(aggregation).ToList();
 
             // Pre-fix: this was false because Telegram's drain bumped the shared timer.
-            // Post-fix: each accumulator owns its own timer, so Slack is still ready to fire.
+            // Post-fix: each accumulator owns its own timer, so Slack + Mattermost are still ready.
             Assert.True(chat.SlackAccumulator.ShouldSend(aggregation));
+            Assert.True(chat.MattermostAccumulator.ShouldSend(aggregation));
+
+            // Drain Slack too — Mattermost must remain unaffected by either prior drain.
+            _ = chat.SlackAccumulator.GetNotifications(aggregation).ToList();
+            Assert.True(chat.MattermostAccumulator.ShouldSend(aggregation));
         }
 
 
@@ -255,6 +264,7 @@ namespace HSMServer.Core.Tests.Notifications
                 TelegramType = (byte)ConnectedChatType.TelegramGroup,
                 AuthorizationTime = DateTime.UtcNow.Ticks,
                 SlackWebhookUrl = "https://hooks.slack.com/services/X",
+                MattermostWebhookUrl = "https://mattermost.example/hooks/X",
             });
 
         private static (ChatsManager manager, Guid chatId) SeedChat()


### PR DESCRIPTION
## Summary

Ports the Slack notification stack component-for-component to Mattermost, closing the gap where `Chat.MattermostWebhookUrl` was saved end-to-end but no channel actually delivered. Mattermost's incoming-webhook contract is Slack-compatible (one POST per `(alert, destination)`, `{"text":"..."}` JSON), so the port is mechanical.

- New `MattermostNotificationChannel : INotificationChannel` + `MattermostMessageBuilder` under `Notifications/Mattermost/`, mirroring the Slack stack line-for-line (3 retry attempts, 2 s exponential backoff, 5xx + timeout retried, 4xx terminal, `MessageSending` / `MessageSended` / `ErrorHandled` events, `DeliverAsync` / `FlushAsync` / `SendTestAsync`).
- `Chat._mattermostAccumulator` + `MattermostAccumulator` (null when `MattermostWebhookUrl` is empty), preserving the post-#1265 per-channel accumulator isolation invariant.
- `MattermostChannelStatistics` diagnostics node (`Mattermost/Errors`, `Mattermost/Total`, `Mattermost/Messages/<destinationName>`) subscribed symmetrically to the Slack wiring in `DataCollectorWrapper`.
- `NotificationsCenter` wires the third channel into `_channels`; `NotificationsController.SendTestMattermostMessage` mirrors `SendTestSlackMessage` with the same `[TelegramRoleFilterById(..., ProductRoleEnum.ProductManager)]` role gate.
- `EditChat` Mattermost tab: webhook input enabled, "delivery not yet implemented" caveat removed, Send-test button added alongside Remove.
- `feature.md` gets a parallel "Mattermost delivery" section; data-flow diagram and `NotificationKind` metadata updated.

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.csproj` — 0 errors.
- [x] `dotnet test src/tests/HSMServer.Core.Tests/HSMServer.Core.Tests.csproj --filter "FullyQualifiedName~Notifications"` — 29/29 pass, including extended `Chat_MultiChannel_AccumulatorsAreIndependent` covering 3 channels.
- [ ] Manual smoke (post-merge on a dev server): set a Mattermost incoming-webhook URL on a chat, trigger an alert, verify the POST reaches Mattermost and `Mattermost/Total` / `Mattermost/Messages/<chatName>` sensors populate.
- [ ] Manual smoke: click "Send test Mattermost message" in the Mattermost tab and verify a `Test message from HSM` lands in the channel.

Closes #1288

🤖 Generated with [Claude Code](https://claude.com/claude-code)