### PR TITLE
Release HSMDataCollector 3.5.0

### DIFF
--- a/ReleaseNote.Collector.md
+++ b/ReleaseNote.Collector.md
@@ -1,0 +1,17 @@
+# HSM DataCollector
+
+## New default sensors (`AddAllComputerSensors`)
+* **Top-CPU sensors** — per-process CPU sensors are now part of the default computer-sensor set; each carries the executable path and a bounded list of system processes, all nested under `.computer` (#1179, #1318).
+* **Per-interface network speed sensors** — rx/tx MB/s sensors per active network interface, nested under `.computer`. Only interfaces carrying traffic are surfaced (#1189).
+
+## Reliability and queue
+* Retry policy no longer drops newer telemetry when a stale retry races queue overflow; FIFO-head ordering preserved across retries (#1088, #1090).
+* Collector shutdown is bounded and crash-isolated: hung user tasks, reentrant lifecycle transitions, and dispose-during-start no longer leak queues or crash the host (#1102, #1103, lifecycle state machine refactor).
+* Accepted telemetry is preserved across post-stop flush retries; last-value sensors are flushed on stop and dispose.
+
+## Behavior and configuration
+* HTTP client timeout is now configurable; untrusted TLS certificates require explicit opt-in (`AllowUntrustedServerCertificate`).
+* Request payloads are redacted from send logs.
+
+## Cross-language default-sensor conformance
+* Managed and native collectors now share a conformance suite covering default-sensor registration and options parity; this release locks the managed side of that contract.

--- a/src/collector/HSMDataCollector/HSMDataCollector.csproj
+++ b/src/collector/HSMDataCollector/HSMDataCollector.csproj
@@ -3,10 +3,10 @@
     <PackageId>HSMDataCollector.HSMDataCollector</PackageId>
     <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <OutputType>Library</OutputType>
-    <AssemblyVersion>3.4.12</AssemblyVersion>
-    <AssemblyFileVersion>3.4.12</AssemblyFileVersion>
-    <ProductVersion>3.4.12</ProductVersion>
-    <Version>3.4.12</Version>
+    <AssemblyVersion>3.5.0</AssemblyVersion>
+    <AssemblyFileVersion>3.5.0</AssemblyFileVersion>
+    <ProductVersion>3.5.0</ProductVersion>
+    <Version>3.5.0</Version>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Authors>HSM team</Authors>
     <Company>Soft-FX</Company>


### PR DESCRIPTION
Bumps `3.4.12` → `3.5.0` and regenerates `ReleaseNote.Collector.md`.

After merge, `/release-collector` will trigger `collector-nuget-build.yml`,
which publishes `HSMDataCollector.HSMDataCollector` `3.5.0` to nuget.org and
automatically tags `collector-v3.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)