### PR TITLE
Native collector: nest Top CPU sensors under .computer

### DIFF
--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -4355,8 +4355,21 @@ namespace
                                 (usage.full_path.empty()
                                      ? "\n\n**Path:** _(system process - path unavailable)_"
                                      : "\n\n**Path:** `" + usage.full_path + "`");
+                            // Computer-sensor registration — mirrors the managed WindowsTopCpuMonitor
+                            // (#1318) for wire parity. Same option tuple as the per-interface network
+                            // speed sensors (#1189 at L4005-L4016), minus keep_history: TotalCPUPrototype
+                            // leaves it unset on both sides, so the server default applies identically.
+                            opts.unit = 100;                       // Unit::Percents
+                            opts.ttl_ms = 300000;                  // 5 min
+                            opts.enable_grafana = TriBool::True;
+                            opts.is_computer_sensor = true;
                             std::shared_ptr<NativeSensor> sensor;
-                            if (CreateSensor(("Top CPU processes/" + usage.name).c_str(),
+                            // RevealDefaultPath + is_computer_sensor => CalculateSystemPath produces
+                            // <ComputerName>/.computer/Top CPU processes/<name>. A bare
+                            // "Top CPU processes/<name>" here would instead create a separate top-level
+                            // node next to .computer (#1189 bug class).
+                            const std::string path = RevealDefaultPath("Top CPU processes", usage.name, /*is_computer_sensor=*/true);
+                            if (CreateSensor(path.c_str(),
                                              HSM_SENSOR_TYPE_DOUBLE, false, "", sensor, opts) == HSM_RESULT_OK)
                             {
                                 it = sensor_cache.emplace(usage.name, sensor).first;

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -4361,8 +4361,8 @@ namespace
                             // instant sensor: no EMA statistics (network is a bar with statistics=EMA),
                             // and keep_history is left unset so TotalCPUPrototype's server-default
                             // behavior applies identically on both collectors.
-                            opts.unit = 100;                       // Unit::Percents
-                            opts.ttl_ms = 300000;                  // 5 min
+                            opts.unit = 100; // Unit::Percents
+                            opts.ttl_ms = 300000; // 5 min
                             opts.enable_grafana = TriBool::True;
                             opts.is_computer_sensor = true;
                             // .NET InstantSensorOptions.ToApi emits DisplayUnit = null (not 0), so the

--- a/src/native/collector/src/hsm_collector.cpp
+++ b/src/native/collector/src/hsm_collector.cpp
@@ -4356,13 +4356,18 @@ namespace
                                      ? "\n\n**Path:** _(system process - path unavailable)_"
                                      : "\n\n**Path:** `" + usage.full_path + "`");
                             // Computer-sensor registration — mirrors the managed WindowsTopCpuMonitor
-                            // (#1318) for wire parity. Same option tuple as the per-interface network
-                            // speed sensors (#1189 at L4005-L4016), minus keep_history: TotalCPUPrototype
-                            // leaves it unset on both sides, so the server default applies identically.
+                            // (#1318) for wire parity. Same is_computer_sensor/TTL/grafana shape as the
+                            // per-interface network speed sensors (#1189 at L4005-L4016), but this is an
+                            // instant sensor: no EMA statistics (network is a bar with statistics=EMA),
+                            // and keep_history is left unset so TotalCPUPrototype's server-default
+                            // behavior applies identically on both collectors.
                             opts.unit = 100;                       // Unit::Percents
                             opts.ttl_ms = 300000;                  // 5 min
                             opts.enable_grafana = TriBool::True;
                             opts.is_computer_sensor = true;
+                            // .NET InstantSensorOptions.ToApi emits DisplayUnit = null (not 0), so the
+                            // native registration must too or conformance parity breaks.
+                            opts.has_display_unit = false;
                             std::shared_ptr<NativeSensor> sensor;
                             // RevealDefaultPath + is_computer_sensor => CalculateSystemPath produces
                             // <ComputerName>/.computer/Top CPU processes/<name>. A bare

--- a/tests/conformance/collector/top_cpu_contract.hsmtest
+++ b/tests/conformance/collector/top_cpu_contract.hsmtest
@@ -7,11 +7,12 @@
 #     count       — max number of processes to report per sample
 #     min_percent — minimum CPU% for a process to be included (0 = any positive delta)
 #     period_ms   — sampling interval in milliseconds
-# Sensors appear at path "Top CPU processes/<exe-name>" (Double, type 2).
-# Data is OS-sourced so cross-platform assertions are API-level only.
+# Sensors appear at path "<ComputerName>/.computer/Top CPU processes/<exe-name>" (Double, type 2) —
+# nested under .computer like every default host sensor (#1318 / #1319). Wire-identical to the
+# managed collector. Data is OS-sourced so cross-platform assertions are API-level only.
 
 # The API call is accepted before start; collector lifecycle completes normally.
-# (Data posting is Windows-only; values appear at "Top CPU processes/<exe>" once the
+# (Data posting is Windows-only; values appear under .computer/Top CPU processes/<exe> once the
 # sampling thread fires — verified via the live-server integration path, not here.)
 top_cpu_is_accepted_before_start|create_collector
 top_cpu_is_accepted_before_start|enable_top_cpu_sensors|100|1.0|60000


### PR DESCRIPTION
## Summary

Native-side companion to PR #1320. Per-process Top CPU sensors were registering with a bare `Top CPU processes/<name>` path and no `is_computer_sensor` flag, so they landed in a separate top-level node next to `.computer` instead of nesting under it. Same bug class as #1189 (per-interface network speed sensors).

Mirrors the proven native #1189 pattern (`hsm_collector.cpp` L4005-L4023): `is_computer_sensor = true` + `RevealDefaultPath("Top CPU processes", name, true)` so `CalculateSystemPath` produces `<ComputerName>/.computer/Top CPU processes/<name>`. Option tuple (`unit=Percents`, `ttl_ms=300000`, `enable_grafana=True`) matches the managed `WindowsTopCpuMonitor` byte-for-byte for wire parity; `keep_history` left unset on both sides to mirror `TotalCPUPrototype`.

Sampling algorithm, `min_percent`, `max_tracked_names` cap and lazy-cache lifecycle are untouched. Conformance fixture `top_cpu_contract.hsmtest` doesn't pin the path — only its header comment is updated.

## Test plan

- [ ] **CI native lanes compile clean** — could not build locally (no cmake on this dev machine); `native-collector-conformance` + the cpp build lane will verify
- [ ] `ctest -R conformance_top_cpu_contract` stays green (fixture asserts API acceptance only, not the path)
- [ ] Manual parity vs PR #1320: on a Windows host, run the native collector with `EnableTopCpuSensors(...)` against `hsm.dev.soft-fx.eu`, confirm per-process sensors appear under `<ComputerName>/.computer/Top CPU processes/<exe-name>` — byte-identical to the .NET collector for the same process name
- [ ] Manual TTL: stop a busy process, confirm its sensor disappears within ~5 min

Closes #1319

🤖 Generated with [Claude Code](https://claude.com/claude-code)