### PR TITLE
Fix #1296: sensor Initialize() publishes the flag only after the history load

### DIFF
--- a/aicontext/features/server/overview.md
+++ b/aicontext/features/server/overview.md
@@ -37,7 +37,11 @@ Typed sensor model. Manages:
 - Alert policies and conditions
 - Status computation
 
-Initialization is expected before values are accepted. Changes around `TryAddValue`, `TryUpdateLastValue`, TTL, or policy loading should include tests for first-value initialization and timeout behavior.
+Initialization is expected before values are accepted. `Initialize()` loads history from LevelDB under a per-sensor lock and publishes its `_isInitialized` flag only once that load has **finished or failed** (#1296), so the three value-ingress gates — `TryAddValue`, `TryUpdateLastValue`, `CheckTimeout` — park on the lock instead of racing past on an empty `Storage`. Two limits the contract does not cover: a failed load latches as well and leaves an empty `Storage` (deliberate — one logged error beats a per-value retry storm against a broken database), and only those three gates wait; direct readers such as `LastValue`, `HasData`, or `Revalidate()` are unguarded and may observe a mid-load sensor.
+
+Policy evaluation runs inside that lock, so `TreeValuesCache.SetExpiredSnapshot` and `ChangeSensorEvent` subscribers must not block on the `UpdatesQueue` — it is a `SingleReader` channel, and its reader waiting on a sensor lock would stall the whole product's ingest.
+
+Changes around `TryAddValue`, `TryUpdateLastValue`, TTL, or policy loading should include tests for first-value initialization and timeout behavior.
 
 ### ConcurrentStorage<T>
 Thread-safe in-memory storage pattern that syncs writes to LevelDB. Used for products, users, access keys, sensor configs.

--- a/aicontext/features/server/overview.md
+++ b/aicontext/features/server/overview.md
@@ -39,7 +39,11 @@ Typed sensor model. Manages:
 
 Initialization is expected before values are accepted. `Initialize()` loads history from LevelDB under a per-sensor lock and publishes its `_isInitialized` flag only once that load has **finished or failed** (#1296), so the three value-ingress gates — `TryAddValue`, `TryUpdateLastValue`, `CheckTimeout` — park on the lock instead of racing past on an empty `Storage`. Two limits the contract does not cover: a failed load latches as well and leaves an empty `Storage` (deliberate — one logged error beats a per-value retry storm against a broken database), and only those three gates wait; direct readers such as `LastValue`, `HasData`, or `Revalidate()` are unguarded and may observe a mid-load sensor.
 
-Policy evaluation runs inside that lock, so `TreeValuesCache.SetExpiredSnapshot` and `ChangeSensorEvent` subscribers must not block on the `UpdatesQueue` — it is a `SingleReader` channel, and its reader waiting on a sensor lock would stall the whole product's ingest.
+Policy evaluation runs inside that lock, and it fans out: `SensorTimeout` → `SensorExpired` → `TreeValuesCache.SetExpiredSnapshot` → `SensorUpdateView` → every `ChangeSensorEvent` subscriber. So the lock is held across up to three LevelDB reads plus that fan-out, and **subscribers must do no blocking work** — today they are all `ConcurrentDictionary` lookups. In particular nothing there may wait on the `UpdatesQueue`: it is a `SingleReader` channel (`MaxQueueSize` 1000, `FullMode.Wait`), so its reader parked on a sensor lock back-pressures all the way to the HTTP ingest threads.
+
+Why startup is nonetheless not serialized: `FillSensorsData` loads sensors one at a time on a single background thread, so at most one queue reader is parked at any moment, and only for that one sensor's load.
+
+`ShouldDestroy()` calls `Initialize()` before reading `HasData`/`LastUpdate`: that path deletes the sensor with its history, and an uninitialized sensor would fall back to `CreationDate` and destroy itself. Other direct readers are still unguarded.
 
 Changes around `TryAddValue`, `TryUpdateLastValue`, TTL, or policy loading should include tests for first-value initialization and timeout behavior.
 

--- a/aicontext/features/server/overview.md
+++ b/aicontext/features/server/overview.md
@@ -39,11 +39,13 @@ Typed sensor model. Manages:
 
 Initialization is expected before values are accepted. `Initialize()` loads history from LevelDB under a per-sensor lock and publishes its `_isInitialized` flag only once that load has **finished or failed** (#1296), so the three value-ingress gates — `TryAddValue`, `TryUpdateLastValue`, `CheckTimeout` — park on the lock instead of racing past on an empty `Storage`. Two limits the contract does not cover: a failed load latches as well and leaves an empty `Storage` (deliberate — one logged error beats a per-value retry storm against a broken database), and only those three gates wait; direct readers such as `LastValue`, `HasData`, or `Revalidate()` are unguarded and may observe a mid-load sensor.
 
-Policy evaluation runs inside that lock, and it fans out: `SensorTimeout` → `SensorExpired` → `TreeValuesCache.SetExpiredSnapshot` → `SensorUpdateView` → every `ChangeSensorEvent` subscriber. So the lock is held across up to three LevelDB reads plus that fan-out, and **subscribers must do no blocking work** — today they are all `ConcurrentDictionary` lookups. In particular nothing there may wait on the `UpdatesQueue`: it is a `SingleReader` channel (`MaxQueueSize` 1000, `FullMode.Wait`), so its reader parked on a sensor lock back-pressures all the way to the HTTP ingest threads.
+**Invariant — nothing reached from inside a sensor's initialization lock may block.** This is the canonical statement; the code carries one-line pointers here rather than four copies of the reasoning.
+
+Policy evaluation runs inside that lock and fans out well past a database read: `Policies.TryValidate` → `CalculateStorageResult` → `SensorTimeout` → `SensorExpired` → `TreeValuesCache.SetExpiredSnapshot`, and from there both `SensorUpdateView` → every `ChangeSensorEvent` subscriber (view-model updates in `TreeViewModel`, panel bookkeeping in `Dashboard`) and `SendNotification` → `ConfirmationManager` → alert dispatch. So the lock is held across up to three LevelDB reads plus all of that. None of those paths takes a blocking lock today, and none may start — in particular nothing there may wait on the `UpdatesQueue`, a `SingleReader` channel (`MaxQueueSize` 1000, `FullMode.Wait`) whose reader, parked on a sensor lock, back-pressures all the way to the HTTP ingest threads.
 
 Why startup is nonetheless not serialized: `FillSensorsData` loads sensors one at a time on a single background thread, so at most one queue reader is parked at any moment, and only for that one sensor's load.
 
-`ShouldDestroy()` calls `Initialize()` before reading `HasData`/`LastUpdate`: that path deletes the sensor with its history, and an uninitialized sensor would fall back to `CreationDate` and destroy itself. Other direct readers are still unguarded.
+Direct `Storage` readers stay unguarded. One of them is a known data-loss path: `ShouldDestroy()` reads `HasData`/`LastUpdate`, and an uninitialized sensor falls back to `CreationDate` and destroys itself with its history — see #1328.
 
 Changes around `TryAddValue`, `TryUpdateLastValue`, TTL, or policy loading should include tests for first-value initialization and timeout behavior.
 

--- a/aicontext/features/server/overview.md
+++ b/aicontext/features/server/overview.md
@@ -43,7 +43,9 @@ Initialization is expected before values are accepted. `Initialize()` loads hist
 
 Policy evaluation runs inside that lock and fans out well past a database read: `Policies.TryValidate` → `CalculateStorageResult` → `SensorTimeout` → `SensorExpired` → `TreeValuesCache.SetExpiredSnapshot`, and from there both `SensorUpdateView` → every `ChangeSensorEvent` subscriber (view-model updates in `TreeViewModel`, panel bookkeeping in `Dashboard`) and `SendNotification` → `ConfirmationManager` → alert dispatch. So the lock is held across up to three LevelDB reads plus all of that. None of those paths takes a blocking lock today, and none may start — in particular nothing there may wait on the `UpdatesQueue`, a `SingleReader` channel (`MaxQueueSize` 1000, `FullMode.Wait`) whose reader, parked on a sensor lock, back-pressures all the way to the HTTP ingest threads.
 
-Why startup is nonetheless not serialized: `FillSensorsData` loads sensors one at a time on a single background thread, so at most one queue reader is parked at any moment, and only for that one sensor's load.
+Why startup is nonetheless not serialized: **the lock is per-sensor**, so a waiter only ever blocks behind that one sensor's load. `Initialize()` is driven from several places at once — `FillSensorsData`, `CheckSensorsTimeout` → `CheckTimeout()` on each product's queue reader, `ProductModel.CheckTimeout()` from `BaseNodeModel.TryUpdate`, and the ingest path — so several sensors can be mid-load on several threads, and more than one reader can be parked at a time.
+
+Worst case worth knowing (not new — `master` does the same loads): a product-settings save during startup runs `TryUpdate` → `ProductModel.CheckTimeout()` → a serial history load for every sensor in the product, on the caller's thread, and now also stalls that product's queue reader behind each in turn. Bounded, but it is the latency ceiling this change makes visible.
 
 Direct `Storage` readers stay unguarded. One of them is a known data-loss path: `ShouldDestroy()` reads `HasData`/`LastUpdate`, and an uninitialized sensor falls back to `CreationDate` and destroys itself with its history — see #1328.
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1046,6 +1046,10 @@ namespace HSMServer.Core.Cache
 
         private void SendNotification(Guid sensorId, PolicyResult result) => _confirmationManager.RegisterNotification(sensorId, result);
 
+        // Reachable from inside a sensor's initialization lock via SetExpiredSnapshot (#1296), so
+        // every ChangeSensorEvent subscriber must be non-blocking: today they are all
+        // ConcurrentDictionary lookups. A subscriber that waits on the UpdatesQueue — a
+        // SingleReader channel — would deadlock the product's ingest against that sensor lock.
         private void SensorUpdateView(BaseSensorModel sensor) => ChangeSensorEvent?.Invoke(sensor, ActionType.Update);
 
 

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -2715,6 +2715,11 @@ namespace HSMServer.Core.Cache
             }
         }
 
+        // May run while the sensor holds its initialization lock (#1296): policy evaluation inside
+        // BaseSensorModel.Initialize() reaches here through SensorTimeout -> SensorExpired. Nothing
+        // below — nor any ChangeSensorEvent subscriber — may block on the UpdatesQueue: that channel
+        // has SingleReader = true, so its reader waiting on this sensor's lock would deadlock the
+        // whole product's ingest and surface as a queue problem rather than an init problem.
         private void SetExpiredSnapshot(BaseSensorModel sensor, bool timeout)
         {
             if (sensor.IsExpired != timeout)

--- a/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
+++ b/src/server/HSMServer.Core/Cache/TreeValuesCache.cs
@@ -1047,9 +1047,7 @@ namespace HSMServer.Core.Cache
         private void SendNotification(Guid sensorId, PolicyResult result) => _confirmationManager.RegisterNotification(sensorId, result);
 
         // Reachable from inside a sensor's initialization lock via SetExpiredSnapshot (#1296), so
-        // every ChangeSensorEvent subscriber must be non-blocking: today they are all
-        // ConcurrentDictionary lookups. A subscriber that waits on the UpdatesQueue — a
-        // SingleReader channel — would deadlock the product's ingest against that sensor lock.
+        // subscribers must not block. Reasoning: aicontext/features/server/overview.md.
         private void SensorUpdateView(BaseSensorModel sensor) => ChangeSensorEvent?.Invoke(sensor, ActionType.Update);
 
 
@@ -2719,11 +2717,8 @@ namespace HSMServer.Core.Cache
             }
         }
 
