### PR TITLE
fix(Notifications): unbreak Remove Slack/Mattermost + reopen on cleared tab

### DIFF
--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -41,9 +41,14 @@ namespace HSMServer.Controllers
 
         [HttpGet]
         [TelegramRoleFilterById(nameof(id), ProductRoleEnum.ProductManager)]
-        public IActionResult EditChat(Guid id) => ChatsManager.TryGetValue(id, out var chat)
-            ? View(new ChatViewModel(chat, BuildChatFolders(chat)))
-            : _emptyResult;
+        public IActionResult EditChat(Guid id, string tab = null)
+        {
+            if (!ChatsManager.TryGetValue(id, out var chat))
+                return _emptyResult;
+
+            ViewData["Tab"] = tab;
+            return View(new ChatViewModel(chat, BuildChatFolders(chat)));
+        }
 
         [HttpPost]
         [TelegramRoleFilterByEditModel(nameof(model), ProductRoleEnum.ProductManager)]

--- a/src/server/HSMServer/Filters/UserRoleFilterBase.cs
+++ b/src/server/HSMServer/Filters/UserRoleFilterBase.cs
@@ -1,5 +1,6 @@
 ﻿using HSMServer.Constants;
 using HSMServer.Model.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using System;
@@ -33,10 +34,22 @@ namespace HSMServer.Filters
             if ((user?.IsAdmin ?? false) || TryCheckRole(context, user)) //Admins have all possible access
                 return;
 
-            context.Result = _redirectToHomeIndex;
+            // AJAX callers (e.g. EditChat's removeChannel POST) follow 302→/Home/Index and end up
+            // with a 200 HTML response — jQuery's `success` fires and the caller reloads the form
+            // looking like the write succeeded when the action was never authorised to run. Return
+            // 403 so jQuery's `error` runs and the user sees the failure toast. Non-AJAX callers
+            // (typed URLs, form GETs) keep the legacy redirect-to-home behavior.
+            context.Result = IsAjaxRequest(context)
+                ? new StatusCodeResult(StatusCodes.Status403Forbidden)
+                : _redirectToHomeIndex;
         }
 
         public void OnActionExecuted(ActionExecutedContext context) { }
+
+
+        private static bool IsAjaxRequest(ActionExecutingContext context) =>
+            context.HttpContext.Request.Headers.TryGetValue("X-Requested-With", out var value)
+            && string.Equals(value, "XMLHttpRequest", StringComparison.OrdinalIgnoreCase);
 
 
         protected abstract bool HasRole(User user, Guid? entityId, ProductRoleEnum role);

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -21,7 +21,11 @@
     // field. An existing chat with no channels configured (e.g. right after ClearSlackWebhook)
     // also falls back to Slack — landing on Telegram would surprise the user, who just acted on
     // the Slack webhook. Mattermost only wins if it's the sole configured channel.
-    var defaultTab = isTelegramBound ? "telegram"
+    // An explicit ?tab= from the query string (e.g. after clearing a channel) wins over everything
+    // so the user lands back on the tab they just acted on.
+    var requestedTab = ViewData["Tab"] as string;
+    var defaultTab = !string.IsNullOrEmpty(requestedTab) ? requestedTab
+                   : isTelegramBound ? "telegram"
                    : Model.HasMattermost && !Model.HasSlack ? "mattermost"
                    : "slack";
 }
@@ -252,8 +256,9 @@
 
 <script>
     // Per-channel Remove buttons. Each clears only its channel; the Chat row and the other
-    // channels stay intact. Form reloads to reflect the post-clear state.
-    function removeChannel(channelName, actionUrl, confirmText) {
+    // channels stay intact. On success the form reopens on the just-cleared channel's tab so
+    // the user can paste a new URL without an extra click.
+    function removeChannel(channelName, channelTab, actionUrl, confirmText) {
         showConfirmationModal(
             `Removing ${channelName} from chat '@Model.Name'`,
             confirmText,
@@ -263,7 +268,10 @@
                     url: actionUrl + `?id=@Model.Id`,
                     cache: false,
                     async: true,
-                    success: function () { window.location.reload(); },
+                    success: function () {
+                        window.location.href =
+                            `@Url.Action(nameof(NotificationsController.EditChat), ViewConstants.NotificationsController)?id=@Model.Id&tab=${channelTab}`;
+                    },
                     error: function () { showToast(`Failed to remove ${channelName.toLowerCase()} from chat.`); }
                 });
             }
