### PR TITLE
fix(Notifications): align Enable messages switch with form axis

### DIFF
--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -90,7 +90,7 @@
                         <i class='fas fa-question-circle text-secondary' title='True means that alert notifications for this chat is enabled.'></i>
                     </div>
                     <div class="col-12 col-md-7">
-                        <div class="form-check form-switch m-0 mt-md-2">
+                        <div class="form-check form-switch m-0 mt-md-2 ps-0">
                             <input id="messages-settings" class="form-check-input m-0" type="checkbox" asp-for="EnableMessages">
                         </div>
                     </div>

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -90,7 +90,7 @@
                         <i class='fas fa-question-circle text-secondary' title='True means that alert notifications for this chat is enabled.'></i>
                     </div>
                     <div class="col-12 col-md-7">
-                        <div class="form-check form-switch m-0">
+                        <div class="form-check form-switch m-0 mt-md-2">
                             <input id="messages-settings" class="form-check-input m-0" type="checkbox" asp-for="EnableMessages">
                         </div>
                     </div>


### PR DESCRIPTION
## Summary

The `Enable messages` switch in `Configuration → Chats → Add/Edit chat` was visually detached from the vertical rhythm used by `Name`, `Description`, and `Messages delay`. The three text rows use `form-control` / `input-group` (~38px tall), while the switch row had `m-0` on its wrapper, leaving the small (~16px) toggle sitting on a shorter row and out of line with the rest of the form.

This change adds `mt-md-2` to the `form-check form-switch` wrapper so the toggle is nudged down to the same input baseline as the surrounding `form-control` rows. It mirrors the existing switch pattern already used in `_Agent.cshtml`, `_Backup.cshtml`, and `_Telegram.cshtml`, so the alignment language stays consistent across the app.

The `Enable messages` behavior and saved value semantics are unchanged — this is markup-only.

## Test plan

- [ ] Open `Configuration → Chats → Add new chat` and confirm the `Enable messages` switch sits on the same input axis as `Name`, `Description`, and `Messages delay`.
- [ ] Open an existing chat's edit page and confirm the same alignment.
- [ ] Resize to a narrow / mobile width and confirm the label + help icon still stack cleanly above the switch with no overlaps (the `mt-md-2` only applies at md+).
- [ ] Toggle `Enable messages` on and off, save, reopen the chat, and confirm the saved value matches what was selected.

Closes #1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)