-        // May run while the sensor holds its initialization lock (#1296): policy evaluation inside
-        // BaseSensorModel.Initialize() reaches here through SensorTimeout -> SensorExpired. Nothing
-        // below — nor any ChangeSensorEvent subscriber — may block on the UpdatesQueue: that channel
-        // has SingleReader = true, so its reader waiting on this sensor's lock would deadlock the
-        // whole product's ingest and surface as a queue problem rather than an init problem.
+        // May run while the sensor holds its initialization lock (#1296), so nothing below — the
+        // notification path included — may block. Reasoning: aicontext/features/server/overview.md.
         private void SetExpiredSnapshot(BaseSensorModel sensor, bool timeout)
         {
             if (sensor.IsExpired != timeout)

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/SensorPolicyCollection.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/SensorPolicyCollection.cs
@@ -25,6 +25,11 @@ namespace HSMServer.Core.Model.Policies
         internal protected PolicyResult ConfimationResult { get; protected set; } = PolicyResult.Ok;
 
         internal Action<ActionType, Policy> Uploaded;
+
+        // Fires from CalculateStorageResult/SensorTimeout, which BaseSensorModel.Initialize() calls
+        // while holding that sensor's initialization lock (#1296). Subscribers must therefore do no
+        // blocking work — in particular nothing that waits on the UpdatesQueue, a SingleReader
+        // channel whose reader would then be parked on a sensor lock, stalling the product's ingest.
         internal Action<BaseSensorModel, bool> SensorExpired;
 
 

--- a/src/server/HSMServer.Core/Model/Policies/PolicyCollection/SensorPolicyCollection.cs
+++ b/src/server/HSMServer.Core/Model/Policies/PolicyCollection/SensorPolicyCollection.cs
@@ -26,10 +26,8 @@ namespace HSMServer.Core.Model.Policies
 
         internal Action<ActionType, Policy> Uploaded;
 
-        // Fires from CalculateStorageResult/SensorTimeout, which BaseSensorModel.Initialize() calls
-        // while holding that sensor's initialization lock (#1296). Subscribers must therefore do no
-        // blocking work — in particular nothing that waits on the UpdatesQueue, a SingleReader
-        // channel whose reader would then be parked on a sensor lock, stalling the product's ingest.
+        // Fires while the sensor holds its initialization lock (#1296), so subscribers must not
+        // block. Reasoning: aicontext/features/server/overview.md, BaseSensorModel<T>.
         internal Action<BaseSensorModel, bool> SensorExpired;
 
 

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModel.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModel.cs
@@ -85,12 +85,6 @@ namespace HSMServer.Core.Model
             if (Settings.SelfDestroy.Value == null)
                 return false;
 
-            // HasData/LastUpdate read Storage directly, and this path DELETES the sensor with its
-            // history. An uninitialized sensor reports HasData == false and falls back to
-            // CreationDate, which for any long-lived sensor is well past its self-destroy interval
-            // (#1296). Idempotent once latched, and only sensors with self-destroy configured pay.
-            Initialize();
-
             return Settings.SelfDestroy.Value.TimeIsUp(HasData ? LastUpdate : CreationDate);
         }
 

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModel.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModel.cs
@@ -85,7 +85,13 @@ namespace HSMServer.Core.Model
             if (Settings.SelfDestroy.Value == null)
                 return false;
 
