### PR TITLE
claude-review: fail the check when the review did not run

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -9,7 +9,7 @@ on:
 # Each review is a paid API call, and the incident that motivated fail-loud was an API usage
 # limit. Without this, ten pushes to one PR buy ten reviews and ten competing check results.
 concurrency:
-  group: claude-review-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -37,12 +37,6 @@ jobs:
         with:
           fetch-depth: 1
 
-      # Recorded before the agent runs. The verify step gates on "the bot posted a comment after
-      # this moment", a property that needs no cooperation from the model — see that step.
-      - name: Record start time
-        id: t0
-        run: echo "since=$(date -u +%FT%TZ)" >> "$GITHUB_OUTPUT"
-
       # No continue-on-error: a review that did not run must fail the check —
       # otherwise API-limit/auth failures silently produce a green "pass" with no review.
       - uses: anthropics/claude-code-action@v1
@@ -56,7 +50,7 @@ jobs:
           base_branch: master
           claude_args: >-
             --verbose
-            --allowedTools "Bash(gh pr comment*),Bash(gh pr diff*),Bash(gh pr view*),Bash(git diff*),Bash(git log*),Write"
+            --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Bash(git diff*),Bash(git log*),Write"
           show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -73,60 +67,33 @@ jobs:
             reach for `git diff origin/<base>...origin/<head>`: this job checks out the PR merge
             ref at depth 1, so neither remote branch exists locally and there is no merge base.
 
-            Write your review to review_output.md. Its last line must be exactly:
-            <!-- claude-review: ${{ github.run_id }}-${{ github.run_attempt }} -->
+            Write your review to review_output.md and stop there. Do NOT post it — the workflow
+            posts that file itself, so that delivery is a deterministic step outcome rather than
+            something inferred from whether you followed an instruction.
 
-            Then post it:
-            gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
-
-      # A green action is not proof of a review: the agent can exit 0 after hitting a turn or
-      # output limit, or write the file and then fail to post it. The gated property is delivery.
-      #
-      # Gate on "a github-actions[bot] comment exists that was created after this job started" —
-      # deterministic, and true whatever the model did with its instructions. The run marker is
-      # only a correlation aid: making the gate depend on a model reproducing a string verbatim
-      # would red-flag delivered reviews, and a check that lies gets bypassed. This workflow is
-      # the only one in the repo that comments, so bot authorship is unambiguous.
-      - name: Verify a review was posted
-        if: steps.claude.outcome == 'success'
+      # Delivery is a workflow step, not an instruction to the model. A green action is not proof
+      # of a review — the agent can exit 0 after a turn/output limit — and inferring delivery from
+      # "a bot comment appeared" was unsound: claude-agent.yml also replies as github-actions[bot],
+      # so an unrelated @claude reply could satisfy the gate while this review silently produced
+      # nothing. Posting here makes the gated property the exit status of this step.
+      - name: Post the review
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          marker='claude-review: ${{ github.run_id }}-${{ github.run_attempt }}'
-          since='${{ steps.t0.outputs.since }}'
-          url="repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
+          # 200 bytes: a stub or truncated write is not a review, and -s alone passes on one byte.
+          if [ ! -s review_output.md ] || [ "$(wc -c < review_output.md)" -lt 200 ]; then
+            echo "::error title=Claude review::The agent exited 0 without writing a review."
+            exit 1
+          fi
 
-          # Deliberately not `gh ... | grep -q`. Without pipefail the pipeline reports grep's
-          # status, so a failed gh read is indistinguishable from "no comment posted" and the
-          # error message asserts something untrue. With pipefail it is worse: grep -q closes
-          # the pipe on the first match, gh dies of SIGPIPE, and a SUCCESSFUL check fails.
-          # gh api --paginate rather than `gh pr view --json comments`, whose single fixed page
-          # can exclude the new comment on a PR with a long comment history.
-          #
-          # Both failure modes share the retry budget: a transient 502 on the first read must not
-          # sink a delivered review, and the comments read may briefly lag the just-posted comment.
-          for attempt in 1 2 3; do
-            if bodies=$(gh api --paginate "$url" \
-                  --jq ".[] | select(.user.login == \"github-actions[bot]\" and .created_at > \"$since\") | .body"); then
-              if [ -n "$bodies" ]; then
-                if ! grep -qF "$marker" <<<"$bodies"; then
-                  echo "::warning title=Claude review::Review delivered, but without this run's marker — cannot correlate it to this run."
-                fi
+          # Appended by the workflow, so it is always present and always correct — it correlates
+          # the comment with this run for anyone reading the PR later.
+          {
+            echo ""
+            echo "<!-- claude-review: ${{ github.run_id }}-${{ github.run_attempt }} -->"
+          } >> review_output.md
 
-                exit 0
-              fi
-            elif [ "$attempt" -eq 3 ]; then
-              echo "::error title=Claude review::Could not read PR comments to verify delivery (gh failed) — this is not a verdict on the review itself."
-              exit 1
-            fi
-
-            if [ "$attempt" -lt 3 ]; then
-              sleep 5
-            fi
-          done
-
-          echo "::error title=Claude review::The agent exited 0 but posted no review comment for this run."
-          exit 1
+          gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
 
       - name: Dump review output (when no review was delivered)
         # failure() and not an outcome check on the agent step: the case this whole guard exists
@@ -152,9 +119,9 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # A skipped job satisfies branch protection, so without this a fork PR shows nothing at all on
-  # the checks tab — the same silent pass this workflow exists to remove, by another route. This
-  # job produces a visible, named check saying a human has to do the review.
+  # Visibility aid, NOT a gate: it passes, so it cannot block anything. A skipped claude-review
+  # job already satisfies branch protection on fork PRs; this only makes that state visible on the
+  # checks tab instead of showing nothing. Making fork PRs actually blocked is a policy decision.
   fork-review-notice:
     if: >-
       github.event.pull_request.draft == false

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,6 +64,9 @@ jobs:
           claude_args: >-
             --verbose
             --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Write"
+          # Kept for in-log diagnosis — reading the raw tool results in the job log is how the
+          # API-limit failure that motivated this workflow change was identified. It no longer
+          # feeds an artifact: claude-execution-output.json is deliberately not archived.
           show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -199,7 +202,15 @@ jobs:
           # Surface it on the checks tab; the detail is otherwise buried in a long log.
           echo "::error title=Claude review::Review check failed — no review reached the PR for this run. See the failing step's log."
           echo "=== review_output.md ==="
