### PR TITLE
Release HSMServer 3.41.3

### DIFF
--- a/ReleaseNote.md
+++ b/ReleaseNote.md
@@ -1,5 +1,8 @@
 # HSM Server
 
-## Notifications
-* Connecting a Telegram chat from the chat editor now binds to the chat being edited (including a brand-new chat saved from the editor) instead of creating a separate orphan chat. Stale Telegram bindings self-heal on reconnect, and when a Telegram chat is already bound elsewhere, the owning chat is named in the refusal message.
-* The chat editor shows a "Telegram chat connected" toast and auto-refreshes to the bound state once the bot completes `/start` — the binding is async (handled by the bot), so the page previously required a manual refresh.
+## Restore
+* New Alert Template restore wizard: import alert templates from a backup file into the current server, with existing templates detected and marked, and camelCase field mapping preserved.
+
+## Bug fixes
+* Fixed silent wipe of alert templates on server restart caused by erroneous deduplication compaction; the misleading compaction hint was also removed.
+* Backup restore now creates the target directory before opening the backup database, preventing a failure on fresh paths.

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -5,7 +5,7 @@
     <DocumentationFile>HSMSwaggerComments.xml</DocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <SatelliteResourceLanguages>en</SatelliteResourceLanguages>
-    <Version>3.41.2</Version>
+    <Version>3.41.3</Version>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>


### PR DESCRIPTION
Bumps `3.41.2` → `3.41.3` and regenerates `ReleaseNote.md`.

After merge, `/release-server` will trigger `server-build.yml` with `isPreRelease=false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)