-            return Settings.SelfDestroy.Value.TimeIsUp(HasData ? LastUpdate : CreationDate); 
+            // HasData/LastUpdate read Storage directly, and this path DELETES the sensor with its
+            // history. An uninitialized sensor reports HasData == false and falls back to
+            // CreationDate, which for any long-lived sensor is well past its self-destroy interval
+            // (#1296). Idempotent once latched, and only sensors with self-destroy configured pay.
+            Initialize();
+
+            return Settings.SelfDestroy.Value.TimeIsUp(HasData ? LastUpdate : CreationDate);
         }
 
         public bool CanSendNotifications => State is SensorState.Available && (!Status?.IsOfftime ?? true);

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
@@ -120,13 +120,21 @@ namespace HSMServer.Core.Model
 
         internal override void Initialize()
         {
+            if (_isInitialized)
+                return;
+
             // Monitor is reentrant, and _isInitialized is deliberately still false while the load
             // runs, so a same-thread re-entry would replay the whole history load: the TryValidate
             // calls below can reach SensorTimeout -> SensorExpired -> TryAddValue -> Initialize.
-            // That path is currently unreachable only by an ordering accident (HasData is still
-            // false at both TryValidate sites), which nothing in the code states or enforces.
-            if (_isInitialized || Monitor.IsEntered(_lock))
+            // Returning here stops the replay but leaves that nested caller running against a
+            // half-built Storage — #1296 on the initializing thread. Unreachable today only by an
+            // ordering accident (HasData is false at both TryValidate sites), so log it: if a
+            // policy change ever makes it reachable, this line is the only thing that will say so.
+            if (Monitor.IsEntered(_lock))
+            {
+                _logger.Warn($"Reentrant Initialize on sensor {Id} during history load — the nested value path sees a partial Storage (#1296)");
                 return;
+            }
 
             lock (_lock)
             {

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
@@ -150,14 +150,19 @@ namespace HSMServer.Core.Model
                         var firstBytes = _database.GetFirstValue(Id);
 
                         last = Convert(lastBytes);
-                        first = Convert(firstBytes);
+                        // Null-guarded because the catch below now latches: a throw here would leave
+                        // _isInitialized true over an empty Storage permanently — the #1296 symptom,
+                        // no longer bounded to a startup window. Both reads are reachable as null:
+                        // retention (KeepHistory) can sweep every real value and leave only the
+                        // timeout marker SetExpiredSnapshot wrote as the newest row.
+                        first = firstBytes != null ? Convert(firstBytes) : null;
 
                         if (last.IsTimeout)
                         {
                             var valueBytes = _database.GetLatestValue(Id, last.Time.Ticks-1);
-                            var value = Convert(valueBytes);
+                            var value = valueBytes != null ? Convert(valueBytes) : null;
 
-                            if (!value.IsTimeout && Policies.TryValidate(value, out _))
+                            if (value is not null && !value.IsTimeout && Policies.TryValidate(value, out _))
                                 Storage.AddValue((T)value);
 
                             IsExpired = true;

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
@@ -27,7 +27,9 @@ namespace HSMServer.Core.Model
         private readonly IDatabaseCore _database;
 
 
-        private bool _isInitialized;
+        // volatile: TryAddValue/TryUpdateLastValue/CheckTimeout read it lock-free, and "true" must
+        // never be observable before the history load in Initialize() has finished filling Storage.
+        private volatile bool _isInitialized;
         private readonly object _lock = new();
 
         protected BaseSensorModel(SensorEntity entity, IDatabaseCore database) : base(entity) 
@@ -122,13 +124,11 @@ namespace HSMServer.Core.Model
 
             lock (_lock)
             {
+                if (_isInitialized)
+                    return;
+
                 try
                 {
-                    if (_isInitialized)
-                        return;
-
-                    _isInitialized = true;
-
                     BaseValue last, first;
                     var lastBytes = _database.GetLatestValue(Id, DateTime.MaxValue.Ticks);
                     if (lastBytes != null)
@@ -160,9 +160,17 @@ namespace HSMServer.Core.Model
 
                     _logger.Info($"Sensor {Id} initialized {From}-{To}");
                 }
-                catch (Exception ex) 
+                catch (Exception ex)
                 {
                     _logger.Error(ex, $"Sensor initialization error {Id}");
+                }
+                finally
+                {
+                    // Published only after the load has finished: callers gate on this flag before
+                    // touching Storage, so a concurrent writer must wait on _lock instead of racing
+                    // past on an empty Storage (#1296). A failed load still latches — one loud error
+                    // above instead of a per-value retry storm against a broken database.
+                    _isInitialized = true;
                 }
             }
 

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
@@ -180,13 +180,10 @@ namespace HSMServer.Core.Model
                 }
                 finally
                 {
-                    // Published once the load has finished OR failed, so the three value-ingress
-                    // gates (TryAddValue/TryUpdateLastValue/CheckTimeout) park on _lock instead of
-                    // racing past on an empty Storage (#1296). Two limits this does NOT cover:
-                    // a failed load latches too and publishes an empty Storage — deliberate, one
-                    // loud error above beats a per-value retry storm against a broken database —
-                    // and only those three gates wait; direct Storage readers (LastValue, HasData,
-                    // Revalidate, Cut, ...) stay unguarded exactly as they were before #1296.
+                    // Published once the load has finished OR FAILED (#1296): a failed load latches
+                    // too and publishes an empty Storage, deliberately — one loud error above beats
+                    // a per-value retry storm against a broken database. Contract and its limits:
+                    // aicontext/features/server/overview.md, BaseSensorModel<T>.
                     _isInitialized = true;
                 }
             }

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
+using System.Threading;
 using HSMCommon.Model;
 using HSMDatabase.AccessManager.DatabaseEntities;
 using HSMDatabase.AccessManager.Formatters;
@@ -119,7 +120,12 @@ namespace HSMServer.Core.Model
 
         internal override void Initialize()
         {
-            if (_isInitialized)
+            // Monitor is reentrant, and _isInitialized is deliberately still false while the load
+            // runs, so a same-thread re-entry would replay the whole history load: the TryValidate
+            // calls below can reach SensorTimeout -> SensorExpired -> TryAddValue -> Initialize.
+            // That path is currently unreachable only by an ordering accident (HasData is still
+            // false at both TryValidate sites), which nothing in the code states or enforces.
+            if (_isInitialized || Monitor.IsEntered(_lock))
                 return;
 
             lock (_lock)
@@ -166,10 +172,14 @@ namespace HSMServer.Core.Model
                 }
                 finally
                 {
-                    // Published only after the load has finished: callers gate on this flag before
-                    // touching Storage, so a concurrent writer must wait on _lock instead of racing
-                    // past on an empty Storage (#1296). A failed load still latches — one loud error
-                    // above instead of a per-value retry storm against a broken database.
+                    // Published only after the load has finished, so the three value-ingress gates
+                    // (TryAddValue/TryUpdateLastValue/CheckTimeout) park on _lock instead of racing
+                    // past on an empty Storage (#1296). Scope: only those three wait. Direct Storage
+                    // readers — LastValue, LastDbValue, HasData, LastUpdate, From/To, Result,
+                    // Revalidate(), Cut(), Clear() — remain unguarded and may still observe a
+                    // mid-load sensor; that read-path staleness predates #1296 and is not fixed here.
+                    // A failed load still latches — one loud error above instead of a per-value
+                    // retry storm against a broken database.
                     _isInitialized = true;
                 }
             }

--- a/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
+++ b/src/server/HSMServer.Core/Model/Sensors/BaseSensorModelT.cs
@@ -172,14 +172,13 @@ namespace HSMServer.Core.Model
                 }
                 finally
                 {
-                    // Published only after the load has finished, so the three value-ingress gates
-                    // (TryAddValue/TryUpdateLastValue/CheckTimeout) park on _lock instead of racing
-                    // past on an empty Storage (#1296). Scope: only those three wait. Direct Storage
-                    // readers — LastValue, LastDbValue, HasData, LastUpdate, From/To, Result,
-                    // Revalidate(), Cut(), Clear() — remain unguarded and may still observe a
-                    // mid-load sensor; that read-path staleness predates #1296 and is not fixed here.
-                    // A failed load still latches — one loud error above instead of a per-value
-                    // retry storm against a broken database.
+                    // Published once the load has finished OR failed, so the three value-ingress
+                    // gates (TryAddValue/TryUpdateLastValue/CheckTimeout) park on _lock instead of
+                    // racing past on an empty Storage (#1296). Two limits this does NOT cover:
+                    // a failed load latches too and publishes an empty Storage — deliberate, one
+                    // loud error above beats a per-value retry storm against a broken database —
+                    // and only those three gates wait; direct Storage readers (LastValue, HasData,
+                    // Revalidate, Cut, ...) stay unguarded exactly as they were before #1296.
                     _isInitialized = true;
                 }
             }

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -78,6 +78,86 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
         [Fact]
         [Trait("Category", "Initialization race")]