+
+          # The runner parses stdout for workflow commands, and a review of THIS file quotes
+          # ::error:: lines verbatim — so dumping one unguarded would emit bogus annotations, and
+          # a ::stop-commands:: line inside it would mute every later annotation in the job.
+          # Fence the dump with an unguessable token.
+          tok="dump-$(date +%s%N)"
+          echo "::stop-commands::$tok"
           cat review_output.md 2>/dev/null || echo "(file not created)"
+          echo "::$tok::"
 
       - name: Upload Claude logs
         if: always()
@@ -215,6 +226,7 @@ jobs:
           # but does not scrub artifact contents, and retention outlives the token. The two files
           # below carry everything anyone actually wants; agent diagnostics stay in the job log.
           path: |
+            review_body.md
             review_output.md
             review_full.md
             *.log

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,9 +17,11 @@ jobs:
     # Skip review while the PR is a draft. This workflow only triggers on pull_request,
     # so the draft flag is always present.
     # Same-repo heads only. Two reasons, and do NOT relax this to "get fork coverage back":
-    #  1. Security. The job holds a write-scoped GITHUB_TOKEN that the agent's shell can reach,
-    #     and its tool grants are prefix wildcards. Feeding that agent a diff written by an
-    #     untrusted contributor is a prompt-injection surface; same-repo heads close it.
+    #  1. Security, and this restriction IS the boundary — not --allowedTools. Read-only shell
+    #     commands run without being on that list (observed: ls, git log, git remote -v); the
+    #     allowlist gates writes. The job also holds a write-scoped GITHUB_TOKEN the agent's shell
+    #     can reach. Feeding that agent a diff written by an untrusted contributor is a
+    #     prompt-injection surface, and same-repo heads are what closes it.
     #  2. It cannot work anyway: GitHub withholds repository secrets from forked-repo events, so
     #     ANTHROPIC_API_KEY is empty and pull-requests write is downgraded to read.
     # Caveat: branch protection counts a skipped job as satisfying a required check, so if this
@@ -42,6 +44,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          # Without this the checkout token sits in the remote URL, where `git remote -v` prints
+          # it in cleartext — and with show_full_output that tool result reaches the uploaded
+          # artifact, which GitHub does not scrub the way it masks logs. Nothing here needs it:
+          # the agent and the post step authenticate through GH_TOKEN.
+          persist-credentials: false
 
       # No continue-on-error: a review that did not run must fail the check —
       # otherwise API-limit/auth failures silently produce a green "pass" with no review.
@@ -71,7 +78,7 @@ jobs:
 
             Use `gh pr diff ${{ github.event.pull_request.number }}` to see the changes. Do not
             reach for `git diff origin/<base>...origin/<head>`: this job checks out the PR merge
-            ref at depth 1, so neither remote branch exists locally and there is no merge base.
+            ref, so the head branch ref is not fetched, and depth-1 leaves no merge base.
 
             Write your review to review_output.md and stop there. Do NOT post it — the workflow
             posts that file itself, so that delivery is a deterministic step outcome rather than
@@ -82,24 +89,33 @@ jobs:
       # "a bot comment appeared" was unsound: claude-agent.yml also replies as github-actions[bot],
       # so an unrelated @claude reply could satisfy the gate while this review silently produced
       # nothing. Posting here makes the gated property the exit status of this step.
+      # always(): a review that exists must reach the PR even if the agent step then failed — a
+      # late API error or the timeout firing during teardown would otherwise discard a finished
+      # review, which is this PR's own failure shape one step later. The check still goes red.
       - name: Post the review
+        if: always() && steps.claude.outcome != 'skipped'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ ! -s review_output.md ]; then
-            echo "::error title=Claude review::The agent exited 0 without writing a review."
+          agent_outcome='${{ steps.claude.outcome }}'
+
+          # Whitespace-only counts as nothing written. Deliberately no length floor beyond that:
+          # "No issues found in this diff." is a legitimate 29-byte review, and failing the check
+          # on it would both lose the review and annotate something untrue.
+          visible=0
+          if [ -f review_output.md ]; then
+            visible=$(tr -d '[:space:]' < review_output.md | wc -c)
+          fi
+
+          if [ "$visible" -eq 0 ]; then
+            if [ "$agent_outcome" = "success" ]; then
+              echo "::error title=Claude review::The agent exited 0 without writing a review."
+            fi
+
             exit 1
           fi
 
           size=$(wc -c < review_output.md)
-
-          # A floor, not a quality bar: distinguishes a stub write from a real (possibly very
-          # short) verdict. Worded separately from the missing-file case so the annotation does
-          # not send a reader hunting for an agent crash that did not happen.
-          if [ "$size" -lt 50 ]; then
-            echo "::error title=Claude review::The agent wrote only $size bytes — not a review."
-            exit 1
-          fi
 
           # GitHub rejects comment bodies over 65536 characters with a 422, which would fail this
           # step. That scales with PR size, so it would fire on exactly the PRs most needing a
@@ -110,11 +126,16 @@ jobs:
             # collects review_output.md — which is about to become the truncated version.
             cp review_output.md review_full.md
 
-            # iconv -c drops the partial UTF-8 sequence head -c can leave at the cut. If it is
-            # unavailable the raw cut is kept: gh encodes the stray bytes as U+FFFD, which is
-            # cosmetic — losing the whole review because a cleanup tool is missing would not be.
+            # iconv -c drops the partial UTF-8 sequence head -c can leave at the cut. Judge it by
+            # its OUTPUT, not its exit status: GNU iconv -c omits invalid sequences but still
+            # exits non-zero on an incomplete one at end of input — precisely the case this
+            # exists for, so keying on the status would discard the cleaned file every time.
+            # An empty result means iconv is missing or unusable; then the raw cut is kept, since
+            # gh renders stray bytes as U+FFFD and losing the review would be the worse outcome.
             head -c "$MAX" review_output.md > review_cut.md
-            if iconv -c -f utf-8 -t utf-8 review_cut.md > review_trimmed.md; then
+            iconv -c -f utf-8 -t utf-8 review_cut.md > review_trimmed.md || true
+
+            if [ -s review_trimmed.md ]; then
               rm -f review_cut.md
             else
               mv review_cut.md review_trimmed.md