@@ -295,6 +303,7 @@
         $("#removeTelegram").off("click").on("click", function () {
             removeChannel(
                 "Telegram binding",
+                "telegram",
                 "@Url.Action(nameof(NotificationsController.RemoveTelegramBinding), ViewConstants.NotificationsController)",
                 `Telegram binding will be removed from chat '@Model.Name'. The chat itself, its folder bindings, and other channels stay intact.`
             );
@@ -303,6 +312,7 @@
         $("#removeSlack").off("click").on("click", function () {
             removeChannel(
                 "Slack webhook",
+                "slack",
                 "@Url.Action(nameof(NotificationsController.ClearSlackWebhook), ViewConstants.NotificationsController)",
                 `Slack webhook will be removed from chat '@Model.Name'. The chat itself and other channels stay intact.`
             );
@@ -311,6 +321,7 @@
         $("#removeMattermost").off("click").on("click", function () {
             removeChannel(
                 "Mattermost webhook",
+                "mattermost",
                 "@Url.Action(nameof(NotificationsController.ClearMattermostWebhook), ViewConstants.NotificationsController)",
                 `Mattermost webhook will be removed from chat '@Model.Name'. The chat itself and other channels stay intact.`
             );

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -180,13 +180,19 @@ test('EditChat: per-channel Remove clears Slack webhook without deleting the cha
   await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/remove-test');
   await expect(page.locator('#removeSlack')).toBeVisible();
 
-  // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and the
-  // page reloads (EditChat.cshtml removeChannel success handler). Wait for the reload to land
-  // before asserting — otherwise the auto-waiting toHaveValue('') can race against the
-  // still-rendering previous DOM and flake.
+  // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and
+  // removeChannel's success handler navigates to EditChat?id=...&tab=slack (#1292 — used to be a
+  // plain reload()). Wait for the navigation to land before asserting — otherwise the
+  // auto-waiting toHaveValue('') can race against the still-rendering previous DOM and flake.
   await page.locator('#removeSlack').click();
   await page.getByRole('button', { name: 'OK' }).click();
   await page.waitForLoadState('domcontentloaded');
+
+  // The navigation target carries &tab=slack and the view's defaultTab honors it first, so the
+  // Slack tab stays active even though HasSlack is now false (the old heuristic would have
+  // fallen through to Mattermost or Telegram).
+  await expect(page).toHaveURL(/tab=slack/);
+  await expect(page.locator('#slack-tab')).toHaveClass(/\bactive\b/);
 
   // After reload, the webhook field is empty and the per-channel Remove button is gone
   // (HasSlack is now false). The chat still exists — only the webhook was cleared.


### PR DESCRIPTION
## Summary

Fixes two issues reported in #1292 with the EditChat Remove buttons:

1. **Remove Slack / Remove Mattermost silently failed for non-admin users editing chats with zero folder bindings** (e.g. Public chats). `UserRoleFilterBase` redirected the POST to `/Home/Index` (302); jQuery followed the redirect to a 200 HTML response; the `success` callback fired; the page reloaded with the webhook unchanged — looking exactly like a successful write. The filter now returns `403 Forbidden` for AJAX callers (detected via `X-Requested-With: XMLHttpRequest`) so jQuery's `error` runs and the failure toast shows. Typed URLs and form GETs keep the legacy redirect-to-home behavior.

2. **After clearing a channel, EditChat now reopens on that channel's tab** instead of falling back to the first-configured-channel heuristic. `removeChannel` now navigates to `EditChat?id=...&tab=<channel>` on success; the GET action accepts an optional `tab` query parameter and stashes it in `ViewData["Tab"]`; the view's `defaultTab` honors it first.

Persistence layer was already correct — `ChatsManagerTests.TryUpdate_ClearSlackWebhook_FlagSetsFieldToNull` and `_ClearMattermostWebhook_...` both pass. The bug was entirely in the filter↔AJAX interaction.

## Test plan

- [x] `dotnet build src/server/HSMServer/HSMServer.csproj` — clean compile
- [x] `dotnet test src/tests/HSMServer.Core.Tests/HSMServer.Core.Tests.csproj --filter "FullyQualifiedName~Notifications|FullyQualifiedName~Chats"` — 36/36 pass
- [x] Extended `src/tests/Autotests/products/modify_folder_chat.spec.ts` Remove-Slack test: updated stale comment (was "page reloads", now "navigates to ?tab=slack"), added assertions that the URL contains `tab=slack` and the `#slack-tab` has the `active` class (verifies feature #2)
- [ ] Manual smoke: as a non-admin user with no ProductManager role on a chat with zero folder bindings, click Remove Slack → confirm → observe the "Failed to remove slack from chat" toast (no silent reload) — verifies feature #1
- [ ] Manual smoke: as an admin, click Remove Slack on a multi-channel chat → webhook cleared, page reloads on the **Slack tab** (not Telegram or Mattermost)
- [ ] Manual smoke: same flow for Mattermost; same flow for Telegram binding (where applicable)

Closes #1292

🤖 Generated with [Claude Code](https://claude.com/claude-code)