+        public void TryAddValue_StaleValueDuringHistoryLoad_IsJudgedAgainstLoadedHistory()
+        {
+            var historyTime = DateTime.UtcNow.AddMinutes(-1);
+            var historyBytes = new MemoryPackFormatter().Serialize(
+                new IntegerValue { Time = historyTime, Status = SensorStatus.Ok, Value = 1 });
+
+            using var loadEntered = new ManualResetEventSlim(false);
+            using var loadGate = new ManualResetEventSlim(false);
+
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                .Returns(() =>
+                {
+                    loadEntered.Set();
+                    loadGate.Wait(_waitTimeout);
+                    return historyBytes;
+                });
+            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(historyBytes);
+
+            // Singleton: TryAddValue decides by comparing against Storage.LastValue, so the verdict
+            // is a direct readout of whether the history was already published when the writer ran.
+            var sensor = new IntegerSensorModel(BuildEntity(isSingleton: true), database.Object, null);
+
+            var init = Task.Run(sensor.Initialize);
+            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+
+            // Older than the history the in-flight load is about to publish.
+            var stale = new IntegerValue { Time = historyTime.AddMinutes(-9), Status = SensorStatus.Ok, Value = 2 };
+            var added = true;
+            var add = Task.Run(() => { added = sensor.TryAddValue(stale); });
+
+            // Settle, not an assertion: gives the writer time to reach the gate and park on _lock.
+            // Pre-fix it runs straight through here instead, which is what the asserts below catch.
+            add.Wait(TimeSpan.FromMilliseconds(200));
+
+            loadGate.Set();
+            Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
+
+            // Pre-fix the writer met an empty Storage, so singleton dedup had nothing to compare
+            // against and stored the stale value as current. Against the loaded history it is
+            // correctly recognised as older and dropped.
+            Assert.False(added, "stale value was accepted because Storage was still empty");
+            var lastValue = Assert.IsType<IntegerValue>(sensor.LastValue);
+            Assert.Equal(1, lastValue.Value);
+            Assert.Equal(historyTime, lastValue.Time);
+        }
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
+        public void Initialize_ReentrantOnSameThread_DoesNotReloadHistory()
+        {
+            IntegerSensorModel sensor = null;
+            var reentered = false;
+
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                .Returns(() =>
+                {
+                    // Stands in for the real re-entry path: a policy evaluated inside the load can
+                    // reach SensorTimeout -> SensorExpired -> TryAddValue -> Initialize on THIS
+                    // thread, where _isInitialized is still false and Monitor lets the owner back in.
+                    if (!reentered)
+                    {
+                        reentered = true;
+                        sensor.Initialize();
+                    }
+
+                    return null;
+                });
+
+            sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+
+            sensor.Initialize();
+
+            Assert.True(reentered, "the re-entry never happened — test no longer exercises the guard");
+            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
         public void Initialize_Concurrent_LoadsHistoryOnce()
         {
             using var loadEntered = new ManualResetEventSlim(false);
@@ -129,13 +209,14 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
 
-        private static SensorEntity BuildEntity() =>
+        private static SensorEntity BuildEntity(bool isSingleton = false) =>
             new()
             {
                 Id = Guid.NewGuid().ToString(),
                 ProductId = Guid.NewGuid().ToString(),
                 DisplayName = RandomGenerator.GetRandomString(),
                 Type = (byte)SensorType.Integer,
+                IsSingleton = isSingleton,
             };
     }
 }

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -65,18 +65,6 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             load.Database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
-        /// <summary>
-        /// The other two entry points that gate on _isInitialized (TryAddValue is covered in depth
-        /// by the test above). CheckTimeout is the operationally interesting one: it is reached from
-        /// ProductModel.CheckTimeout() and BaseNodeModel.TryUpdate, so a settings change during
-        /// startup walks every sensor and can park on each in-flight load.
-        /// </summary>
-        public enum ValueGate
-        {
-            TryUpdateLastValue,
-            CheckTimeout,
-        }
-
         [Theory]
         [InlineData(ValueGate.TryUpdateLastValue)]
         [InlineData(ValueGate.CheckTimeout)]
@@ -156,28 +144,6 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             var lastValue = Assert.IsType<IntegerValue>(sensor.LastValue);
             Assert.Equal(1, lastValue.Value);
             Assert.Equal(historyTime, lastValue.Time);
-        }
-
-        [Fact]
-        [Trait("Category", "Initialization race")]
-        public void ShouldDestroy_UninitializedSensor_JudgesByHistoryNotCreationDate()
-        {
-            // A long-lived sensor that is still receiving data: created 10 days ago, last value a
-            // minute old, self-destroy after an hour of inactivity.
-            var database = new Mock<IDatabaseCore>();
-            var recent = History(DateTime.UtcNow.AddMinutes(-1), 1);
-            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>())).Returns(recent);
-            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(recent);
-
-            var entity = BuildEntity(selfDestroy: TimeSpan.FromHours(1), creationDate: DateTime.UtcNow.AddDays(-10));
-            var sensor = new IntegerSensorModel(entity, database.Object, null);
-
-            // Unguarded, ShouldDestroy() reads HasData == false on an uninitialized sensor and falls
-            // back to CreationDate — 10 days > 1 hour — and the self-destroy sweep deletes the
-            // sensor with its history. Only the ordering inside ClearDatabaseService.ServiceActionAsync
-            // keeps that from firing today, which is three statements, not an invariant.
-            Assert.False(sensor.ShouldDestroy(), "a sensor with fresh history was judged by its CreationDate");
-            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
         [Fact]
@@ -283,7 +249,12 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                     .Returns(() =>
                     {
                         Entered.Set();
-                        Gate.Wait(_waitTimeout);
+
+                        // Throw rather than return: a test that forgets to open the gate would
+                        // otherwise get its history 10s later and pass having proved nothing.
+                        if (!Gate.Wait(_waitTimeout))
+                            throw new TimeoutException("the test never opened the load gate");
+
                         return history;
                     });
 
@@ -299,27 +270,31 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
 
+        /// <summary>
+        /// The other two entry points that gate on _isInitialized (TryAddValue is covered in depth
+        /// by the test above). CheckTimeout is the operationally interesting one: it is reached from
+        /// ProductModel.CheckTimeout() and BaseNodeModel.TryUpdate, so a settings change during
+        /// startup walks every sensor and can park on each in-flight load.
+        /// </summary>
+        public enum ValueGate
+        {
+            TryUpdateLastValue,
+            CheckTimeout,
+        }
+
+
         private static byte[] History(DateTime time, int value) =>
             new MemoryPackFormatter().Serialize(
                 new IntegerValue { Time = time, Status = SensorStatus.Ok, Value = value });
 
-        private static SensorEntity BuildEntity(bool isSingleton = false, TimeSpan? selfDestroy = null,
-            DateTime? creationDate = null)
-        {
-            var entity = new SensorEntity
+        private static SensorEntity BuildEntity(bool isSingleton = false) =>
+            new()
             {
                 Id = Guid.NewGuid().ToString(),
                 ProductId = Guid.NewGuid().ToString(),
                 DisplayName = RandomGenerator.GetRandomString(),
                 Type = (byte)SensorType.Integer,
                 IsSingleton = isSingleton,
-                CreationDate = (creationDate ?? DateTime.UtcNow).Ticks,
             };
-
-            if (selfDestroy.HasValue)
-                entity.Settings["SelfDestroy"] = new TimeIntervalEntity((long)TimeInterval.Ticks, selfDestroy.Value.Ticks);
-
-            return entity;
-        }
     }
 }

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -57,6 +57,7 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
+            Assert.False(load.TimedOut, "the load gate was never opened");
 
             Assert.True(added);
             var lastValue = Assert.IsType<IntegerValue>(sensor.LastValue);
@@ -71,13 +72,16 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         [Trait("Category", "Initialization race")]
         public void ValueGate_DuringHistoryLoad_WaitsForLoadedStorage(ValueGate gate)
         {
-            using var load = new GatedLoad(History(DateTime.UtcNow.AddMinutes(-5), 1));
+            var historyTime = DateTime.UtcNow.AddMinutes(-5);
+
+            using var load = new GatedLoad(History(historyTime, 1));
             var sensor = new IntegerSensorModel(BuildEntity(), load.Database.Object, null);
 
             var init = Task.Run(sensor.Initialize);
             Assert.True(load.Entered.Wait(_waitTimeout), "history load never started");
 
             using var callStarted = new ManualResetEventSlim(false);
+            var observedFrom = DateTime.MaxValue;
             var call = Task.Run(() =>
             {
                 callStarted.Set();
@@ -93,6 +97,10 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                         sensor.CheckTimeout();
                         break;
                 }
+
+                // Captured the instant the gate returns, before the load could have finished
+                // afterwards — this is the assertion that actually encodes the contract.
+                observedFrom = sensor.From;
             });
 
             Assert.True(callStarted.Wait(_waitTimeout), $"{gate} task never started");
@@ -101,6 +109,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { init, call }, _waitTimeout), "init/call did not finish");
+            Assert.False(load.TimedOut, "the load gate was never opened");
+
+            // Storage.Cut(first.Time) runs at the end of the load, so From is the loaded history's
+            // timestamp only if the caller really waited. Pre-fix it returned first and saw MinValue.
+            Assert.Equal(historyTime, observedFrom);
         }
 
         [Fact]