@@ -122,10 +143,14 @@ jobs:
 
             # If the cut landed inside a fenced block, everything appended after it is swallowed
             # into that block — including the HTML-comment marker, which would then render as
-            # visible noise instead of staying invisible. An odd fence count means we are inside.
-            fences=$(grep -c '^```' review_trimmed.md || true)
+            # visible noise instead of staying invisible. An odd fence count means we are inside;
+            # close it with the same marker the last fence opened, since ``` cannot close ~~~ or
+            # a four-backtick fence. Indented fences (up to three spaces) are valid CommonMark.
+            fence_re='^ {0,3}(`{3,}|~{3,})'
+            fences=$(grep -cE "$fence_re" review_trimmed.md || true)
             if [ $(( fences % 2 )) -eq 1 ]; then
-              printf '\n```\n' >> review_trimmed.md
+              closer=$(grep -E "$fence_re" review_trimmed.md | tail -1 | sed -E 's/^ *((`{3,})|(~{3,})).*/\1/')
+              printf '\n%s\n' "$closer" >> review_trimmed.md
             fi
 
             printf '\n\n_Review truncated at %s bytes. Full text: the `claude-logs-%s` artifact of run %s._\n' \
@@ -144,6 +169,13 @@ jobs:
           } >> review_output.md
 
           gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
+
+          # The review is delivered, but a failed agent step still means this run is not
+          # trustworthy — post first, then report the truth.
+          if [ "$agent_outcome" != "success" ]; then
+            echo "::error title=Claude review::Review posted, but the agent step did not succeed ($agent_outcome) — it may be incomplete. See its log."
+            exit 1
+          fi
 
       - name: Dump review output (when no review was delivered)
         # failure() and not an outcome check on the agent step: the case this whole guard exists

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -110,9 +110,26 @@ jobs:
             # collects review_output.md — which is about to become the truncated version.
             cp review_output.md review_full.md
 
-            head -c "$MAX" review_output.md > review_trimmed.md
-            printf '\n\n_Review truncated at %s bytes. Full text: the `claude-logs` artifact of run %s._\n' \
-              "$MAX" '${{ github.run_id }}' >> review_trimmed.md
+            # iconv -c drops the partial UTF-8 sequence head -c can leave at the cut. If it is
+            # unavailable the raw cut is kept: gh encodes the stray bytes as U+FFFD, which is
+            # cosmetic — losing the whole review because a cleanup tool is missing would not be.
+            head -c "$MAX" review_output.md > review_cut.md
+            if iconv -c -f utf-8 -t utf-8 review_cut.md > review_trimmed.md; then
+              rm -f review_cut.md
+            else
+              mv review_cut.md review_trimmed.md
+            fi
+
+            # If the cut landed inside a fenced block, everything appended after it is swallowed
+            # into that block — including the HTML-comment marker, which would then render as
+            # visible noise instead of staying invisible. An odd fence count means we are inside.
+            fences=$(grep -c '^```' review_trimmed.md || true)
+            if [ $(( fences % 2 )) -eq 1 ]; then
+              printf '\n```\n' >> review_trimmed.md
+            fi
+
+            printf '\n\n_Review truncated at %s bytes. Full text: the `claude-logs-%s` artifact of run %s._\n' \
+              "$MAX" '${{ github.run_attempt }}' '${{ github.run_id }}' >> review_trimmed.md
             mv review_trimmed.md review_output.md
             echo "::warning title=Claude review::Review was $size bytes and got truncated to fit GitHub's comment limit."
           fi
@@ -157,13 +174,15 @@ jobs:
           retention-days: 7
 
   # Visibility aid, NOT a gate: it passes, so it cannot block anything. A skipped claude-review
-  # job already satisfies branch protection on fork PRs; this only makes that state visible on the
-  # checks tab instead of showing nothing. Making fork PRs actually blocked is a policy decision.
-  fork-review-notice:
+  # job already satisfies branch protection; this only makes that state visible on the checks tab
+  # instead of showing nothing. Making such PRs actually blocked is a policy decision.
+  # Covers both skip reasons — fork heads and Dependabot — since both are invisible otherwise.
+  review-skipped-notice:
     if: >-
       github.event.pull_request.draft == false
-      && github.event.pull_request.head.repo.full_name != github.repository
+      && (github.event.pull_request.head.repo.full_name != github.repository
+      || github.actor == 'dependabot[bot]')
     runs-on: ubuntu-latest
     permissions: {}
     steps:
-      - run: echo "::warning title=Claude review::Skipped for a fork PR — secrets are withheld from forked-repo events, so this PR needs a manual review."
+      - run: echo "::warning title=Claude review::Skipped — secrets are withheld from fork and Dependabot events, so this PR needs a manual review."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -95,6 +95,7 @@ jobs:
       # still goes red. But always() also fires on cancellation, and cancel-in-progress means a
       # superseded run would then post a review of a commit that has already been replaced.
       - name: Post the review
