### PR TITLE
Release HSMServer 3.41.2

### DIFF
--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,27 +1,5 @@
 # HSM Server
 
 ## Notifications
-* Mattermost delivery shipped — third channel alongside Telegram and Slack. Per-folder chats deliver to any combination of the three.
-* Unified Chat entity: Telegram + Slack + Mattermost merged into a single per-folder Chat. LevelDB migration runs on startup; legacy entities preserved.
-* Chats promoted to a top-level Configuration menu entry.
-* Unbound chats are now accessible from any folder.
-* Per-channel Remove buttons and Send-test Slack/Mattermost in the chat editor.
-* Folder bindings shown as badges on the Chats list.
-* XSS hardening: chat names double-encoded in dropdown data attributes.
-* Chat edit save redirects to the Chats list; non-admin PMs no longer 401.
-
-## Alerts
-* Slack destinations appear in the Alert Template notification dropdown.
-* Saved TTL alert can be demoted back to a regular condition.
-* Mixed-type path templates blocked; stale template policies pruned on edit.
-
-## Folder nodes
-* New Chart tab overlays up to 20 comparable child sensors with a group/type/unit selector.
-
-## Security
-* DOMPurify upgraded 3.0.1 → 3.4.11 (HIGH XSS fixes).
-* Usernames limited to 64 characters across all creation flows.
-* Node Chart gated on caller's product access.
-
-## Products
-* "Download agent" action moved to the product edit page.
+* Connecting a Telegram chat from the chat editor now binds to the chat being edited (including a brand-new chat saved from the editor) instead of creating a separate orphan chat. Stale Telegram bindings self-heal on reconnect, and when a Telegram chat is already bound elsewhere, the owning chat is named in the refusal message.
+* The chat editor shows a "Telegram chat connected" toast and auto-refreshes to the bound state once the bot completes `/start` — the binding is async (handled by the bot), so the page previously required a manual refresh.

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.41.1</Version>
+    <Version>3.41.2</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Bumps \`3.41.1\` → \`3.41.2\` and regenerates \`ReleaseNote.md\`.

### What's in the release
- **Notifications:** connecting a Telegram chat from the chat editor now binds to the chat being edited instead of creating an orphan; stale bindings self-heal on reconnect, and the owning chat is named when a Telegram chat already bound elsewhere is refused (#1304 / #1305).
- **Notifications:** the chat editor shows a "Telegram chat connected" toast and auto-refreshes to the bound state once the bot completes \`/start\` (#1307 / #1308).

After merge, \`/release-server\` will trigger \`server-build.yml\` with \`isPreRelease=false\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)