@@ -135,6 +148,7 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
+            Assert.False(load.TimedOut, "the load gate was never opened");
 
             // Pre-fix the writer met an empty Storage, so singleton dedup had nothing to compare
             // against and stored the stale value as current. Against the loaded history it is
@@ -181,7 +195,7 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         [Trait("Category", "Initialization race")]
         public void Initialize_Concurrent_LoadsHistoryOnce()
         {
-            using var load = new GatedLoad(null);
+            using var load = new GatedLoad(History(DateTime.UtcNow.AddMinutes(-5), 1));
             var sensor = new IntegerSensorModel(BuildEntity(), load.Database.Object, null);
 
             var first = Task.Run(sensor.Initialize);
@@ -191,10 +205,12 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             // task later than the bound below makes the Wait return false for the wrong reason and
             // the test passes having verified nothing.
             using var secondStarted = new ManualResetEventSlim(false);
+            var secondSawHistory = false;
             var second = Task.Run(() =>
             {
                 secondStarted.Set();
                 sensor.Initialize();
+                secondSawHistory = sensor.HasData;
             });
 
             Assert.True(secondStarted.Wait(_waitTimeout), "second Initialize task never started");
@@ -204,7 +220,12 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { first, second }, _waitTimeout), "initializations did not finish");
+            Assert.False(load.TimedOut, "the load gate was never opened");
 
+            // Times.Once alone does not discriminate — pre-fix the second caller also skipped the
+            // load, on the early latch. This does: returning from Initialize() must mean the
+            // history is visible, which pre-fix it was not.
+            Assert.True(secondSawHistory, "Initialize() returned before the history was visible");
             load.Database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
@@ -242,6 +263,12 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             public ManualResetEventSlim Gate { get; } = new(false);
 
