### PR TITLE
Fix collector-nuget-build.yml: leftover conflict markers

### DIFF
--- a/.github/workflows/collector-nuget-build.yml
+++ b/.github/workflows/collector-nuget-build.yml
@@ -77,6 +77,3 @@ jobs:
           tag: ${{ steps.read-version.outputs.tag }}
           message: "Release HSMDataCollector ${{ steps.read-version.outputs.version }}"
           force_push_tag: false
-=======
-        run: dotnet nuget push ${{ env.OutputFolder }}/*.nupkg --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json
->>>>>>> Stashed changes


### PR DESCRIPTION
Follow-up to #1323: the merge-conflict resolution left a stray `=======` / `>>>>>>> Stashed changes` tail in `collector-nuget-build.yml`. The YAML fails to parse, so the workflow cannot be dispatched (`HTTP 422: Workflow does not have 'workflow_dispatch' trigger`).

Removed the leftover lines; validated the YAML parses with both jobs (`build-nuget`, `create-tag`) intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)