+        id: post
         if: ${{ !cancelled() && steps.claude.outcome != 'skipped' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -123,6 +124,7 @@ jobs:
           # step. That scales with PR size, so it would fire on exactly the PRs most needing a
           # review. wc -c counts bytes, so this is conservative for multi-byte characters.
           MAX=60000
+          truncated=""
           if [ "$size" -gt "$MAX" ]; then
             # Keep the full text: the notice below points at the artifact, and the artifact
             # collects review_output.md — which is about to become the truncated version.
@@ -143,34 +145,41 @@ jobs:
               mv review_cut.md review_trimmed.md
             fi
 
-            # If the cut landed inside a fenced block, everything appended after it is swallowed
-            # into that block — including the HTML-comment marker, which would then render as
-            # visible noise instead of staying invisible. An odd fence count means we are inside;
-            # close it with the same marker the last fence opened, since ``` cannot close ~~~ or
-            # a four-backtick fence. Indented fences (up to three spaces) are valid CommonMark.
-            fence_re='^ {0,3}(`{3,}|~{3,})'
-            fences=$(grep -cE "$fence_re" review_trimmed.md || true)
-            if [ $(( fences % 2 )) -eq 1 ]; then
-              closer=$(grep -E "$fence_re" review_trimmed.md | tail -1 | sed -E 's/^ *((`{3,})|(~{3,})).*/\1/')
-              printf '\n%s\n' "$closer" >> review_trimmed.md
-            fi
-
-            printf '\n\n_Review truncated at %s bytes. Full text: the `claude-logs-%s` artifact of run %s._\n' \
-              "$MAX" '${{ github.run_attempt }}' '${{ github.run_id }}' >> review_trimmed.md
             mv review_trimmed.md review_output.md
+            truncated=yes
             echo "::warning title=Claude review::Review was $size bytes and got truncated to fit GitHub's comment limit."
           fi
 
-          # Appended by the workflow, so it is always present and always correct — it correlates
-          # the comment with this run for anyone reading the PR later. Deliberately not used to
-          # find and edit a previous comment via --edit-last: that targets the last comment by
-          # this identity, and claude-agent.yml replies as the same bot, so it could clobber one.
+          # Everything the workflow adds goes at the TOP of the body. A byte-offset cut can leave
+          # an unclosed code fence, and a fence only swallows what FOLLOWS it — so a header is
+          # unconditionally safe and needs no fence repair (parity counting cannot handle nested
+          # or cut-in-half fences anyway). It also means the marker survives on the pathological
+          # input where the whole review is one huge code block.
+          #
+          # The marker correlates the comment with this run. Deliberately not used with
+          # --edit-last to collapse older reviews: that targets the last comment by this identity,
+          # and claude-agent.yml replies as the same bot, so it could clobber one.
           {
-            echo ""
             echo "<!-- claude-review: ${{ github.run_id }}-${{ github.run_attempt }} -->"
-          } >> review_output.md
+            echo ""
 
-          gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
+            # The caveat belongs in the artifact a human reads, not only in a checks-tab
+            # annotation: an agent that died partway through enumerating findings otherwise
+            # renders as a complete, authoritative review.
+            if [ "$agent_outcome" != "success" ]; then
+              printf '> [!WARNING]\n> The review agent did not finish (%s) — this review may be incomplete.\n\n' "$agent_outcome"
+            fi
+
+            if [ -n "$truncated" ]; then
+              printf '_Review truncated at %s bytes. Full text: the `claude-logs-%s` artifact of run %s._\n\n' \
+                "$MAX" '${{ github.run_attempt }}' '${{ github.run_id }}'
+            fi
+
+            cat review_output.md
+          } > review_body.md
+
+          gh pr comment ${{ github.event.pull_request.number }} --body-file review_body.md
+          echo "posted=true" >> "$GITHUB_OUTPUT"
 
           # The review is delivered, but a failed agent step still means this run is not
           # trustworthy — post first, then report the truth.
@@ -182,12 +191,13 @@ jobs:
       - name: Dump review output (when no review was delivered)
         # failure() and not an outcome check on the agent step: the case this whole guard exists
         # for — file written, posting failed — leaves that step 'success' and would skip the dump.
-        if: failure()
+        # The posted check excludes the opposite case: the review DID reach the PR and the job is
+        # red only because the agent step was unhealthy. Without it this annotation contradicts
+        # the one the post step just emitted, and dumps the delivered review into the log.
+        if: failure() && steps.post.outputs.posted != 'true'
         run: |
-          # Surface it on the checks tab; the detail is otherwise buried in a long log. Worded to
-          # stay true on every path failure() covers — the agent failing, the step timing out, and
-          # the review being written but rejected when posted.
-          echo "::error title=Claude review::Review check failed — no review confirmed for this run. See the failing step's log."
+          # Surface it on the checks tab; the detail is otherwise buried in a long log.
+          echo "::error title=Claude review::Review check failed — no review reached the PR for this run. See the failing step's log."
           echo "=== review_output.md ==="
           cat review_output.md 2>/dev/null || echo "(file not created)"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -6,6 +6,12 @@ on:
     # (marking ready does not emit a synchronize event).
     types: [opened, synchronize, reopened, ready_for_review]
 
+# Each review is a paid API call, and the incident that motivated fail-loud was an API usage
+# limit. Without this, ten pushes to one PR buy ten reviews and ten competing check results.
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     # Skip review while the PR is a draft. This workflow only triggers on pull_request,
@@ -69,25 +75,49 @@ jobs:
 
       # A green action is not proof of a review: the agent can exit 0 after hitting a turn or
       # output limit, or write the file and then fail to post it. The gated property is delivery,
-      # so assert on the comment — keyed by this run's id, which is what keeps an earlier run's
-      # comment on the same PR from satisfying the check.
+      # so assert on the comment — keyed by run id AND attempt, which keeps an earlier run's
+      # comment (or the previous attempt of a `gh run rerun`) from satisfying the check.
       - name: Verify a review was posted
         if: steps.claude.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[].body' \
-            | grep -qF 'claude-review: ${{ github.run_id }}-${{ github.run_attempt }}' || {
-            echo "::error title=Claude review::The action exited 0 but posted no review comment for this run."
-            exit 1
-          }
+          marker='claude-review: ${{ github.run_id }}-${{ github.run_attempt }}'
 