+            /// <summary>Set when the gate was never opened. Throwing instead is not enough: the
+            /// throw lands inside Initialize()'s catch, which swallows it and latches an empty
+            /// Storage, so a test asserting no post-conditions would still pass. Every test asserts
+            /// this is false.</summary>
+            public bool TimedOut { get; private set; }
+
 
             public GatedLoad(byte[] history)
             {
@@ -250,10 +277,11 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
                     {
                         Entered.Set();
 
-                        // Throw rather than return: a test that forgets to open the gate would
-                        // otherwise get its history 10s later and pass having proved nothing.
                         if (!Gate.Wait(_waitTimeout))
+                        {
+                            TimedOut = true;
                             throw new TimeoutException("the test never opened the load gate");
+                        }
 
                         return history;
                     });

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -1,0 +1,141 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using HSMCommon.Model;
+using HSMDatabase.AccessManager.DatabaseEntities;
+using HSMDatabase.AccessManager.Formatters;
+using HSMServer.Core.DataLayer;
+using HSMServer.Core.Model;
+using HSMServer.Core.Model.Sensors.SensorModels;
+using HSMServer.Core.Tests.Infrastructure;
+using Moq;
+using Xunit;
+
+namespace HSMServer.Core.Tests.TreeValuesCacheTests
+{
+    /// <summary>
+    /// Pins the Initialize() publication contract (#1296): _isInitialized must become observable only
+    /// AFTER the history load has filled Storage, so a value arriving while the load is in flight
+    /// waits instead of racing past the gate on an empty Storage. No fixture — these tests use a
+    /// mocked IDatabaseCore, never LevelDB.
+    /// </summary>
+    public class SensorInitializationTests
+    {
+        private static readonly TimeSpan _waitTimeout = TimeSpan.FromSeconds(10);
+
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
+        public void TryAddValue_DuringHistoryLoad_WaitsForLoadedStorage()
+        {
+            var historyBytes = new MemoryPackFormatter().Serialize(
+                new IntegerValue { Time = DateTime.UtcNow.AddMinutes(-5), Status = SensorStatus.Ok, Value = 1 });
+
+            using var loadEntered = new ManualResetEventSlim(false);
+            using var loadGate = new ManualResetEventSlim(false);
+
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                .Returns(() =>
+                {
+                    loadEntered.Set();
+                    loadGate.Wait(_waitTimeout);
+                    return historyBytes;
+                });
+            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(historyBytes);
+
+            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+
+            var init = Task.Run(sensor.Initialize);
+            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+
+            var newValue = new IntegerValue { Time = DateTime.UtcNow, Status = SensorStatus.Ok, Value = 2 };
+            var added = false;
+            using var addStarted = new ManualResetEventSlim(false);
+            var add = Task.Run(() =>
+            {
+                addStarted.Set();
+                added = sensor.TryAddValue(newValue);
+            });
+
+            Assert.True(addStarted.Wait(_waitTimeout), "TryAddValue task never started");
+            // The load is still in flight (the gate is closed), so the writer must be parked on the
+            // initialization lock. Pre-fix code latched the flag before reading the database, and
+            // this Wait returned true immediately — TryAddValue completed against an empty Storage.
+            Assert.False(add.Wait(TimeSpan.FromMilliseconds(200)),
+                "TryAddValue completed while the history load was still in flight");
+
+            loadGate.Set();
+            Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
+
+            Assert.True(added);
+            var lastValue = Assert.IsType<IntegerValue>(sensor.LastValue);
+            Assert.Equal(2, lastValue.Value);
+            Assert.Equal(newValue.Time, lastValue.Time);
+            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
+        public void Initialize_Concurrent_LoadsHistoryOnce()
+        {
+            using var loadEntered = new ManualResetEventSlim(false);
+            using var loadGate = new ManualResetEventSlim(false);
+
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                .Returns(() =>
+                {
+                    loadEntered.Set();
+                    loadGate.Wait(_waitTimeout);
+                    return null;
+                });
+
+            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+
+            var first = Task.Run(sensor.Initialize);
+            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+
+            var second = Task.Run(sensor.Initialize);
+            // The second caller must wait for the in-flight load, not skip ahead on the early latch.
+            Assert.False(second.Wait(TimeSpan.FromMilliseconds(200)),
+                "second Initialize returned while the first was still loading");
+
+            loadGate.Set();
+            Assert.True(Task.WaitAll(new[] { first, second }, _waitTimeout), "initializations did not finish");
+
+            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
+        }
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
+        public void Initialize_LoadFails_LatchesWithoutPerValueRetry()
+        {
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                .Throws(new IOException("database is broken"));
+
+            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+
+            sensor.Initialize(); // must swallow + log, not throw
+
+            // The sensor stays usable and the failed load is NOT retried on every value — the flag
+            // latches even on failure (deliberate: one loud error beats a retry storm on a broken DB).
+            Assert.True(sensor.TryAddValue(new IntegerValue { Time = DateTime.UtcNow, Status = SensorStatus.Ok, Value = 7 }));
+            Assert.True(sensor.TryAddValue(new IntegerValue { Time = DateTime.UtcNow, Status = SensorStatus.Ok, Value = 8 }));
+
+            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
+        }
+
+
+        private static SensorEntity BuildEntity() =>
+            new()
+            {
+                Id = Guid.NewGuid().ToString(),
+                ProductId = Guid.NewGuid().ToString(),
+                DisplayName = RandomGenerator.GetRandomString(),
+                Type = (byte)SensorType.Integer,
+            };
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -24,31 +24,20 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
     {
         private static readonly TimeSpan _waitTimeout = TimeSpan.FromSeconds(10);
 
+        /// <summary>Bounds how long a call may be given to prove it did NOT complete. Asserting
+        /// non-completion is the safe polarity: a loaded agent makes it more likely to hold.</summary>
+        private static readonly TimeSpan _mustNotComplete = TimeSpan.FromMilliseconds(200);
+
 
         [Fact]
         [Trait("Category", "Initialization race")]
         public void TryAddValue_DuringHistoryLoad_WaitsForLoadedStorage()
         {
-            var historyBytes = new MemoryPackFormatter().Serialize(
-                new IntegerValue { Time = DateTime.UtcNow.AddMinutes(-5), Status = SensorStatus.Ok, Value = 1 });
-
-            using var loadEntered = new ManualResetEventSlim(false);
-            using var loadGate = new ManualResetEventSlim(false);
-
-            var database = new Mock<IDatabaseCore>();
-            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
-                .Returns(() =>
-                {
-                    loadEntered.Set();
-                    loadGate.Wait(_waitTimeout);
-                    return historyBytes;
-                });
-            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(historyBytes);
-
-            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+            using var load = new GatedLoad(History(DateTime.UtcNow.AddMinutes(-5), 1));
+            var sensor = new IntegerSensorModel(BuildEntity(), load.Database.Object, null);
 
             var init = Task.Run(sensor.Initialize);
-            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+            Assert.True(load.Entered.Wait(_waitTimeout), "history load never started");
 
             var newValue = new IntegerValue { Time = DateTime.UtcNow, Status = SensorStatus.Ok, Value = 2 };
             var added = false;
@@ -63,59 +52,42 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             // The load is still in flight (the gate is closed), so the writer must be parked on the
             // initialization lock. Pre-fix code latched the flag before reading the database, and
             // this Wait returned true immediately — TryAddValue completed against an empty Storage.
-            Assert.False(add.Wait(TimeSpan.FromMilliseconds(200)),
+            Assert.False(add.Wait(_mustNotComplete),
                 "TryAddValue completed while the history load was still in flight");
 
-            loadGate.Set();
+            load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
 
             Assert.True(added);
             var lastValue = Assert.IsType<IntegerValue>(sensor.LastValue);
             Assert.Equal(2, lastValue.Value);
             Assert.Equal(newValue.Time, lastValue.Time);
-            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
+            load.Database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
         /// <summary>
-        /// The three entry points that gate on _isInitialized. TryAddValue is covered in depth
-        /// above; this pins that the other two honour the same publication contract, which matters
-        /// operationally — CheckTimeout is reached from ProductModel.CheckTimeout() and from
-        /// BaseNodeModel.TryUpdate, so a settings change during startup walks every sensor.
+        /// The other two entry points that gate on _isInitialized (TryAddValue is covered in depth
+        /// by the test above). CheckTimeout is the operationally interesting one: it is reached from
+        /// ProductModel.CheckTimeout() and BaseNodeModel.TryUpdate, so a settings change during
+        /// startup walks every sensor and can park on each in-flight load.
         /// </summary>
         public enum ValueGate
         {
-            TryAddValue,
             TryUpdateLastValue,
             CheckTimeout,
         }
 
         [Theory]
-        [InlineData(ValueGate.TryAddValue)]
         [InlineData(ValueGate.TryUpdateLastValue)]
         [InlineData(ValueGate.CheckTimeout)]
         [Trait("Category", "Initialization race")]
         public void ValueGate_DuringHistoryLoad_WaitsForLoadedStorage(ValueGate gate)
         {
-            var historyBytes = new MemoryPackFormatter().Serialize(
-                new IntegerValue { Time = DateTime.UtcNow.AddMinutes(-5), Status = SensorStatus.Ok, Value = 1 });
-
-            using var loadEntered = new ManualResetEventSlim(false);
-            using var loadGate = new ManualResetEventSlim(false);
-
-            var database = new Mock<IDatabaseCore>();
-            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
-                .Returns(() =>
-                {
-                    loadEntered.Set();
-                    loadGate.Wait(_waitTimeout);
-                    return historyBytes;
-                });
-            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(historyBytes);
-
-            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+            using var load = new GatedLoad(History(DateTime.UtcNow.AddMinutes(-5), 1));
+            var sensor = new IntegerSensorModel(BuildEntity(), load.Database.Object, null);
 
             var init = Task.Run(sensor.Initialize);
-            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+            Assert.True(load.Entered.Wait(_waitTimeout), "history load never started");
 
             using var callStarted = new ManualResetEventSlim(false);
             var call = Task.Run(() =>
@@ -126,9 +98,6 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
                 switch (gate)
                 {
-                    case ValueGate.TryAddValue:
-                        sensor.TryAddValue(value);
-                        break;
                     case ValueGate.TryUpdateLastValue:
                         sensor.TryUpdateLastValue(value);
                         break;
@@ -139,10 +108,10 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             });
 
             Assert.True(callStarted.Wait(_waitTimeout), $"{gate} task never started");
-            Assert.False(call.Wait(TimeSpan.FromMilliseconds(200)),
+            Assert.False(call.Wait(_mustNotComplete),
                 $"{gate} completed while the history load was still in flight");
 
-            loadGate.Set();
+            load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { init, call }, _waitTimeout), "init/call did not finish");
         }
 
@@ -151,28 +120,14 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         public void TryAddValue_StaleValueDuringHistoryLoad_IsJudgedAgainstLoadedHistory()
         {
             var historyTime = DateTime.UtcNow.AddMinutes(-1);
-            var historyBytes = new MemoryPackFormatter().Serialize(
-                new IntegerValue { Time = historyTime, Status = SensorStatus.Ok, Value = 1 });
 
-            using var loadEntered = new ManualResetEventSlim(false);
-            using var loadGate = new ManualResetEventSlim(false);
-
-            var database = new Mock<IDatabaseCore>();
-            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
-                .Returns(() =>
-                {
-                    loadEntered.Set();
-                    loadGate.Wait(_waitTimeout);
-                    return historyBytes;
-                });
-            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(historyBytes);
-
+            using var load = new GatedLoad(History(historyTime, 1));
             // Singleton: TryAddValue decides by comparing against Storage.LastValue, so the verdict
             // is a direct readout of whether the history was already published when the writer ran.
-            var sensor = new IntegerSensorModel(BuildEntity(isSingleton: true), database.Object, null);
+            var sensor = new IntegerSensorModel(BuildEntity(isSingleton: true), load.Database.Object, null);
 
             var init = Task.Run(sensor.Initialize);
-            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+            Assert.True(load.Entered.Wait(_waitTimeout), "history load never started");
 
             // Older than the history the in-flight load is about to publish.
             var stale = new IntegerValue { Time = historyTime.AddMinutes(-9), Status = SensorStatus.Ok, Value = 2 };
@@ -187,19 +142,42 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             // Pin the overlap rather than assuming it: without these two the writer could run
             // entirely after the load and the outcome assert below would pass without a race.
             Assert.True(addStarted.Wait(_waitTimeout), "TryAddValue task never started");
-            Assert.False(add.Wait(TimeSpan.FromMilliseconds(200)),
+            Assert.False(add.Wait(_mustNotComplete),
                 "TryAddValue completed while the history load was still in flight");
 
-            loadGate.Set();
+            load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
 
             // Pre-fix the writer met an empty Storage, so singleton dedup had nothing to compare
             // against and stored the stale value as current. Against the loaded history it is
-            // correctly recognised as older and dropped.
+            // correctly recognised as older and dropped. These asserts are order-sensitive and
+            // cannot pass by accident, unlike the non-completion bound above.
             Assert.False(added, "stale value was accepted because Storage was still empty");
             var lastValue = Assert.IsType<IntegerValue>(sensor.LastValue);
             Assert.Equal(1, lastValue.Value);
             Assert.Equal(historyTime, lastValue.Time);
+        }
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
+        public void ShouldDestroy_UninitializedSensor_JudgesByHistoryNotCreationDate()
+        {
+            // A long-lived sensor that is still receiving data: created 10 days ago, last value a
+            // minute old, self-destroy after an hour of inactivity.
+            var database = new Mock<IDatabaseCore>();
+            var recent = History(DateTime.UtcNow.AddMinutes(-1), 1);
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>())).Returns(recent);
+            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(recent);
+
+            var entity = BuildEntity(selfDestroy: TimeSpan.FromHours(1), creationDate: DateTime.UtcNow.AddDays(-10));
+            var sensor = new IntegerSensorModel(entity, database.Object, null);
+
+            // Unguarded, ShouldDestroy() reads HasData == false on an uninitialized sensor and falls
+            // back to CreationDate — 10 days > 1 hour — and the self-destroy sweep deletes the
+            // sensor with its history. Only the ordering inside ClearDatabaseService.ServiceActionAsync
+            // keeps that from firing today, which is three statements, not an invariant.
+            Assert.False(sensor.ShouldDestroy(), "a sensor with fresh history was judged by its CreationDate");
+            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
         [Fact]
@@ -237,25 +215,14 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         [Trait("Category", "Initialization race")]
         public void Initialize_Concurrent_LoadsHistoryOnce()
         {
-            using var loadEntered = new ManualResetEventSlim(false);
-            using var loadGate = new ManualResetEventSlim(false);
-
-            var database = new Mock<IDatabaseCore>();
-            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
-                .Returns(() =>
-                {
-                    loadEntered.Set();
-                    loadGate.Wait(_waitTimeout);
-                    return null;
-                });
-
-            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+            using var load = new GatedLoad(null);
+            var sensor = new IntegerSensorModel(BuildEntity(), load.Database.Object, null);
 
             var first = Task.Run(sensor.Initialize);
-            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+            Assert.True(load.Entered.Wait(_waitTimeout), "history load never started");
 
             // secondStarted proves the task body ran: without it a thread pool that schedules the
-            // task later than the 200 ms below makes the Wait return false for the wrong reason and
+            // task later than the bound below makes the Wait return false for the wrong reason and
             // the test passes having verified nothing.
             using var secondStarted = new ManualResetEventSlim(false);
             var second = Task.Run(() =>
@@ -266,13 +233,13 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
             Assert.True(secondStarted.Wait(_waitTimeout), "second Initialize task never started");
             // The second caller must wait for the in-flight load, not skip ahead on the early latch.
-            Assert.False(second.Wait(TimeSpan.FromMilliseconds(200)),
+            Assert.False(second.Wait(_mustNotComplete),
                 "second Initialize returned while the first was still loading");
 
-            loadGate.Set();
+            load.Gate.Set();
             Assert.True(Task.WaitAll(new[] { first, second }, _waitTimeout), "initializations did not finish");
 
-            database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
+            load.Database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
         [Fact]
@@ -296,14 +263,63 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
         }
 
 
-        private static SensorEntity BuildEntity(bool isSingleton = false) =>
-            new()
+        /// <summary>
+        /// A mocked database whose history read blocks until <see cref="Gate"/> is set, so a test can
+        /// hold Initialize() mid-load and act while it is in flight. <see cref="Entered"/> signals
+        /// that the load actually reached the database.
+        /// </summary>
+        private sealed class GatedLoad : IDisposable
+        {
+            public Mock<IDatabaseCore> Database { get; } = new();
+
+            public ManualResetEventSlim Entered { get; } = new(false);
+
+            public ManualResetEventSlim Gate { get; } = new(false);
+
+
+            public GatedLoad(byte[] history)
+            {
+                Database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                    .Returns(() =>
+                    {
+                        Entered.Set();
+                        Gate.Wait(_waitTimeout);
+                        return history;
+                    });
+
+                Database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(history);
+            }
+
+
+            public void Dispose()
+            {
+                Entered.Dispose();
+                Gate.Dispose();
+            }
+        }
+
+
+        private static byte[] History(DateTime time, int value) =>
+            new MemoryPackFormatter().Serialize(
+                new IntegerValue { Time = time, Status = SensorStatus.Ok, Value = value });
+
+        private static SensorEntity BuildEntity(bool isSingleton = false, TimeSpan? selfDestroy = null,
+            DateTime? creationDate = null)
+        {
+            var entity = new SensorEntity
             {
                 Id = Guid.NewGuid().ToString(),
                 ProductId = Guid.NewGuid().ToString(),
                 DisplayName = RandomGenerator.GetRandomString(),
                 Type = (byte)SensorType.Integer,
                 IsSingleton = isSingleton,
+                CreationDate = (creationDate ?? DateTime.UtcNow).Ticks,
             };
+
+            if (selfDestroy.HasValue)
+                entity.Settings["SelfDestroy"] = new TimeIntervalEntity((long)TimeInterval.Ticks, selfDestroy.Value.Ticks);
+
+            return entity;
+        }
     }
 }

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -76,6 +76,76 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             database.Verify(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()), Times.Once);
         }
 
+        /// <summary>
+        /// The three entry points that gate on _isInitialized. TryAddValue is covered in depth
+        /// above; this pins that the other two honour the same publication contract, which matters
+        /// operationally — CheckTimeout is reached from ProductModel.CheckTimeout() and from
+        /// BaseNodeModel.TryUpdate, so a settings change during startup walks every sensor.
+        /// </summary>
+        public enum ValueGate
+        {
+            TryAddValue,
+            TryUpdateLastValue,
+            CheckTimeout,
+        }
+
+        [Theory]
+        [InlineData(ValueGate.TryAddValue)]
+        [InlineData(ValueGate.TryUpdateLastValue)]
+        [InlineData(ValueGate.CheckTimeout)]
+        [Trait("Category", "Initialization race")]
+        public void ValueGate_DuringHistoryLoad_WaitsForLoadedStorage(ValueGate gate)
+        {
+            var historyBytes = new MemoryPackFormatter().Serialize(
+                new IntegerValue { Time = DateTime.UtcNow.AddMinutes(-5), Status = SensorStatus.Ok, Value = 1 });
+
+            using var loadEntered = new ManualResetEventSlim(false);
+            using var loadGate = new ManualResetEventSlim(false);
+
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), It.IsAny<long>()))
+                .Returns(() =>
+                {
+                    loadEntered.Set();
+                    loadGate.Wait(_waitTimeout);
+                    return historyBytes;
+                });
+            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(historyBytes);
+
+            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+
+            var init = Task.Run(sensor.Initialize);
+            Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
+
+            using var callStarted = new ManualResetEventSlim(false);
+            var call = Task.Run(() =>
+            {
+                callStarted.Set();
+
+                var value = new IntegerValue { Time = DateTime.UtcNow, Status = SensorStatus.Ok, Value = 2 };
+
+                switch (gate)
+                {
+                    case ValueGate.TryAddValue:
+                        sensor.TryAddValue(value);
+                        break;
+                    case ValueGate.TryUpdateLastValue:
+                        sensor.TryUpdateLastValue(value);
+                        break;
+                    case ValueGate.CheckTimeout:
+                        sensor.CheckTimeout();
+                        break;
+                }
+            });
+
+            Assert.True(callStarted.Wait(_waitTimeout), $"{gate} task never started");
+            Assert.False(call.Wait(TimeSpan.FromMilliseconds(200)),
+                $"{gate} completed while the history load was still in flight");
+
+            loadGate.Set();
+            Assert.True(Task.WaitAll(new[] { init, call }, _waitTimeout), "init/call did not finish");
+        }
+
         [Fact]
         [Trait("Category", "Initialization race")]
         public void TryAddValue_StaleValueDuringHistoryLoad_IsJudgedAgainstLoadedHistory()
