### PR TITLE
fix(alert-templates): stop silent template wipe on server restart

### DIFF
--- a/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
+++ b/src/database/HSMDatabase.LevelDB/DatabaseImplementations/EnvironmentDatabaseWorker.cs
@@ -717,7 +717,7 @@ namespace HSMDatabase.LevelDB.DatabaseImplementations
             {
                 var ids = GetAllAlertTemplatesIds();
 
-                if (!ids.Contains(id))
+                if (!ids.Any(existingId => existingId.SequenceEqual(id)))
                 {
                     ids.Add(id);
                     _database.Put(_alertTemplatesIdsKey, JsonSerializer.SerializeToUtf8Bytes(ids));

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -2012,14 +2012,18 @@ namespace HSMServer.Core.Cache
             _logger.Info($"{nameof(IDatabaseCore.GetAllAlertTemplates)} requested");
 
             _logger.Info($"{nameof(alertTemlatesEntities)} are applying");
+            // NOTE: GetAllAlertTemplates expands from the "AlertTemplates" index, which historically
+            // could contain duplicate GUIDs (AddAlertTemplateIdToList used reference equality on byte[]).
+            // Do NOT delete template entities here for duplicates seen during iteration — that wiped
+            // every template on restart once the index had grown duplicates (see #1312). Just populate
+            // the in-memory cache with the first occurrence of each GUID and ignore subsequent copies.
             foreach (var template in alertTemlatesEntities)
             {
                 var model = new AlertTemplateModel(template);
-                if (!_alertTemplates.ContainsKey(new Guid(template.Id)))
-                    _alertTemplates.TryAdd(model.Id, model);
-                else
-                    _database.RemoveAlertTemplate(new Guid(template.Id));
+                _alertTemplates.TryAdd(model.Id, model);
             }
+            if (alertTemlatesEntities.Count != _alertTemplates.Count)
+                _logger.Warn($"AlertTemplates index contained duplicates: {alertTemlatesEntities.Count} entries for {_alertTemplates.Count} unique templates. Run database compaction cleanup to deduplicate.");
             _logger.Info($"{nameof(alertTemlatesEntities)} applied");
 
             _logger.Info($"{nameof(TreeValuesCache)} initialized");

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -2012,18 +2012,18 @@ namespace HSMServer.Core.Cache
             _logger.Info($"{nameof(IDatabaseCore.GetAllAlertTemplates)} requested");
 
             _logger.Info($"{nameof(alertTemlatesEntities)} are applying");
-            // NOTE: GetAllAlertTemplates expands from the "AlertTemplates" index, which historically
-            // could contain duplicate GUIDs (AddAlertTemplateIdToList used reference equality on byte[]).
-            // Do NOT delete template entities here for duplicates seen during iteration — that wiped
-            // every template on restart once the index had grown duplicates (see #1312). Just populate
-            // the in-memory cache with the first occurrence of each GUID and ignore subsequent copies.
+            // GetAllAlertTemplates expands from the "AlertTemplates" index, which historically could
+            // contain duplicate GUIDs. Do NOT delete templates seen more than once here — that wiped
+            // every template on restart once the index had grown duplicates (see #1312). Use TryAdd so
+            // the in-memory cache keeps the first occurrence per GUID; any pre-existing duplicates in
+            // the LevelDB index are reported below but require manual cleanup.
             foreach (var template in alertTemlatesEntities)
             {
                 var model = new AlertTemplateModel(template);
                 _alertTemplates.TryAdd(model.Id, model);
             }
             if (alertTemlatesEntities.Count != _alertTemplates.Count)
-                _logger.Warn($"AlertTemplates index contained duplicates: {alertTemlatesEntities.Count} entries for {_alertTemplates.Count} unique templates. Run database compaction cleanup to deduplicate.");
+                _logger.Warn($"AlertTemplates index contained duplicates: {alertTemlatesEntities.Count} entries for {_alertTemplates.Count} unique templates. Manual cleanup of the LevelDB \"AlertTemplates\" key is required to remove them.");
             _logger.Info($"{nameof(alertTemlatesEntities)} applied");
 
             _logger.Info($"{nameof(TreeValuesCache)} initialized");

--- a/src/tests/HSMDatabase.LevelDB.Tests/AlertTemplatesDBTests/AlertTemplateIndexTests.cs
+++ b/src/tests/HSMDatabase.LevelDB.Tests/AlertTemplatesDBTests/AlertTemplateIndexTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Linq;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMServer.Core.Tests.DatabaseTests;
+using HSMServer.Core.Tests.Infrastructure;
+using HSMServer.Core.Tests.MonitoringCoreTests.Fixture;
+using Xunit;
+
+namespace HSMDatabase.LevelDB.Tests.AlertTemplatesDBTests;
+
+[Collection("Database collection")]
+public class AlertTemplateIndexTests : DatabaseCoreTestsBase<AlertTemplateIndexFixture>, IClassFixture<DatabaseRegisterFixture>
+{
+    public AlertTemplateIndexTests(AlertTemplateIndexFixture fixture, DatabaseRegisterFixture registerFixture)
+        : base(fixture, registerFixture) { }
+
+
+    // Regression for #1312: AddAlertTemplateIdToList used List<byte[]>.Contains, which compares arrays
+    // by reference. Every re-save of a template appended another copy of its GUID to the "AlertTemplates"
+    // index. Repeated AddAlertTemplate with the same Id must keep the index at a single entry.
+    [Fact]
+    public void AddAlertTemplate_SameIdRepeated_KeepsSingleIndexEntry()
+    {
+        var id = Guid.NewGuid();
+        var entity = BuildEntity(id);
+
+        _databaseCoreManager.DatabaseCore.AddAlertTemplate(entity);
+        _databaseCoreManager.DatabaseCore.AddAlertTemplate(entity);
+        _databaseCoreManager.DatabaseCore.AddAlertTemplate(entity);
+
+        var all = _databaseCoreManager.DatabaseCore.GetAllAlertTemplates();
+
+        var matching = all.Where(t => new Guid(t.Id) == id).ToList();
+        Assert.Single(matching);
+    }
+
+    [Fact]
+    public void AddAlertTemplate_DistinctIds_KeepsAllEntries()
+    {
+        var idA = Guid.NewGuid();
+        var idB = Guid.NewGuid();
+
+        _databaseCoreManager.DatabaseCore.AddAlertTemplate(BuildEntity(idA));
+        _databaseCoreManager.DatabaseCore.AddAlertTemplate(BuildEntity(idB));
+
+        var all = _databaseCoreManager.DatabaseCore.GetAllAlertTemplates();
+
+        Assert.Contains(all, t => new Guid(t.Id) == idA);
+        Assert.Contains(all, t => new Guid(t.Id) == idB);
+    }
+
+
+    private static AlertTemplateEntity BuildEntity(Guid id) => new()
+    {
+        Id = id.ToByteArray(),
+        Name = $"Template {id}",
+        FolderId = Guid.Empty,
+        SensorType = 0,
+        Policies = [],
+        TTLPolicies = [],
+        TTLs = [],
+        Paths = [],
+    };
+}
+
+public class AlertTemplateIndexFixture : DatabaseFixture
+{
+    protected override string DatabaseFolder => nameof(AlertTemplateIndexTests);
+}


### PR DESCRIPTION
## Summary
Fixes the two compounding bugs from #1312 that silently wiped every Alert Template whose GUID had accumulated duplicates in the LevelDB `"AlertTemplates"` index. On the live deployment this deleted 17 templates between the July 17 and July 21 backups while leaving orphaned `TemplateId` references on sensor policies.

- `AddAlertTemplateIdToList` now compares `byte[]` by content (`SequenceEqual`) instead of reference equality, matching the existing `AddAlertScheduleIdToList`. Duplicate GUIDs are no longer appended on every re-save.
- `TreeValuesCache.Initialize()` no longer calls `_database.RemoveAlertTemplate` for templates it sees more than once during startup. The in-memory cache is populated with `TryAdd`, and a warning is logged when duplicates are detected. Template entities are never deleted during dedup.

## Test plan
- [x] Build of `HSMDatabase.LevelDB` and `HSMServer.Core` succeeds with 0 errors
- [x] Build of `HSMDatabase.LevelDB.Tests` succeeds with 0 errors
- [ ] CI: new test `AlertTemplateIndexTests.AddAlertTemplate_SameIdRepeated_KeepsSingleIndexEntry` passes (would have failed on the old `ids.Contains(id)` code)
- [ ] CI: `AlertTemplateIndexTests.AddAlertTemplate_DistinctIds_KeepsAllEntries` passes
- [ ] Manual: restart server with a duplicated `"AlertTemplates"` index — all template entities preserved, index no longer collapsed

Closes #1312

🤖 Generated with [Claude Code](https://claude.com/claude-code)