-      - name: Dump review output (when the agent did not succeed)
-        # 'cancelled' covers the timeout-minutes case, which would otherwise annotate nothing.
-        if: always() && (steps.claude.outcome == 'failure' || steps.claude.outcome == 'cancelled')
+          # Deliberately not `gh ... | grep -q`. Without pipefail the pipeline reports grep's
+          # status, so a failed gh read is indistinguishable from "no comment posted" and the
+          # error message asserts something untrue. With pipefail it is worse: grep -q closes
+          # the pipe on the first match, gh dies of SIGPIPE, and a SUCCESSFUL check fails.
+          # gh api --paginate rather than `gh pr view --json comments`, whose single fixed page
+          # can exclude the new comment on a PR with a long comment history.
+          for attempt in 1 2 3; do
+            if ! bodies=$(gh api --paginate \
+                  "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+                  --jq '.[].body'); then
+              echo "::error title=Claude review::Could not read PR comments to verify delivery (gh failed) — this is not a verdict on the review itself."
+              exit 1
+            fi
+
+            if grep -qF "$marker" <<<"$bodies"; then
+              exit 0
+            fi
+
+            # The comment was posted seconds ago; the read is not guaranteed to see it at once.
+            if [ "$attempt" -lt 3 ]; then
+              sleep 5
+            fi
+          done
+
+          echo "::error title=Claude review::The agent exited 0 but posted no review comment for this run."
+          exit 1
+
+      - name: Dump review output (when no review was delivered)
+        # failure() and not an outcome check on the agent step: the case this whole guard exists
+        # for — file written, posting failed — leaves that step 'success' and would skip the dump.
+        if: failure()
         run: |
-          # Surface the cause on the checks tab; the reason is otherwise buried in a long log.
-          echo "::error title=Claude review::The review step did not succeed — see job logs for the cause (API usage limit, auth, agent error, or timeout)."
+          # Surface it on the checks tab; the detail is otherwise buried in a long log.
+          echo "::error title=Claude review::No review was delivered for this run — see the failing step's log."
           echo "=== review_output.md ==="
           cat review_output.md 2>/dev/null || echo "(file not created)"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,9 +10,14 @@ jobs:
   claude-review:
     # Skip review while the PR is a draft. This workflow only triggers on pull_request,
     # so the draft flag is always present.
-    # Fork PRs are skipped rather than failed: GitHub withholds repository secrets from
-    # forked-repo events, so ANTHROPIC_API_KEY is empty and pull-requests write is downgraded
-    # to read — the review structurally cannot run, and "skipped" is the honest signal.
+    # Same-repo heads only. Two reasons, and do NOT relax this to "get fork coverage back":
+    #  1. Security. --allowedTools grants Bash(gh pr comment*), and the wildcard also accepts
+    #     --body-file <any path>. Feeding that agent a diff written by an untrusted contributor
+    #     is a prompt-injection surface; restricting to same-repo heads closes it.
+    #  2. It cannot work anyway: GitHub withholds repository secrets from forked-repo events, so
+    #     ANTHROPIC_API_KEY is empty and pull-requests write is downgraded to read.
+    # Caveat: branch protection counts a skipped job as satisfying a required check, so if this
+    # check is ever made required, fork PRs pass it unreviewed and must be reviewed by hand.
     if: >-
       github.event.pull_request.draft == false
       && github.event.pull_request.head.repo.full_name == github.repository
@@ -30,6 +35,9 @@ jobs:
       # otherwise API-limit/auth failures silently produce a green "pass" with no review.
       - uses: anthropics/claude-code-action@v1
         id: claude
+        # Bounded so a wedged agent fails in 20 minutes instead of holding the runner — and the
+        # check — for the 6-hour default. Full reviews here run in ~3 minutes.
+        timeout-minutes: 20
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -49,28 +57,37 @@ jobs:
             - Code quality and maintainability
             - Performance issues
 
-            Use `git diff origin/${{ github.base_ref }}...origin/${{ github.head_ref }}` to see the changes.
-            Write your review to review_output.md, then post it:
+            Use `gh pr diff ${{ github.event.pull_request.number }}` to see the changes. Do not
+            reach for `git diff origin/<base>...origin/<head>`: this job checks out the PR merge
+            ref at depth 1, so neither remote branch exists locally and there is no merge base.
+
+            Write your review to review_output.md. Its last line must be exactly:
+            <!-- claude-review: ${{ github.run_id }}-${{ github.run_attempt }} -->
+
+            Then post it:
             gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
 
       # A green action is not proof of a review: the agent can exit 0 after hitting a turn or
-      # output limit without ever writing the file it was told to post. Catch that here rather
-      # than shipping another silent pass. (This asserts the review was produced, not that the
-      # gh pr comment call landed — checking for the comment itself would match stale comments
-      # from earlier runs on the same PR.)
-      - name: Verify a review was produced
+      # output limit, or write the file and then fail to post it. The gated property is delivery,
+      # so assert on the comment — keyed by this run's id, which is what keeps an earlier run's
+      # comment on the same PR from satisfying the check.
+      - name: Verify a review was posted
         if: steps.claude.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          test -s review_output.md || {
-            echo "::error title=Claude review::The action exited 0 but produced no review output."
+          gh pr view ${{ github.event.pull_request.number }} --json comments --jq '.comments[].body' \
+            | grep -qF 'claude-review: ${{ github.run_id }}-${{ github.run_attempt }}' || {
+            echo "::error title=Claude review::The action exited 0 but posted no review comment for this run."
             exit 1
           }
 
-      - name: Dump review output (on failure)
-        if: always() && steps.claude.outcome == 'failure'
+      - name: Dump review output (when the agent did not succeed)
+        # 'cancelled' covers the timeout-minutes case, which would otherwise annotate nothing.
+        if: always() && (steps.claude.outcome == 'failure' || steps.claude.outcome == 'cancelled')
         run: |
           # Surface the cause on the checks tab; the reason is otherwise buried in a long log.
-          echo "::error title=Claude review::The review did not run (API usage limit, auth, or agent error). See job logs."
+          echo "::error title=Claude review::The review step did not succeed — see job logs for the cause (API usage limit, auth, agent error, or timeout)."
           echo "=== review_output.md ==="
           cat review_output.md 2>/dev/null || echo "(file not created)"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -10,7 +10,12 @@ jobs:
   claude-review:
     # Skip review while the PR is a draft. This workflow only triggers on pull_request,
     # so the draft flag is always present.
-    if: github.event.pull_request.draft == false
+    # Fork PRs are skipped rather than failed: GitHub withholds repository secrets from
+    # forked-repo events, so ANTHROPIC_API_KEY is empty and pull-requests write is downgraded
+    # to read — the review structurally cannot run, and "skipped" is the honest signal.
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,9 +53,24 @@ jobs:
             Write your review to review_output.md, then post it:
             gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
 
+      # A green action is not proof of a review: the agent can exit 0 after hitting a turn or
+      # output limit without ever writing the file it was told to post. Catch that here rather
+      # than shipping another silent pass. (This asserts the review was produced, not that the
+      # gh pr comment call landed — checking for the comment itself would match stale comments
+      # from earlier runs on the same PR.)
+      - name: Verify a review was produced
+        if: steps.claude.outcome == 'success'
+        run: |
+          test -s review_output.md || {
+            echo "::error title=Claude review::The action exited 0 but produced no review output."
+            exit 1
+          }
+
       - name: Dump review output (on failure)
         if: always() && steps.claude.outcome == 'failure'
         run: |
+          # Surface the cause on the checks tab; the reason is otherwise buried in a long log.
+          echo "::error title=Claude review::The review did not run (API usage limit, auth, or agent error). See job logs."
           echo "=== review_output.md ==="
           cat review_output.md 2>/dev/null || echo "(file not created)"
 

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,9 +21,10 @@ jobs:
         with:
           fetch-depth: 1
 
+      # No continue-on-error: a review that did not run must fail the check —
+      # otherwise API-limit/auth failures silently produce a green "pass" with no review.
       - uses: anthropics/claude-code-action@v1
         id: claude
-        continue-on-error: true
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -64,10 +64,12 @@ jobs:
           claude_args: >-
             --verbose
             --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Write"
-          # Kept for in-log diagnosis — reading the raw tool results in the job log is how the
-          # API-limit failure that motivated this workflow change was identified. It no longer
-          # feeds an artifact: claude-execution-output.json is deliberately not archived.
-          show_full_output: true
+          # show_full_output is deliberately NOT enabled. Its own description warns that it prints
+          # every Claude message including raw tool results, "which may contain secrets, API keys,
+          # or other sensitive information", into logs that are publicly visible — and this repo
+          # is public. A write-scoped GH_TOKEN sits in the agent's environment, so one `env` or
+          # `git remote -v` in the transcript would publish it. The action's own error line (e.g.
+          # the API usage limit that motivated this workflow change) is in the log without it.
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
@@ -220,11 +222,10 @@ jobs:
           # the artifact the first attempt already uploaded, and fail on a path this PR makes
           # more likely to be taken.
           name: claude-logs-${{ github.run_attempt }}
-          # claude-execution-output.json is deliberately NOT collected. show_full_output puts raw
-          # tool results in it, and a write-scoped GH_TOKEN sits in the agent's environment — one
-          # `env` while orienting itself would archive a live token. GitHub masks secrets in logs
-          # but does not scrub artifact contents, and retention outlives the token. The two files
-          # below carry everything anyone actually wants; agent diagnostics stay in the job log.
+          # claude-execution-output.json is deliberately NOT collected — same reasoning as
+          # show_full_output above, and worse here: GitHub masks secrets in logs but does not
+          # scrub artifact contents, and retention outlives the token. The files below carry
+          # everything anyone actually wants.
           path: |
             review_body.md
             review_output.md

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -17,9 +17,9 @@ jobs:
     # Skip review while the PR is a draft. This workflow only triggers on pull_request,
     # so the draft flag is always present.
     # Same-repo heads only. Two reasons, and do NOT relax this to "get fork coverage back":
-    #  1. Security. --allowedTools grants Bash(gh pr comment*), and the wildcard also accepts
-    #     --body-file <any path>. Feeding that agent a diff written by an untrusted contributor
-    #     is a prompt-injection surface; restricting to same-repo heads closes it.
+    #  1. Security. The job holds a write-scoped GITHUB_TOKEN that the agent's shell can reach,
+    #     and its tool grants are prefix wildcards. Feeding that agent a diff written by an
+    #     untrusted contributor is a prompt-injection surface; same-repo heads close it.
     #  2. It cannot work anyway: GitHub withholds repository secrets from forked-repo events, so
     #     ANTHROPIC_API_KEY is empty and pull-requests write is downgraded to read.
     # Caveat: branch protection counts a skipped job as satisfying a required check, so if this
@@ -50,7 +50,7 @@ jobs:
           base_branch: master
           claude_args: >-
             --verbose
-            --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Bash(git diff*),Bash(git log*),Write"
+            --allowedTools "Bash(gh pr diff*),Bash(gh pr view*),Write"
           show_full_output: true
           prompt: |
             REPO: ${{ github.repository }}
@@ -80,14 +80,37 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # 200 bytes: a stub or truncated write is not a review, and -s alone passes on one byte.
-          if [ ! -s review_output.md ] || [ "$(wc -c < review_output.md)" -lt 200 ]; then
+          if [ ! -s review_output.md ]; then
             echo "::error title=Claude review::The agent exited 0 without writing a review."
             exit 1
           fi
 
+          size=$(wc -c < review_output.md)
+
+          # A floor, not a quality bar: distinguishes a stub write from a real (possibly very
+          # short) verdict. Worded separately from the missing-file case so the annotation does
+          # not send a reader hunting for an agent crash that did not happen.
+          if [ "$size" -lt 50 ]; then
+            echo "::error title=Claude review::The agent wrote only $size bytes — not a review."
+            exit 1
+          fi
+
+          # GitHub rejects comment bodies over 65536 characters with a 422, which would fail this
+          # step. That scales with PR size, so it would fire on exactly the PRs most needing a
+          # review. wc -c counts bytes, so this is conservative for multi-byte characters.
+          MAX=60000
+          if [ "$size" -gt "$MAX" ]; then
+            head -c "$MAX" review_output.md > review_trimmed.md
+            printf '\n\n_Review truncated at %s bytes. Full text: the `claude-logs` artifact of run %s._\n' \
+              "$MAX" '${{ github.run_id }}' >> review_trimmed.md
+            mv review_trimmed.md review_output.md
+            echo "::warning title=Claude review::Review was $size bytes and got truncated to fit GitHub's comment limit."
+          fi
+
           # Appended by the workflow, so it is always present and always correct — it correlates
-          # the comment with this run for anyone reading the PR later.
+          # the comment with this run for anyone reading the PR later. Deliberately not used to
+          # find and edit a previous comment via --edit-last: that targets the last comment by
+          # this identity, and claude-agent.yml replies as the same bot, so it could clobber one.
           {
             echo ""
             echo "<!-- claude-review: ${{ github.run_id }}-${{ github.run_attempt }} -->"
@@ -101,8 +124,8 @@ jobs:
         if: failure()
         run: |
           # Surface it on the checks tab; the detail is otherwise buried in a long log. Worded to
-          # stay true on every path failure() covers, including a failed comments read — which is
-          # explicitly NOT a verdict on whether a review was written.
+          # stay true on every path failure() covers — the agent failing, the step timing out, and
+          # the review being written but rejected when posted.
           echo "::error title=Claude review::Review check failed — no review confirmed for this run. See the failing step's log."
           echo "=== review_output.md ==="
           cat review_output.md 2>/dev/null || echo "(file not created)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -24,9 +24,15 @@ jobs:
     #     ANTHROPIC_API_KEY is empty and pull-requests write is downgraded to read.
     # Caveat: branch protection counts a skipped job as satisfying a required check, so if this
     # check is ever made required, fork PRs pass it unreviewed and must be reviewed by hand.
+    #
+    # Dependabot is excluded for the same structural reason as forks: its pull_request events read
+    # from the separate Dependabot secret store, so ANTHROPIC_API_KEY is empty and every such PR
+    # would go permanently red. (No dependabot.yml exists today — this is here so enabling it
+    # later does not silently break the check.)
     if: >-
       github.event.pull_request.draft == false
       && github.event.pull_request.head.repo.full_name == github.repository
+      && github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -100,6 +106,10 @@ jobs:
           # review. wc -c counts bytes, so this is conservative for multi-byte characters.
           MAX=60000
           if [ "$size" -gt "$MAX" ]; then
+            # Keep the full text: the notice below points at the artifact, and the artifact
+            # collects review_output.md — which is about to become the truncated version.
+            cp review_output.md review_full.md
+
             head -c "$MAX" review_output.md > review_trimmed.md
             printf '\n\n_Review truncated at %s bytes. Full text: the `claude-logs` artifact of run %s._\n' \
               "$MAX" '${{ github.run_id }}' >> review_trimmed.md
@@ -134,9 +144,13 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: claude-logs
+          # run_attempt in the name: re-running only the failed job would otherwise collide with
+          # the artifact the first attempt already uploaded, and fail on a path this PR makes
+          # more likely to be taken.
+          name: claude-logs-${{ github.run_attempt }}
           path: |
             review_output.md
+            review_full.md
             *.log
             /home/runner/work/_temp/claude-execution-output.json
           if-no-files-found: ignore

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -37,6 +37,12 @@ jobs:
         with:
           fetch-depth: 1
 
+      # Recorded before the agent runs. The verify step gates on "the bot posted a comment after
+      # this moment", a property that needs no cooperation from the model — see that step.
+      - name: Record start time
+        id: t0
+        run: echo "since=$(date -u +%FT%TZ)" >> "$GITHUB_OUTPUT"
+
       # No continue-on-error: a review that did not run must fail the check —
       # otherwise API-limit/auth failures silently produce a green "pass" with no review.
       - uses: anthropics/claude-code-action@v1
@@ -74,15 +80,21 @@ jobs:
             gh pr comment ${{ github.event.pull_request.number }} --body-file review_output.md
 
       # A green action is not proof of a review: the agent can exit 0 after hitting a turn or
-      # output limit, or write the file and then fail to post it. The gated property is delivery,
-      # so assert on the comment — keyed by run id AND attempt, which keeps an earlier run's
-      # comment (or the previous attempt of a `gh run rerun`) from satisfying the check.
+      # output limit, or write the file and then fail to post it. The gated property is delivery.
+      #
+      # Gate on "a github-actions[bot] comment exists that was created after this job started" —
+      # deterministic, and true whatever the model did with its instructions. The run marker is
+      # only a correlation aid: making the gate depend on a model reproducing a string verbatim
+      # would red-flag delivered reviews, and a check that lies gets bypassed. This workflow is
+      # the only one in the repo that comments, so bot authorship is unambiguous.
       - name: Verify a review was posted
         if: steps.claude.outcome == 'success'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           marker='claude-review: ${{ github.run_id }}-${{ github.run_attempt }}'
+          since='${{ steps.t0.outputs.since }}'
+          url="repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments"
 
           # Deliberately not `gh ... | grep -q`. Without pipefail the pipeline reports grep's
           # status, so a failed gh read is indistinguishable from "no comment posted" and the
@@ -90,19 +102,24 @@ jobs:
           # the pipe on the first match, gh dies of SIGPIPE, and a SUCCESSFUL check fails.
           # gh api --paginate rather than `gh pr view --json comments`, whose single fixed page
           # can exclude the new comment on a PR with a long comment history.
+          #
+          # Both failure modes share the retry budget: a transient 502 on the first read must not
+          # sink a delivered review, and the comments read may briefly lag the just-posted comment.
           for attempt in 1 2 3; do
-            if ! bodies=$(gh api --paginate \
-                  "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-                  --jq '.[].body'); then
+            if bodies=$(gh api --paginate "$url" \
+                  --jq ".[] | select(.user.login == \"github-actions[bot]\" and .created_at > \"$since\") | .body"); then
+              if [ -n "$bodies" ]; then
+                if ! grep -qF "$marker" <<<"$bodies"; then
+                  echo "::warning title=Claude review::Review delivered, but without this run's marker — cannot correlate it to this run."
+                fi
+
+                exit 0
+              fi
+            elif [ "$attempt" -eq 3 ]; then
               echo "::error title=Claude review::Could not read PR comments to verify delivery (gh failed) — this is not a verdict on the review itself."
               exit 1
             fi
 
-            if grep -qF "$marker" <<<"$bodies"; then
-              exit 0
-            fi
-
-            # The comment was posted seconds ago; the read is not guaranteed to see it at once.
             if [ "$attempt" -lt 3 ]; then
               sleep 5
             fi
@@ -116,8 +133,10 @@ jobs:
         # for — file written, posting failed — leaves that step 'success' and would skip the dump.
         if: failure()
         run: |
-          # Surface it on the checks tab; the detail is otherwise buried in a long log.
-          echo "::error title=Claude review::No review was delivered for this run — see the failing step's log."
+          # Surface it on the checks tab; the detail is otherwise buried in a long log. Worded to
+          # stay true on every path failure() covers, including a failed comments read — which is
+          # explicitly NOT a verdict on whether a review was written.
+          echo "::error title=Claude review::Review check failed — no review confirmed for this run. See the failing step's log."
           echo "=== review_output.md ==="
           cat review_output.md 2>/dev/null || echo "(file not created)"
 
@@ -132,3 +151,15 @@ jobs:
             /home/runner/work/_temp/claude-execution-output.json
           if-no-files-found: ignore
           retention-days: 7
+
+  # A skipped job satisfies branch protection, so without this a fork PR shows nothing at all on
+  # the checks tab — the same silent pass this workflow exists to remove, by another route. This
+  # job produces a visible, named check saying a human has to do the review.
+  fork-review-notice:
+    if: >-
+      github.event.pull_request.draft == false
+      && github.event.pull_request.head.repo.full_name != github.repository
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: echo "::warning title=Claude review::Skipped for a fork PR — secrets are withheld from forked-repo events, so this PR needs a manual review."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -38,16 +38,16 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
-      issues: write
+      pull-requests: write # gh pr comment; issues: write is not needed for it
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 1
           # Without this the checkout token sits in the remote URL, where `git remote -v` prints
-          # it in cleartext — and with show_full_output that tool result reaches the uploaded
-          # artifact, which GitHub does not scrub the way it masks logs. Nothing here needs it:
-          # the agent and the post step authenticate through GH_TOKEN.
+          # it in cleartext. Nothing here needs it: the agent and the post step authenticate
+          # through GH_TOKEN. This closes one route, not the class — a write-scoped token is still
+          # in the agent's shell environment, which is why the transcript is no longer archived
+          # (see the artifact step) and why the same-repo restriction is the real boundary.
           persist-credentials: false
 
       # No continue-on-error: a review that did not run must fail the check —
@@ -89,11 +89,13 @@ jobs:
       # "a bot comment appeared" was unsound: claude-agent.yml also replies as github-actions[bot],
       # so an unrelated @claude reply could satisfy the gate while this review silently produced
       # nothing. Posting here makes the gated property the exit status of this step.
-      # always(): a review that exists must reach the PR even if the agent step then failed — a
-      # late API error or the timeout firing during teardown would otherwise discard a finished
-      # review, which is this PR's own failure shape one step later. The check still goes red.
+      # !cancelled(), not always(): a review that exists must reach the PR even if the agent step
+      # then failed — a late API error or the timeout firing during teardown would otherwise
+      # discard a finished review, which is this PR's own failure shape one step later. The check
+      # still goes red. But always() also fires on cancellation, and cancel-in-progress means a
+      # superseded run would then post a review of a commit that has already been replaced.
       - name: Post the review
-        if: always() && steps.claude.outcome != 'skipped'
+        if: ${{ !cancelled() && steps.claude.outcome != 'skipped' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -197,11 +199,15 @@ jobs:
           # the artifact the first attempt already uploaded, and fail on a path this PR makes
           # more likely to be taken.
           name: claude-logs-${{ github.run_attempt }}
+          # claude-execution-output.json is deliberately NOT collected. show_full_output puts raw
+          # tool results in it, and a write-scoped GH_TOKEN sits in the agent's environment — one
+          # `env` while orienting itself would archive a live token. GitHub masks secrets in logs
+          # but does not scrub artifact contents, and retention outlives the token. The two files
+          # below carry everything anyone actually wants; agent diagnostics stay in the job log.
           path: |
             review_output.md
             review_full.md
             *.log
-            /home/runner/work/_temp/claude-execution-output.json
           if-no-files-found: ignore
           retention-days: 7
 


### PR DESCRIPTION
## What

The `claude-review` check could pass green while no review happened. On #1323/#1324/#1325 it finished in ~20s with `API Error: 400 You have reached your specified API usage limits` and reported success, because `continue-on-error: true` swallowed it. This makes the check mean what its name says, and closes the other routes to the same silent pass that came up in review.

### Fail loud
- Drop `continue-on-error: true` — a review that did not run now fails the check.
- `timeout-minutes: 20` on the agent step, so a wedged run fails instead of holding a pending check for the 6-hour default.
- Failures emit an `::error::` annotation, so the cause shows on the checks tab instead of only in a long log. The dump step gates on `failure()` — gating on the agent's outcome would have skipped the "review written, posting failed" case.

### Delivery is a workflow step, not an instruction to the model
The agent now only writes `review_output.md`; the workflow appends a run marker and posts it. Earlier attempts gated on evidence *about* the comment, and both were unsound:
- requiring the model to emit an exact marker made a required check depend on instruction-following — a delivered review with a dropped marker was indistinguishable from no review;
- inferring delivery from "a `github-actions[bot]` comment appeared after the job started" was worse: `claude-agent.yml` replies to `@claude` mentions as the same bot, so an unrelated reply could satisfy the gate while this run posted nothing.

Posting from the workflow makes the gated property that step's exit status — no dependence on the model, and none on which bot identity the action uses.

The post step rejects a whitespace-only file and truncates at 60000 bytes: GitHub rejects comment bodies over 65536 characters, and review length scales with PR size, so that would have fired on exactly the PRs most needing review.

Note what the check does and does not guarantee: it gates on "a non-empty review reached the PR", not on "a useful review happened" — an agent that writes `Unable to fetch the diff.` still produces a green check. A length floor was considered and rejected: `No issues found in this diff.` is a legitimate 29-byte review, and failing on it would both lose the review and annotate something untrue.

### Coverage change: fork PRs are no longer reviewed
`claude-review` is now restricted to same-repo heads. This is a change to *which PRs get reviewed at all*, not just a reliability fix:
- fork PRs never could work — GitHub withholds repository secrets from forked-repo events, so `ANTHROPIC_API_KEY` is empty and the token is read-only. Without this guard, removing `continue-on-error` would have turned every fork PR permanently red;
- it is also a security boundary: the job holds a write-scoped `GITHUB_TOKEN` the agent's shell can reach, and its tool grants are prefix wildcards, so an untrusted contributor's diff is a prompt-injection surface.

A `review-skipped-notice` job makes that state visible on the checks tab. It passes — it is a visibility aid, not a gate. Note that branch protection counts a skipped job as satisfying a required check, so fork PRs need manual review either way.

### Also
- The prompt told the agent to run `git diff origin/<base>...origin/<head>`, which fails 100% of the time here: checkout takes the PR merge ref at depth 1, so neither remote branch exists and there is no merge base. Every review so far discovered that at runtime. Now it says `gh pr diff <n>` and explains why. The unusable `git diff`/`git log` grants are dropped, as is `gh pr comment` — the agent no longer posts.
- Workflow-level `concurrency` with `cancel-in-progress`: every `synchronize` starts a paid review, and an API usage limit is what motivated this PR.

## Known gaps, deliberately not in this PR
- No retry on transient API failures — a 429/5xx fails the check and needs a manual re-run. Fail-loud and fail-on-first-flake are separable; only the first is wanted.
- The agent job still holds a write-scoped token. Splitting into a read-only agent job plus a poster job is the natural next step now that delivery is separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