@@ -107,11 +177,18 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             // Older than the history the in-flight load is about to publish.
             var stale = new IntegerValue { Time = historyTime.AddMinutes(-9), Status = SensorStatus.Ok, Value = 2 };
             var added = true;
-            var add = Task.Run(() => { added = sensor.TryAddValue(stale); });
+            using var addStarted = new ManualResetEventSlim(false);
+            var add = Task.Run(() =>
+            {
+                addStarted.Set();
+                added = sensor.TryAddValue(stale);
+            });
 
-            // Settle, not an assertion: gives the writer time to reach the gate and park on _lock.
-            // Pre-fix it runs straight through here instead, which is what the asserts below catch.
-            add.Wait(TimeSpan.FromMilliseconds(200));
+            // Pin the overlap rather than assuming it: without these two the writer could run
+            // entirely after the load and the outcome assert below would pass without a race.
+            Assert.True(addStarted.Wait(_waitTimeout), "TryAddValue task never started");
+            Assert.False(add.Wait(TimeSpan.FromMilliseconds(200)),
+                "TryAddValue completed while the history load was still in flight");
 
             loadGate.Set();
             Assert.True(Task.WaitAll(new[] { init, add }, _waitTimeout), "init/add did not finish");
@@ -177,7 +254,17 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
             var first = Task.Run(sensor.Initialize);
             Assert.True(loadEntered.Wait(_waitTimeout), "history load never started");
 
-            var second = Task.Run(sensor.Initialize);
+            // secondStarted proves the task body ran: without it a thread pool that schedules the
+            // task later than the 200 ms below makes the Wait return false for the wrong reason and
+            // the test passes having verified nothing.
+            using var secondStarted = new ManualResetEventSlim(false);
+            var second = Task.Run(() =>
+            {
+                secondStarted.Set();
+                sensor.Initialize();
+            });
+
+            Assert.True(secondStarted.Wait(_waitTimeout), "second Initialize task never started");
             // The second caller must wait for the in-flight load, not skip ahead on the early latch.
             Assert.False(second.Wait(TimeSpan.FromMilliseconds(200)),
                 "second Initialize returned while the first was still loading");

--- a/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
+++ b/src/tests/HSMServer.Core.Tests/TreeValuesCacheTests/SensorInitializationTests.cs
@@ -162,6 +162,35 @@ namespace HSMServer.Core.Tests.TreeValuesCacheTests
 
         [Fact]
         [Trait("Category", "Initialization race")]
+        public void Initialize_TimeoutOnlyHistory_LoadsWithoutThrowing()
+        {
+            // Reachable state, not a synthetic one: KeepHistory retention sweeps a quiet sensor's
+            // real values and leaves only the timeout marker SetExpiredSnapshot wrote as the newest
+            // row. The lookup for the value *before* the marker then returns null.
+            var timeoutTime = DateTime.UtcNow.AddMinutes(-30);
+            var timeoutBytes = new MemoryPackFormatter().Serialize(
+                new IntegerValue { Time = timeoutTime, Status = SensorStatus.Ok, Value = 0, IsTimeout = true });
+
+            var database = new Mock<IDatabaseCore>();
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), DateTime.MaxValue.Ticks)).Returns(timeoutBytes);
+            database.Setup(db => db.GetLatestValue(It.IsAny<Guid>(), timeoutTime.Ticks - 1)).Returns((byte[])null);
+            database.Setup(db => db.GetFirstValue(It.IsAny<Guid>())).Returns(timeoutBytes);
+
+            var sensor = new IntegerSensorModel(BuildEntity(), database.Object, null);
+
+            sensor.Initialize();
+
+            // Unguarded, Convert(null) throws, the catch swallows it and the finally latches — the
+            // sensor is left initialized over an empty Storage with no expiry state, permanently.
+            // That is the #1296 symptom, no longer bounded to a startup window.
+            Assert.True(sensor.IsExpired, "expiry state was lost — the load threw before setting it");
+            // AddValueBase routes a timeout marker to _lastTimeout, not _lastValue.
+            Assert.NotNull(sensor.LastTimeout);
+            Assert.Equal(timeoutTime, sensor.LastTimeout.Time);
+        }
+
+        [Fact]
+        [Trait("Category", "Initialization race")]
         public void Initialize_ReentrantOnSameThread_DoesNotReloadHistory()
         {
             IntegerSensorModel sensor = null;


### PR DESCRIPTION
## Summary

`BaseSensorModel<T>.Initialize()` latched `_isInitialized` **before** reading the sensor's history out of LevelDB, and the fast-path check sits outside the lock on a plain bool. During server startup the cache fires the history load as fire-and-forget (`Task.Run(FillSensorsData)`) while the API is already accepting data — so a value landing in that window saw the sensor as "initialized" and ran against an **empty Storage**: `SensorTimeout(null)` skipped the TTL/expired notification, `isLastValue` came out `true` for stale values, singleton dedup had nothing to compare against, EMA started from an empty window. Found while diagnosing the flaky `TreeValuesCacheTests` (#1287, which made the *tests* robust to this and deliberately left the production race in place).

The core fix is confined to latch placement and memory ordering — the load logic itself is untouched:

- `_isInitialized` is now `volatile` (the gates in `TryAddValue` / `TryUpdateLastValue` / `CheckTimeout` read it lock-free);
- the flag is written in a `finally` **after** the load completes, so `true` means "Storage is loaded", and a concurrent writer parks on the per-sensor lock instead of racing past;
- a failed load still latches, exactly as before — one loud error log instead of a per-value retry storm against a broken database (decision point called out in the issue).

Startup is not serialized because **the lock is per-sensor**: a waiter only ever blocks behind that one sensor's load. `Initialize()` is driven from several places at once (`FillSensorsData`, `CheckSensorsTimeout` on each product's queue reader, `ProductModel.CheckTimeout()` via `BaseNodeModel.TryUpdate`, and the ingest path), so several sensors do load on several threads.

## What the wait actually spans

Worth stating plainly, since the blocking half of this is new: the lock is held across up to **three** LevelDB reads plus the policy fan-out — `TryValidate` → `CalculateStorageResult` → `SensorTimeout` → `SensorExpired` → `SetExpiredSnapshot`, and from there both `ChangeSensorEvent` subscribers and the notification path. That fan-out already ran under the lock on `master`; what is new is that value ingress now *waits* on it, which makes "nothing reached from inside a sensor's initialization lock may block" a load-bearing invariant. It is stated canonically in `aicontext/features/server/overview.md`, with one-line pointers from the three code sites.

## Two hardenings the latch made necessary

- **Re-entrancy guard.** The early latch doubled as one. Without it, a same-thread re-entry (`TryValidate` → `SensorTimeout` → `SensorExpired` → `TryAddValue` → `Initialize`) would replay the whole history load, recursing until the stack blows. `Monitor.IsEntered(_lock)` stops the replay and logs a `Warn` — the path is unreachable today only by an ordering accident, so the log line is the tripwire if a policy change ever opens it. Caveat recorded in #1328.
- **Null guards on the history reads.** `Convert(valueBytes)` and `Convert(firstBytes)` ran unguarded, and both reads are reachable as null: `KeepHistory` retention sweeps a quiet sensor's real values and leaves only the timeout marker as the newest row. `Convert(null)` throws, the `catch` swallows it, and the `finally` latches — leaving the sensor initialized over an empty Storage with `IsExpired` unset and TTL state never restored. That pre-existed, but latch-on-failure turned it from a startup-window glitch into a permanent one.

## Tests

`SensorInitializationTests` — no fixture, no LevelDB; the model is built directly against a gated `IDatabaseCore` mock. Seven methods, eight cases:

1. `TryAddValue_DuringHistoryLoad_WaitsForLoadedStorage` — the writer must not complete while the load is held open; afterwards the new value sits on top of the loaded history and the DB was read once.
2. `ValueGate_DuringHistoryLoad_WaitsForLoadedStorage` (`TryUpdateLastValue`, `CheckTimeout`) — the other two gates honour the same contract. Each captures `Storage.From` the instant its call returns; `Cut` sets it at the end of the load, so pre-fix it reads `MinValue`.
3. `TryAddValue_StaleValueDuringHistoryLoad_IsJudgedAgainstLoadedHistory` — a stale value arriving mid-load is judged against the loaded history (singleton dedup drops it); pre-fix it was stored against an empty Storage.
4. `Initialize_TimeoutOnlyHistory_LoadsWithoutThrowing` — the retention-swept sensor above; expiry state must survive.
5. `Initialize_ReentrantOnSameThread_DoesNotReloadHistory` — the guard; the mock drives re-entry on the loading thread.
6. `Initialize_Concurrent_LoadsHistoryOnce` — the second concurrent `Initialize` waits and observes the history on return. (`Times.Once` alone does not discriminate — pre-fix the second caller also skipped the load.)
7. `Initialize_LoadFails_LatchesWithoutPerValueRetry` — pins the kept semantics: swallow + log, stay latched, sensor stays usable.

Every assertion that matters is a post-condition captured at the moment the gated call returns, not a "did not finish in 200 ms" bound — those are timing-shaped and can pass for the wrong reason.

## Test plan

- [x] `SensorInitializationTests` 8/8
- [x] All five race cases verified **red** under a pre-fix simulation (early latch restored), green with the fix
- [x] The re-entrancy test verified red with the guard removed; the timeout-only test verified red with the null guard removed
- [x] Full `HSMServer.Core.Tests`: **537/537**
- [ ] Server lane on merge (`HSMServer build` runs on master push only)

## Deliberately not in this PR

Direct `Storage` readers (`LastValue`, `HasData`, `Revalidate()`, `Cut()`, `Clear()`) stay unguarded, as before #1296. One of them is a data-loss path — `ShouldDestroy()` falls back to `CreationDate` on an uninitialized sensor and deletes it with its history. Fixing it here meant calling `Initialize()` from a `public bool` predicate, which would let it emit TTL alerts for a sensor about to be deleted, so it is **#1328** instead.

Closes #1296

🤖 Generated with [Claude Code](https://claude.com/claude-code)