### PR TITLE
security(chats): mask Slack/Mattermost webhook URLs in EditChat (#1329)

### DIFF
--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -64,7 +64,18 @@ namespace HSMServer.Controllers
             ValidateWebhooks(model, stored);
 
             if (!ModelState.IsValid)
+            {
+                // Re-render must carry the server-owned folder data, not the model-bound shell.
+                // ChatFoldersViewModel.DisplayFolders is get-only and populated only by the server
+                // ctor; the form never posts it, so the re-render would otherwise drop the folders
+                // table AND the hidden Folders.Folders[i] inputs. The next Save (the user pasting the
+                // full URL as the error tells them to) would then post empty Folders, and SyncFolders
+                // would unbind the chat from every managed folder (#1329 review).
+                if (stored is not null)
+                    model.Folders = BuildChatFolders(stored);
+
                 return View(model);
+            }
 
             if (await ChatsManager.TryUpdate(model.ToUpdate()))
                 await SyncFolders(model);
@@ -111,7 +122,14 @@ namespace HSMServer.Controllers
             ValidateWebhooks(model, stored);
 
             if (!ModelState.IsValid)
+            {
+                // Same folder-rebuild as EditChat POST — see there for why the server-owned folder
+                // data must be repopulated before re-render or the next Save unbinds folders.
+                if (stored is not null)
+                    model.Folders = BuildChatFolders(stored);
+
                 return View(nameof(EditChat), model);
+            }
 
             // The user may have already triggered /start against the pre-allocated guid, in which
             // case the Chat row exists in storage with a Telegram binding but no admin-set name.

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -74,6 +74,14 @@ namespace HSMServer.Controllers
                 if (stored is not null)
                     model.Folders = BuildChatFolders(stored);
 
+                // Land the user on the tab whose field actually has the error. EditChat.cshtml
+                // renders asp-validation-for spans inside .tab-pane fade divs that are display:none
+                // unless that tab is active; without this the default-tab heuristic (telegram → slack
+                // → mattermost) hides the rejection on most chat configurations — e.g. a Telegram-
+                // bound chat with a Slack webhook lands on the telegram tab and the Slack error is
+                // invisible, recreating exactly the silent-rotation failure the guard exists to fix.
+                SetTabFromWebhookErrors();
+
                 return View(model);
             }
 
@@ -127,6 +135,10 @@ namespace HSMServer.Controllers
                 // data must be repopulated before re-render or the next Save unbinds folders.
                 if (stored is not null)
                     model.Folders = BuildChatFolders(stored);
+
+                // And the same tab-routing — see EditChat POST for why the failing field's tab must
+                // become active or the rejection error is rendered into a display:none pane.
+                SetTabFromWebhookErrors();
 
                 return View(nameof(EditChat), model);
             }
@@ -284,6 +296,22 @@ namespace HSMServer.Controllers
                     (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
                     ModelState.AddModelError(key, "Webhook URL must be a valid URL");
             }
+        }
+
+        // Routes the re-rendered EditChat form to the tab whose webhook field actually has an error,
+        // so the asp-validation-for span (rendered inside a display:none .tab-pane unless the tab is
+        // active) is visible. EditChat.cshtml honors ViewData["Tab"] over its default-tab heuristic;
+        // both POST actions call this right before return View(model). Slack wins over Mattermost
+        // when both error (arbitrary but deterministic), matching the default-tab fallback's order.
+        private void SetTabFromWebhookErrors()
+        {
+            if (HasWebhookErrors(nameof(ChatViewModel.SlackWebhookUrl)))
+                ViewData["Tab"] = "slack";
+            else if (HasWebhookErrors(nameof(ChatViewModel.MattermostWebhookUrl)))
+                ViewData["Tab"] = "mattermost";
+
+            bool HasWebhookErrors(string key) =>
+                ModelState.ContainsKey(key) && ModelState[key].Errors.Count > 0;
         }
 
 

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -289,9 +289,18 @@ namespace HSMServer.Controllers
 
             void ValidateWebhook(string posted, string storedUrl, string key, string channelName)
             {
-                if (string.IsNullOrWhiteSpace(posted) && !string.IsNullOrEmpty(storedUrl))
+                // MVC binds an empty text input to null via ConvertEmptyStringToNull, so both null
+                // and "" reach here. Empty + stored webhook = the regression guard (point to Remove).
+                // Empty + no stored webhook is legitimate (new chat, or an already-cleared channel) —
+                // MUST return here, not fall through: Uri.TryCreate(null, Absolute) returns false,
+                // which would add a spurious "must be a valid URL" error to a field the user never
+                // filled in, breaking AddChat for any chat missing one of the two webhooks (#1329
+                // review).
+                if (string.IsNullOrWhiteSpace(posted))
                 {
-                    ModelState.AddModelError(key, $"Use Remove {channelName} to delete the webhook.");
+                    if (!string.IsNullOrEmpty(storedUrl))
+                        ModelState.AddModelError(key, $"Use Remove {channelName} to delete the webhook.");
+
                     return;
                 }
 
@@ -302,8 +311,10 @@ namespace HSMServer.Controllers
                     return;
                 }
 
-                // ValidatePosted returned null: either empty (no stored webhook, valid) or a real
-                // URL. Real URLs must still be well-formed absolute http/https.
+                // ValidatePosted returned null: the only remaining case is a real URL. Masked values
+                // can't reach here (IsMasked + matching Mask(stored) returned null from ValidatePosted;
+                // IsMasked + mismatch returned an error). Real URLs must be well-formed absolute
+                // http/https.
                 if (WebhookUrlMasker.IsMasked(posted))
                     return;
 

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -273,13 +273,28 @@ namespace HSMServer.Controllers
         // IsMasked is a substring test (#1329 review: a rotation could appear to succeed while
         // nothing changed). The classification lives in WebhookUrlMasker.ValidatePosted so it's unit-
         // covered; a real pasted URL still has to pass the absolute http/https check here.
+        //
+        // Empty-on-stored regression guard: pre-PR, ToUpdate passed the posted value straight
+        // through, so Chat.ApplyUpdate (`update.SlackWebhookUrl ?? SlackWebhookUrl`) received "" and
+        // the webhook was cleared. Now ResolveWebhook maps empty → null = "no change", so deleting
+        // the field contents became a silent no-op — the admin sees a success redirect while the
+        // old webhook stays live (#1329 review). The sanctioned path is Remove Slack / Remove
+        // Mattermost (ClearSlackWebhook/ClearMattermostWebhook flags); reject empty and point there.
+        // No stored webhook → empty is valid (e.g. brand-new chat, or clearing an already-cleared
+        // field), so the guard only fires when stored has a value.
         private void ValidateWebhooks(ChatViewModel model, Chat stored)
         {
-            ValidateWebhook(model.SlackWebhookUrl, stored?.SlackWebhookUrl, nameof(ChatViewModel.SlackWebhookUrl));
-            ValidateWebhook(model.MattermostWebhookUrl, stored?.MattermostWebhookUrl, nameof(ChatViewModel.MattermostWebhookUrl));
+            ValidateWebhook(model.SlackWebhookUrl, stored?.SlackWebhookUrl, nameof(ChatViewModel.SlackWebhookUrl), "Slack");
+            ValidateWebhook(model.MattermostWebhookUrl, stored?.MattermostWebhookUrl, nameof(ChatViewModel.MattermostWebhookUrl), "Mattermost");
 
-            void ValidateWebhook(string posted, string storedUrl, string key)
+            void ValidateWebhook(string posted, string storedUrl, string key, string channelName)
             {
+                if (string.IsNullOrWhiteSpace(posted) && !string.IsNullOrEmpty(storedUrl))
+                {
+                    ModelState.AddModelError(key, $"Use Remove {channelName} to delete the webhook.");
+                    return;
+                }
+
                 var maskError = WebhookUrlMasker.ValidatePosted(posted, storedUrl);
                 if (maskError != null)
                 {
@@ -287,9 +302,9 @@ namespace HSMServer.Controllers
                     return;
                 }
 
-                // ValidatePosted returned null: either empty (no change) or a real URL. Real URLs
-                // must still be well-formed absolute http/https — masked/empty values skip this.
-                if (string.IsNullOrWhiteSpace(posted) || WebhookUrlMasker.IsMasked(posted))
+                // ValidatePosted returned null: either empty (no stored webhook, valid) or a real
+                // URL. Real URLs must still be well-formed absolute http/https.
+                if (WebhookUrlMasker.IsMasked(posted))
                     return;
 
                 if (!Uri.TryCreate(posted, UriKind.Absolute, out var uri) ||

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -57,7 +57,11 @@ namespace HSMServer.Controllers
         [TelegramRoleFilterByEditModel(nameof(model), ProductRoleEnum.ProductManager)]
         public async Task<IActionResult> EditChat(ChatViewModel model)
         {
-            ValidateWebhooks(model);
+            // Load the stored chat so ValidateWebhooks can tell "the unchanged masked sentinel was
+            // posted back" (expected, no change) from "the admin partially edited the masked value"
+            // (must be rejected — see #1329 review: a partial edit used to be silently discarded).
+            ChatsManager.TryGetValue(model.Id, out var stored);
+            ValidateWebhooks(model, stored);
 
             if (!ModelState.IsValid)
                 return View(model);
@@ -100,7 +104,11 @@ namespace HSMServer.Controllers
         [AuthorizeIsAdmin]
         public async Task<IActionResult> AddChat(ChatViewModel model)
         {
-            ValidateWebhooks(model);
+            // AddChat is for brand-new chats; a masked sentinel should never appear here (the new-chat
+            // form renders empty webhook fields). Still, if /start pre-created the chat, load it so the
+            // same partial-edit guard applies on the idempotent update path.
+            ChatsManager.TryGetValue(model.Id, out var stored);
+            ValidateWebhooks(model, stored);
 
             if (!ModelState.IsValid)
                 return View(nameof(EditChat), model);
@@ -229,21 +237,34 @@ namespace HSMServer.Controllers
 
         // Webhook URL validation moved server-side (was [Url] on ChatViewModel — the masked display
         // value `https://…/••••` fails Uri.TryCreate, so the attribute was removed). The masked
-        // sentinel and empty values are "no change" and skip the check; a freshly-pasted URL must be
-        // an absolute http/https URL or the submit is rejected (parity with chats_validation.spec.ts).
-        private void ValidateWebhooks(ChatViewModel model)
+        // sentinel must match Mask(stored) exactly, or the post is rejected: the field is a plain
+        // editable input pre-filled with the mask, so an admin who partially edits it (e.g. changes
+        // only the host) must be told — otherwise ToUpdate would silently drop the edit because
+        // IsMasked is a substring test (#1329 review: a rotation could appear to succeed while
+        // nothing changed). The classification lives in WebhookUrlMasker.ValidatePosted so it's unit-
+        // covered; a real pasted URL still has to pass the absolute http/https check here.
+        private void ValidateWebhooks(ChatViewModel model, Chat stored)
         {
-            ValidateWebhook(model.SlackWebhookUrl, nameof(ChatViewModel.SlackWebhookUrl), "Slack webhook URL must be a valid URL");
-            ValidateWebhook(model.MattermostWebhookUrl, nameof(ChatViewModel.MattermostWebhookUrl), "Mattermost webhook URL must be a valid URL");
+            ValidateWebhook(model.SlackWebhookUrl, stored?.SlackWebhookUrl, nameof(ChatViewModel.SlackWebhookUrl));
+            ValidateWebhook(model.MattermostWebhookUrl, stored?.MattermostWebhookUrl, nameof(ChatViewModel.MattermostWebhookUrl));
 
-            void ValidateWebhook(string posted, string key, string errorMessage)
+            void ValidateWebhook(string posted, string storedUrl, string key)
             {
+                var maskError = WebhookUrlMasker.ValidatePosted(posted, storedUrl);
+                if (maskError != null)
+                {
+                    ModelState.AddModelError(key, maskError);
+                    return;
+                }
+
+                // ValidatePosted returned null: either empty (no change) or a real URL. Real URLs
+                // must still be well-formed absolute http/https — masked/empty values skip this.
                 if (string.IsNullOrWhiteSpace(posted) || WebhookUrlMasker.IsMasked(posted))
                     return;
 
                 if (!Uri.TryCreate(posted, UriKind.Absolute, out var uri) ||
                     (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
-                    ModelState.AddModelError(key, errorMessage);
+                    ModelState.AddModelError(key, "Webhook URL must be a valid URL");
             }
         }
 

--- a/src/server/HSMServer/Controllers/NotificationsController.cs
+++ b/src/server/HSMServer/Controllers/NotificationsController.cs
@@ -57,6 +57,8 @@ namespace HSMServer.Controllers
         [TelegramRoleFilterByEditModel(nameof(model), ProductRoleEnum.ProductManager)]
         public async Task<IActionResult> EditChat(ChatViewModel model)
         {
+            ValidateWebhooks(model);
+
             if (!ModelState.IsValid)
                 return View(model);
 
@@ -98,6 +100,8 @@ namespace HSMServer.Controllers
         [AuthorizeIsAdmin]
         public async Task<IActionResult> AddChat(ChatViewModel model)
         {
+            ValidateWebhooks(model);
+
             if (!ModelState.IsValid)
                 return View(nameof(EditChat), model);
 
@@ -220,6 +224,27 @@ namespace HSMServer.Controllers
             };
 
             return await ChatsManager.TryUpdate(update) ? Ok() : NotFound();
+        }
+
+
+        // Webhook URL validation moved server-side (was [Url] on ChatViewModel — the masked display
+        // value `https://…/••••` fails Uri.TryCreate, so the attribute was removed). The masked
+        // sentinel and empty values are "no change" and skip the check; a freshly-pasted URL must be
+        // an absolute http/https URL or the submit is rejected (parity with chats_validation.spec.ts).
+        private void ValidateWebhooks(ChatViewModel model)
+        {
+            ValidateWebhook(model.SlackWebhookUrl, nameof(ChatViewModel.SlackWebhookUrl), "Slack webhook URL must be a valid URL");
+            ValidateWebhook(model.MattermostWebhookUrl, nameof(ChatViewModel.MattermostWebhookUrl), "Mattermost webhook URL must be a valid URL");
+
+            void ValidateWebhook(string posted, string key, string errorMessage)
+            {
+                if (string.IsNullOrWhiteSpace(posted) || WebhookUrlMasker.IsMasked(posted))
+                    return;
+
+                if (!Uri.TryCreate(posted, UriKind.Absolute, out var uri) ||
+                    (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps))
+                    ModelState.AddModelError(key, errorMessage);
+            }
         }
 
 

--- a/src/server/HSMServer/Model/Notifications/ChatViewModel.cs
+++ b/src/server/HSMServer/Model/Notifications/ChatViewModel.cs
@@ -40,10 +40,14 @@ namespace HSMServer.Model.Notifications
         public string TelegramChatDescription { get; set; }
 
 
-        [Url(ErrorMessage = "Slack webhook URL must be a valid URL")]
+        // Bound to the EditChat input. On GET this carries the masked display value
+        // (WebhookUrlMasker.Mask) — the raw secret is never rendered. On POST it carries either the
+        // unchanged masked sentinel (→ ToUpdate emits null, "no change") or a freshly-pasted URL.
+        // URL-shape validation moved server-side: the masked value (with non-ASCII bullets) fails
+        // [Url], so the attribute was removed and the controller runs Uri.TryCreate on non-masked
+        // values, adding ModelState errors for genuinely malformed input.
         public string SlackWebhookUrl { get; set; }
 
-        [Url(ErrorMessage = "Mattermost webhook URL must be a valid URL")]
         public string MattermostWebhookUrl { get; set; }
 
 
@@ -116,8 +120,10 @@ namespace HSMServer.Model.Notifications
             TelegramType = chat.TelegramType;
             TelegramChatTitle = chat.TelegramChatTitle;
             TelegramChatDescription = chat.TelegramChatDescription;
-            SlackWebhookUrl = chat.SlackWebhookUrl;
-            MattermostWebhookUrl = chat.MattermostWebhookUrl;
+            // Mask on read — the raw webhook secret never reaches the view. ToUpdate treats the
+            // masked sentinel as "no change" on POST, so the stored cleartext URL survives.
+            SlackWebhookUrl = WebhookUrlMasker.Mask(chat.SlackWebhookUrl);
+            MattermostWebhookUrl = WebhookUrlMasker.Mask(chat.MattermostWebhookUrl);
             MessagesDelay = chat.MessagesAggregationTimeSec;
             EnableMessages = chat.SendMessages;
             Folders = folders ?? new ChatFoldersViewModel();
@@ -132,9 +138,20 @@ namespace HSMServer.Model.Notifications
                 Description = Description,
                 SendMessages = EnableMessages,
                 MessagesAggregationTimeSec = MessagesDelay,
-                SlackWebhookUrl = SlackWebhookUrl,
-                MattermostWebhookUrl = MattermostWebhookUrl,
+                // ResolveWebhook: null = "no change" (Chat.ApplyUpdate uses ?? current). The masked
+                // sentinel posted back from the unchanged field, and an empty field, both mean "keep
+                // the stored webhook"; only a real pasted URL overwrites. ToNewChat reads the raw
+                // props directly (a brand-new chat posts a real URL, never the mask).
+                SlackWebhookUrl = ResolveWebhook(SlackWebhookUrl),
+                MattermostWebhookUrl = ResolveWebhook(MattermostWebhookUrl),
             };
+
+        // null  → don't change the stored webhook (ApplyUpdate: ?? current).
+        // value → overwrite with the newly-pasted URL.
+        private static string ResolveWebhook(string posted) =>
+            string.IsNullOrWhiteSpace(posted) || WebhookUrlMasker.IsMasked(posted)
+                ? null
+                : posted;
 
         internal Chat ToNewChat(Guid authorId)
         {

--- a/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
+++ b/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
@@ -47,6 +47,28 @@ namespace HSMServer.Notifications
         // bullets) emitted, not a real webhook URL. Real URLs never contain `••••`.
         public static bool IsMasked(string url) => url != null && url.Contains(MaskMarker);
 
+        // Classifies a posted webhook value against the stored URL. Returns null when the post is
+        // acceptable (empty = no change; unchanged sentinel; or a real URL), and an error message
+        // when it must be rejected. The "unchanged sentinel" check compares against Mask(stored) —
+        // NOT just IsMasked — because the field is a plain editable input pre-filled with the mask,
+        // so an admin who partially edits it (e.g. changes only the host) would otherwise have the
+        // edit silently dropped by ResolveWebhook (IsMasked is a substring test, see #1329 review).
+        //
+        //   null/empty posted                     → null  (no change; new chat stays empty)
+        //   posted == Mask(stored)                → null  (the unchanged sentinel round-tripped)
+        //   posted IsMasked but ≠ Mask(stored)    → error (partial edit of the masked value)
+        //   otherwise                             → null  (a real pasted URL; caller runs Uri checks)
+        public static string ValidatePosted(string posted, string storedUrl)
+        {
+            if (string.IsNullOrWhiteSpace(posted))
+                return null;
+
+            if (IsMasked(posted) && posted != Mask(storedUrl))
+                return "Paste the full webhook URL to replace it, or leave the field unchanged.";
+
+            return null;
+        }
+
         // Rebuild the display value from the URI's structured parts: authority verbatim + every path
         // segment except the last non-empty one verbatim + the last non-empty segment masked. Query
         // and fragment are dropped from the display value (they're not needed to recognize the

--- a/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
+++ b/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
@@ -3,9 +3,11 @@ using System;
 namespace HSMServer.Notifications
 {
     // Masks webhook URLs for display in EditChat so the cleartext secret is never rendered to the
-    // browser. The mask keeps scheme + host + a prefix of the path + the last few chars of the URL,
-    // so an admin can still recognize which webhook is set (`…/services/T01••••cret` is distinct
-    // from `…/services/T02••••ging`) without the full secret being recoverable.
+    // browser. The mask keeps scheme + host + all path segments except the LAST one verbatim; the
+    // last segment (typically the secret token) is reduced to its first 4 and last 4 chars with the
+    // marker in between — e.g. `http://localhost:8065/hooks/nuddbzeoztbau8juhobap348fw` becomes
+    // `http://localhost:8065/hooks/nudd••••48fw`, so an admin can recognize the webhook without the
+    // full token being recoverable.
     //
     // The marker doubles as the POST sentinel: EditChat posts the masked value back when the admin
     // didn't replace the webhook, and ChatViewModel.ToUpdate treats any IsMasked value as "no change"
@@ -14,10 +16,11 @@ namespace HSMServer.Notifications
     {
         public const string MaskMarker = "••••";
 
-        // Visible chars of the path prefix / URL tail. Tuned so an admin can tell two webhooks apart
-        // without leaking enough to reconstruct the secret.
-        private const int PathPrefixChars = 8;
-        private const int TailChars = 4;
+        // Visible head/tail of the last path segment. Tuned so an admin can tell two webhooks apart
+        // without leaking enough to reconstruct the secret token.
+        private const int LastSegmentHeadChars = 4;
+        private const int LastSegmentTailChars = 4;
+        private const int LastSegmentRevealThreshold = LastSegmentHeadChars + LastSegmentTailChars;
 
         // null/empty/whitespace → null (distinguishes "no webhook" from "masked webhook" and lets
         // ToUpdate apply the ??-no-change rule uniformly with the empty-input case).
@@ -26,38 +29,40 @@ namespace HSMServer.Notifications
             if (string.IsNullOrWhiteSpace(url))
                 return null;
 
-            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && !uri.IsFile)
-            {
-                var host = uri.Scheme + Uri.SchemeDelimiter + uri.Host;
-                var pathAndQuery = uri.PathAndQuery;
-                return host + MaskMiddle(pathAndQuery);
-            }
+            // Find the last '/' that is NOT part of `scheme://`. Without this guard, a URL with no
+            // real path (`https://hooks.slack.com`) would mask the host itself. `schemeIndex` points
+            // at the second slash of `://`; only slashes after it count as path separators.
+            var schemeIndex = url.IndexOf("://", StringComparison.Ordinal);
+            var searchFrom = schemeIndex >= 0 ? schemeIndex + 3 : 0;
+            var lastSlash = url.LastIndexOf('/');
 
-            // Unparseable input (rare for a stored webhook) — still mask rather than throw. Slice at
-            // the first '/' so the host-ish prefix survives and the tail is masked the same way.
-            var firstSlash = url.IndexOf('/', StringComparison.Ordinal);
-            var head = firstSlash < 0 ? url : url.Substring(0, firstSlash);
-            var rest = firstSlash < 0 ? string.Empty : url.Substring(firstSlash);
-            return head + MaskMiddle(rest);
+            if (lastSlash < searchFrom)
+                return url + MaskMarker;
+
+            var head = url.Substring(0, lastSlash + 1); // includes the trailing '/'
+            var lastSegment = url.Substring(lastSlash + 1);
+            return head + MaskLastSegment(lastSegment);
         }
 
         // True iff url carries the mask marker — i.e. it's a value we (or someone typing the literal
         // bullets) emitted, not a real webhook URL. Real URLs never contain `••••`.
         public static bool IsMasked(string url) => url != null && url.Contains(MaskMarker);
 
-        // Keeps the first PathPrefixChars and the last TailChars of `body`, inserting the marker
-        // between. A short body (≤ prefix+tail threshold) is replaced by the marker alone — showing
-        // it verbatim would leak the whole short secret, and the marker MUST be present so the POST
-        // sentinel detection in IsMasked works for every masked value.
-        private static string MaskMiddle(string body)
+        // Reduces the last path segment to `head4 + MaskMarker + tail4`. A short segment (≤ 8 chars)
+        // is shown verbatim per UX decision, with the marker appended as a trailing sentinel so
+        // IsMasked stays true for every masked value (without it, the POST "no change" detection in
+        // ToUpdate would treat the round-tripped value as a fresh URL and overwrite the stored one).
+        private static string MaskLastSegment(string segment)
         {
-            if (string.IsNullOrEmpty(body) || body.Length <= PathPrefixChars + TailChars)
-                return "/" + MaskMarker;
+            if (string.IsNullOrEmpty(segment))
+                return MaskMarker;
 
-            var prefix = body.Substring(0, PathPrefixChars);
-            var tail = body.Substring(body.Length - TailChars);
-            return prefix + MaskMarker + tail;
+            if (segment.Length <= LastSegmentRevealThreshold)
+                return segment + MaskMarker;
+
+            var head = segment.Substring(0, LastSegmentHeadChars);
+            var tail = segment.Substring(segment.Length - LastSegmentTailChars);
+            return head + MaskMarker + tail;
         }
     }
 }
-

--- a/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
+++ b/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
@@ -3,8 +3,9 @@ using System;
 namespace HSMServer.Notifications
 {
     // Masks webhook URLs for display in EditChat so the cleartext secret is never rendered to the
-    // browser. The mask keeps scheme + host + the first path segment (enough for an admin to tell
-    // `…/services/…` from `…/hooks/…`) and replaces the rest with the fixed marker `••••`.
+    // browser. The mask keeps scheme + host + a prefix of the path + the last few chars of the URL,
+    // so an admin can still recognize which webhook is set (`…/services/T01••••cret` is distinct
+    // from `…/services/T02••••ging`) without the full secret being recoverable.
     //
     // The marker doubles as the POST sentinel: EditChat posts the masked value back when the admin
     // didn't replace the webhook, and ChatViewModel.ToUpdate treats any IsMasked value as "no change"
@@ -12,6 +13,11 @@ namespace HSMServer.Notifications
     public static class WebhookUrlMasker
     {
         public const string MaskMarker = "••••";
+
+        // Visible chars of the path prefix / URL tail. Tuned so an admin can tell two webhooks apart
+        // without leaking enough to reconstruct the secret.
+        private const int PathPrefixChars = 8;
+        private const int TailChars = 4;
 
         // null/empty/whitespace → null (distinguishes "no webhook" from "masked webhook" and lets
         // ToUpdate apply the ??-no-change rule uniformly with the empty-input case).
@@ -23,29 +29,35 @@ namespace HSMServer.Notifications
             if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && !uri.IsFile)
             {
                 var host = uri.Scheme + Uri.SchemeDelimiter + uri.Host;
-                var firstSegment = GetFirstPathSegment(uri.AbsolutePath);
-                return host + firstSegment + "/" + MaskMarker;
+                var pathAndQuery = uri.PathAndQuery;
+                return host + MaskMiddle(pathAndQuery);
             }
 
-            // Unparseable input (rare for a stored webhook) — still mask rather than throw. Fall back
-            // to slicing at the first '/' after the host-ish portion so we never leak the tail.
+            // Unparseable input (rare for a stored webhook) — still mask rather than throw. Slice at
+            // the first '/' so the host-ish prefix survives and the tail is masked the same way.
             var firstSlash = url.IndexOf('/', StringComparison.Ordinal);
-            return firstSlash < 0 ? url + "/" + MaskMarker : url.Substring(0, firstSlash) + "/" + MaskMarker;
+            var head = firstSlash < 0 ? url : url.Substring(0, firstSlash);
+            var rest = firstSlash < 0 ? string.Empty : url.Substring(firstSlash);
+            return head + MaskMiddle(rest);
         }
 
         // True iff url carries the mask marker — i.e. it's a value we (or someone typing the literal
         // bullets) emitted, not a real webhook URL. Real URLs never contain `••••`.
         public static bool IsMasked(string url) => url != null && url.Contains(MaskMarker);
 
-        // Returns "/segment" (with a leading slash) for the first non-empty path piece, or "" when the
-        // URL has no path. Trailing slashes on the host root are treated as "no path".
-        private static string GetFirstPathSegment(string absolutePath)
+        // Keeps the first PathPrefixChars and the last TailChars of `body`, inserting the marker
+        // between. A short body (≤ prefix+tail threshold) is replaced by the marker alone — showing
+        // it verbatim would leak the whole short secret, and the marker MUST be present so the POST
+        // sentinel detection in IsMasked works for every masked value.
+        private static string MaskMiddle(string body)
         {
-            if (string.IsNullOrEmpty(absolutePath))
-                return string.Empty;
+            if (string.IsNullOrEmpty(body) || body.Length <= PathPrefixChars + TailChars)
+                return "/" + MaskMarker;
 
-            var segments = absolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
-            return segments.Length == 0 ? string.Empty : "/" + segments[0];
+            var prefix = body.Substring(0, PathPrefixChars);
+            var tail = body.Substring(body.Length - TailChars);
+            return prefix + MaskMarker + tail;
         }
     }
 }
+

--- a/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
+++ b/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
@@ -12,6 +12,10 @@ namespace HSMServer.Notifications
     // The marker doubles as the POST sentinel: EditChat posts the masked value back when the admin
     // didn't replace the webhook, and ChatViewModel.ToUpdate treats any IsMasked value as "no change"
     // (null in the ChatUpdate → Chat.ApplyUpdate keeps the stored URL).
+    //
+    // Masking is segment-based via Uri parsing, NOT raw string slicing, so trailing slashes and
+    // query strings don't move the split point past the secret token (regression coverage lives in
+    // WebhookUrlMaskerTests).
     public static class WebhookUrlMasker
     {
         public const string MaskMarker = "••••";
@@ -29,24 +33,53 @@ namespace HSMServer.Notifications
             if (string.IsNullOrWhiteSpace(url))
                 return null;
 
-            // Find the last '/' that is NOT part of `scheme://`. Without this guard, a URL with no
-            // real path (`https://hooks.slack.com`) would mask the host itself. `schemeIndex` points
-            // at the second slash of `://`; only slashes after it count as path separators.
-            var schemeIndex = url.IndexOf("://", StringComparison.Ordinal);
-            var searchFrom = schemeIndex >= 0 ? schemeIndex + 3 : 0;
-            var lastSlash = url.LastIndexOf('/');
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && !uri.IsFile)
+                return MaskAbsoluteUri(uri);
 
-            if (lastSlash < searchFrom)
-                return url + MaskMarker;
-
-            var head = url.Substring(0, lastSlash + 1); // includes the trailing '/'
-            var lastSegment = url.Substring(lastSlash + 1);
-            return head + MaskLastSegment(lastSegment);
+            // Unparseable input (rare for a stored webhook) — fall back to masking everything after
+            // the first '/' so the host-ish prefix survives. This path is best-effort; the structured
+            // path above is the one real webhook URLs take.
+            var firstSlash = url.IndexOf('/', StringComparison.Ordinal);
+            return firstSlash < 0 ? url + MaskMarker : url.Substring(0, firstSlash + 1) + MaskMarker;
         }
 
         // True iff url carries the mask marker — i.e. it's a value we (or someone typing the literal
         // bullets) emitted, not a real webhook URL. Real URLs never contain `••••`.
         public static bool IsMasked(string url) => url != null && url.Contains(MaskMarker);
+
+        // Rebuild the display value from the URI's structured parts: authority verbatim + every path
+        // segment except the last non-empty one verbatim + the last non-empty segment masked. Query
+        // and fragment are dropped from the display value (they're not needed to recognize the
+        // webhook and a `?redirect=/x` query must not move the mask split past the token).
+        private static string MaskAbsoluteUri(Uri uri)
+        {
+            var authority = uri.GetLeftPart(UriPartial.Authority);
+            var segments = uri.Segments;
+
+            // uri.Segments is `/`-prefixed and never empty for an absolute URI (worst case: ["/"]).
+            // Walk back from the end to find the last segment that carries a non-slash token; a
+            // trailing-slash URL (`…/token/`) has its last real segment one step before the end.
+            var lastIdx = -1;
+            for (var i = segments.Length - 1; i >= 0; i--)
+            {
+                if (!string.IsNullOrWhiteSpace(segments[i]) && segments[i] != "/")
+                {
+                    lastIdx = i;
+                    break;
+                }
+            }
+
+            if (lastIdx < 0)
+                return authority + "/" + MaskMarker;
+
+            // Leading segments verbatim (each already carries its trailing '/'); then the masked
+            // last segment WITHOUT its trailing slash (slashes after the token were display noise).
+            var prefix = new System.Text.StringBuilder();
+            for (var i = 0; i < lastIdx; i++)
+                prefix.Append(segments[i]);
+            var lastSegment = segments[lastIdx].TrimEnd('/');
+            return authority + prefix.ToString() + MaskLastSegment(lastSegment);
+        }
 
         // Reduces the last path segment to `head4 + MaskMarker + tail4`. A short segment (≤ 8 chars)
         // is shown verbatim per UX decision, with the marker appended as a trailing sentinel so

--- a/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
+++ b/src/server/HSMServer/Notifications/WebhookUrlMasker.cs
@@ -1,0 +1,51 @@
+using System;
+
+namespace HSMServer.Notifications
+{
+    // Masks webhook URLs for display in EditChat so the cleartext secret is never rendered to the
+    // browser. The mask keeps scheme + host + the first path segment (enough for an admin to tell
+    // `…/services/…` from `…/hooks/…`) and replaces the rest with the fixed marker `••••`.
+    //
+    // The marker doubles as the POST sentinel: EditChat posts the masked value back when the admin
+    // didn't replace the webhook, and ChatViewModel.ToUpdate treats any IsMasked value as "no change"
+    // (null in the ChatUpdate → Chat.ApplyUpdate keeps the stored URL).
+    public static class WebhookUrlMasker
+    {
+        public const string MaskMarker = "••••";
+
+        // null/empty/whitespace → null (distinguishes "no webhook" from "masked webhook" and lets
+        // ToUpdate apply the ??-no-change rule uniformly with the empty-input case).
+        public static string Mask(string url)
+        {
+            if (string.IsNullOrWhiteSpace(url))
+                return null;
+
+            if (Uri.TryCreate(url, UriKind.Absolute, out var uri) && !uri.IsFile)
+            {
+                var host = uri.Scheme + Uri.SchemeDelimiter + uri.Host;
+                var firstSegment = GetFirstPathSegment(uri.AbsolutePath);
+                return host + firstSegment + "/" + MaskMarker;
+            }
+
+            // Unparseable input (rare for a stored webhook) — still mask rather than throw. Fall back
+            // to slicing at the first '/' after the host-ish portion so we never leak the tail.
+            var firstSlash = url.IndexOf('/', StringComparison.Ordinal);
+            return firstSlash < 0 ? url + "/" + MaskMarker : url.Substring(0, firstSlash) + "/" + MaskMarker;
+        }
+
+        // True iff url carries the mask marker — i.e. it's a value we (or someone typing the literal
+        // bullets) emitted, not a real webhook URL. Real URLs never contain `••••`.
+        public static bool IsMasked(string url) => url != null && url.Contains(MaskMarker);
+
+        // Returns "/segment" (with a leading slash) for the first non-empty path piece, or "" when the
+        // URL has no path. Trailing slashes on the host root are treated as "no path".
+        private static string GetFirstPathSegment(string absolutePath)
+        {
+            if (string.IsNullOrEmpty(absolutePath))
+                return string.Empty;
+
+            var segments = absolutePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            return segments.Length == 0 ? string.Empty : "/" + segments[0];
+        }
+    }
+}

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -188,7 +188,11 @@
                                 <label class="chat-form-label col-form-label" for="SlackWebhookUrl">Slack Webhook URL</label>
                             </div>
                             <div class="col-12 col-md-7">
-                                <input type="url" class="form-control" asp-for="SlackWebhookUrl" placeholder="https://hooks.slack.com/services/..." />
+                                <input type="text" class="form-control" asp-for="SlackWebhookUrl" placeholder="https://hooks.slack.com/services/..." />
+                                @if (Model.HasSlack)
+                                {
+                                    <small class="text-muted d-block mt-1">Type a new URL to replace; leave as-is to keep the current webhook.</small>
+                                }
                             </div>
                         </div>
                         <div class="row mb-3">
@@ -215,7 +219,11 @@
                                 <label class="chat-form-label col-form-label" for="MattermostWebhookUrl">Mattermost Webhook URL</label>
                             </div>
                             <div class="col-12 col-md-7">
-                                <input type="url" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." />
+                                <input type="text" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." />
+                                @if (Model.HasMattermost)
+                                {
+                                    <small class="text-muted d-block mt-1">Type a new URL to replace; leave as-is to keep the current webhook.</small>
+                                }
                             </div>
                         </div>
                         <div class="row mb-3">

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -253,10 +253,13 @@
                 </div>
             }
 
-            <div class="chat-edit-section d-flex justify-content-end gap-2">
-                <a href="@Url.Action(nameof(NotificationsController.Index), ViewConstants.NotificationsController)"
-                   class="btn btn-outline-secondary chat-cancel-btn">Cancel</a>
-                <button type="submit" class="btn chat-save-btn">Save</button>
+            <div class="chat-edit-section">
+                <div asp-validation-summary="ModelOnly" class="text-danger small mb-2"></div>
+                <div class="d-flex justify-content-end gap-2">
+                    <a href="@Url.Action(nameof(NotificationsController.Index), ViewConstants.NotificationsController)"
+                       class="btn btn-outline-secondary chat-cancel-btn">Cancel</a>
+                    <button type="submit" class="btn chat-save-btn">Save</button>
+                </div>
             </div>
         </div>
     </form>

--- a/src/server/HSMServer/Views/Notifications/EditChat.cshtml
+++ b/src/server/HSMServer/Views/Notifications/EditChat.cshtml
@@ -189,6 +189,7 @@
                             </div>
                             <div class="col-12 col-md-7">
                                 <input type="text" class="form-control" asp-for="SlackWebhookUrl" placeholder="https://hooks.slack.com/services/..." />
+                                <span class="text-danger small d-block mt-1" asp-validation-for="SlackWebhookUrl"></span>
                                 @if (Model.HasSlack)
                                 {
                                     <small class="text-muted d-block mt-1">Type a new URL to replace; leave as-is to keep the current webhook.</small>
@@ -220,6 +221,7 @@
                             </div>
                             <div class="col-12 col-md-7">
                                 <input type="text" class="form-control" asp-for="MattermostWebhookUrl" placeholder="https://your-mattermost/hooks/..." />
+                                <span class="text-danger small d-block mt-1" asp-validation-for="MattermostWebhookUrl"></span>
                                 @if (Model.HasMattermost)
                                 {
                                     <small class="text-muted d-block mt-1">Type a new URL to replace; leave as-is to keep the current webhook.</small>

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -12,6 +12,8 @@ const chatName = uniqueName('EditChat');
 const renamedChatName = uniqueName('EditChatRenamed');
 const mattermostChatName = uniqueName('MMChat');
 const sendTestChatName = uniqueName('SendTestChat');
+const maskSlackChatName = uniqueName('MaskSlackChat');
+const maskMattermostChatName = uniqueName('MaskMattermostChat');
 
 test.afterEach(async ({ browser }) => {
   const page = await browser.newPage();
@@ -21,6 +23,8 @@ test.afterEach(async ({ browser }) => {
     await cleanup.chat(page, renamedChatName);
     await cleanup.chat(page, mattermostChatName);
     await cleanup.chat(page, sendTestChatName);
+    await cleanup.chat(page, maskSlackChatName);
+    await cleanup.chat(page, maskMattermostChatName);
   } finally {
     await page.close();
   }
@@ -111,9 +115,10 @@ test('Add and remove a Mattermost webhook chat (channel-type parity with Slack)'
   await expect(chatRow).toBeVisible();
   await expect(chatRow).toHaveAttribute('data-has-mattermost', 'true');
 
-  // --- EditChat: webhook value persisted, per-channel Remove button present ---
+  // --- EditChat: webhook value persisted (masked, #1329), per-channel Remove button present ---
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://hooks.mattermost.example/hooks/test');
+  // The raw webhook is never rendered (#1329); the field shows host + first path segment + `••••`.
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://hooks.mattermost.example/hooks/••••');
   await expect(page.locator('#removeMattermost')).toBeVisible();
 
   // --- Remove Mattermost clears only the webhook, chat itself stays (parity with Slack test) ---
@@ -175,6 +180,81 @@ test('EditChat: Send test Slack/Mattermost message buttons trigger the request a
   await expect(page.locator('#toast_body')).toHaveText('Test Mattermost message sent.', { timeout: 10000 });
 
   // --- Logout ---
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+
+
+// Covers #1329: the Slack/Mattermost webhook URL is a secret, so EditChat must render a masked
+// display value and never expose the raw URL in the page source or the input value attribute. The
+// masked sentinel also round-trips: saving other fields without touching the webhook keeps the
+// stored cleartext URL intact (ToUpdate treats the mask + empty as "no change").
+test('EditChat: Slack webhook is masked, raw URL is not in the page, and survives a no-change save', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password } = testConfig;
+  const rawSecret = 'mask-coverage-secret';
+  const rotatedSecret = 'rotated-slack-secret';
+
+  // --- Login + create a Slack chat ---
+  await login(page, admin_user, admin_user_password, apiUrl);
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(maskSlackChatName);
+  await page.locator('#SlackWebhookUrl').fill(`https://hooks.slack.com/services/${rawSecret}`);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  // --- Reopen EditChat: field shows the masked sentinel, not the raw URL ---
+  const chatRow = page.locator('.chat-row').filter({ hasText: maskSlackChatName });
+  await chatRow.locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+
+  // The raw secret must not appear anywhere in the rendered HTML (covers input value attr + any
+  // incidental rendering). This is the hard acceptance criterion from #1329.
+  const pageHtml = await page.content();
+  expect(pageHtml).not.toContain(rawSecret);
+
+  // --- Save a non-webhook field without touching the webhook → stored webhook must survive ---
+  await page.locator('#Description').fill('edited without touching webhook');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+  await page.locator('.chat-row').filter({ hasText: maskSlackChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+
+  // --- Replace the webhook: clear, paste a new URL, save → mask reflects the new value ---
+  await page.locator('#SlackWebhookUrl').fill(`https://hooks.slack.com/services/${rotatedSecret}`);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+  await page.locator('.chat-row').filter({ hasText: maskSlackChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+  expect(await page.content()).not.toContain(rotatedSecret);
+
+  // --- Logout ---
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+
+
+// Mattermost parity with the Slack masking test above (#1329).
+test('EditChat: Mattermost webhook is masked and the raw URL is not in the page', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password } = testConfig;
+  const rawSecret = 'mattermost-mask-secret';
+
+  await login(page, admin_user, admin_user_password, apiUrl);
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(maskMattermostChatName);
+  await page.getByRole('tab', { name: 'Mattermost' }).click();
+  await page.locator('#MattermostWebhookUrl').fill(`https://mattermost.example.com/hooks/${rawSecret}`);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  const chatRow = page.locator('.chat-row').filter({ hasText: maskMattermostChatName });
+  await chatRow.locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://mattermost.example.com/hooks/••••');
+  expect(await page.content()).not.toContain(rawSecret);
+
   await page.getByRole('link', { name: 'Logout' }).click();
   await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
 });

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -15,6 +15,8 @@ const sendTestChatName = uniqueName('SendTestChat');
 const maskSlackChatName = uniqueName('MaskSlackChat');
 const maskMattermostChatName = uniqueName('MaskMattermostChat');
 const partialEditChatName = uniqueName('PartialEditChat');
+const folderBindingChatName = uniqueName('FolderBindingChat');
+const folderBindingFolderName = uniqueName('FolderBindingFldr');
 
 test.afterEach(async ({ browser }) => {
   const page = await browser.newPage();
@@ -27,6 +29,8 @@ test.afterEach(async ({ browser }) => {
     await cleanup.chat(page, maskSlackChatName);
     await cleanup.chat(page, maskMattermostChatName);
     await cleanup.chat(page, partialEditChatName);
+    await cleanup.chat(page, folderBindingChatName);
+    await cleanup.folder(page, folderBindingFolderName);
   } finally {
     await page.close();
   }
@@ -307,6 +311,76 @@ test('EditChat: a partial edit of the masked webhook is rejected, stored value u
   await page.locator('.chat-row').filter({ hasText: partialEditChatName }).locator('.chat-action-btn[title="Edit"]').click();
   await expect(page.locator('#MattermostWebhookUrl')).toHaveValue(`https://${originalHost}/hooks/orig••••oken`);
   expect(await page.content()).not.toContain(editedHost);
+
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+
+
+// Regression for #1329 review: when EditChat POST rejects a partial mask edit, the re-render must
+// carry the server-owned folder data (Connected folders table + the hidden Folders.Folders[i]
+// inputs). The POST-bound ChatViewModel has DisplayFolders empty (get-only, never posted), so
+// without a rebuild the next Save — the user pasting the full URL as the error tells them to —
+// posts empty Folders and SyncFolders unbinds the chat from every managed folder. For an admin
+// that means every folder; the rotation looks successful while the chat silently stops receiving
+// alerts from everywhere.
+test('EditChat: a rejected webhook edit preserves folder bindings across the re-save', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password, folder_description, folder_color } = testConfig;
+
+  // --- Login + create a Slack chat ---
+  await login(page, admin_user, admin_user_password, apiUrl);
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(folderBindingChatName);
+  await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/binding-test-secret');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  // --- Create a folder and bind the chat to it via the folder's Chats tab ---
+  await page.getByRole('link', { name: 'Products' }).click();
+  await page.getByRole('link', { name: 'Add folder' }).click();
+  await page.getByRole('textbox', { name: 'Name' }).fill(folderBindingFolderName);
+  await page.getByRole('textbox', { name: 'Description' }).fill(folder_description);
+  await page.locator('#Color').fill(folder_color);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page.getByRole('textbox', { name: 'Name' })).toHaveValue(folderBindingFolderName);
+
+  await page.getByRole('tab', { name: 'Chats' }).click();
+  const picker = page.locator('#chatsSelect .bootstrap-select');
+  await picker.locator('button.dropdown-toggle').click();
+  await picker.locator('.dropdown-menu').locator('li, a').filter({ hasText: folderBindingChatName }).first().click();
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/EditFolder|Folder/);
+
+  // --- EditChat: the chat now shows the folder under "Connected folders" ---
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.locator('.chat-row').filter({ hasText: folderBindingChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.getByText('Connected folders')).toBeVisible();
+  await expect(page.locator('table').filter({ hasText: folderBindingFolderName })).toBeVisible();
+
+  // --- Partially edit the masked webhook → rejected with an inline error, form stays on EditChat ---
+  const masked = await page.locator('#SlackWebhookUrl').inputValue();
+  await page.locator('#SlackWebhookUrl').fill(masked.replace('hooks.slack.com', 'hooks.different.host'));
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/EditChat/);
+  await expect(page.locator('[data-valmsg-for="SlackWebhookUrl"]')).toContainText('Paste the full webhook URL');
+
+  // The Connected folders table must still be rendered after the rejection — that is the bug: the
+  // re-render used to drop it along with the hidden Folders.Folders[i] inputs.
+  await expect(page.locator('table').filter({ hasText: folderBindingFolderName })).toBeVisible();
+
+  // --- Do what the error says: paste the full URL and Save again ---
+  await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/rotated-binding-secret');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  // --- Reopen EditChat → the folder binding must have survived the rejected-then-successful save.
+  // Without the rebuild-on-reject fix, SyncFolders would have unbound the chat from the folder on
+  // the second Save because the rejection re-render posted an empty Folders list.
+  await page.locator('.chat-row').filter({ hasText: folderBindingChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('table').filter({ hasText: folderBindingFolderName })).toBeVisible();
 
   await page.getByRole('link', { name: 'Logout' }).click();
   await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -17,6 +17,7 @@ const maskMattermostChatName = uniqueName('MaskMattermostChat');
 const partialEditChatName = uniqueName('PartialEditChat');
 const folderBindingChatName = uniqueName('FolderBindingChat');
 const folderBindingFolderName = uniqueName('FolderBindingFldr');
+const dualChannelChatName = uniqueName('DualChannelChat');
 
 test.afterEach(async ({ browser }) => {
   const page = await browser.newPage();
@@ -30,6 +31,7 @@ test.afterEach(async ({ browser }) => {
     await cleanup.chat(page, maskMattermostChatName);
     await cleanup.chat(page, partialEditChatName);
     await cleanup.chat(page, folderBindingChatName);
+    await cleanup.chat(page, dualChannelChatName);
     await cleanup.folder(page, folderBindingFolderName);
   } finally {
     await page.close();
@@ -317,7 +319,57 @@ test('EditChat: a partial edit of the masked webhook is rejected, stored value u
 });
 
 
-// Regression for #1329 review: when EditChat POST rejects a partial mask edit, the re-render must
+// Regression for #1329 review: the rejection error span lives INSIDE the .tab-pane for its channel,
+// and a .tab-pane is display:none unless its tab is active. Without SetTabFromWebhookErrors the
+// default-tab heuristic (telegram → slack → mattermost) hides the rejection for any chat whose
+// failing channel is not the heuristic's pick. This test covers the Slack+Mattermost case (Telegram
+// binding can't be simulated in Playwright without a live bot-invite flow, but Slack+Mattermost
+// fails the same way: default-tab lands on Slack, so a Mattermost-only error would be invisible).
+// SetTabFromWebhookErrors must switch the active tab to the failing field's channel.
+test('EditChat: a rejected webhook edit surfaces the error on the failing channel\'s tab', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password } = testConfig;
+
+  // --- Login + create a chat with BOTH Slack and Mattermost webhooks ---
+  await login(page, admin_user, admin_user_password, apiUrl);
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(dualChannelChatName);
+  await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/dual-channel-slack');
+  await page.getByRole('tab', { name: 'Mattermost' }).click();
+  await page.locator('#MattermostWebhookUrl').fill('https://mattermost.example.com/hooks/dual-channel-mm');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  // --- Reopen EditChat. Default-tab heuristic picks Slack (both channels configured → falls
+  // through to "slack" per EditChat.cshtml:26-30). Verify that assumption before the rejection.
+  await page.locator('.chat-row').filter({ hasText: dualChannelChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#slack-tab')).toHaveClass(/\bactive\b/);
+  await expect(page.locator('#mattermost-tab')).not.toHaveClass(/\bactive\b/);
+
+  // --- Partially edit only the MATTERMOST webhook (switch to its tab first to type, then submit) ---
+  await page.getByRole('tab', { name: 'Mattermost' }).click();
+  const masked = await page.locator('#MattermostWebhookUrl').inputValue();
+  await page.locator('#MattermostWebhookUrl').fill(masked.replace('mattermost.example.com', 'mattermost.tampered.host'));
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // --- The save is rejected and the form re-renders ON THE MATTERMOST TAB — not the Slack tab the
+  // default heuristic would pick. The asp-validation-for span is inside the Mattermost .tab-pane;
+  // it's only visible if the Mattermost tab is active. Before SetTabFromWebhookErrors this was
+  // rendered into a display:none Slack-tab DOM and the admin saw an unchanged-looking form.
+  await expect(page).toHaveURL(/EditChat/);
+  await expect(page.locator('#mattermost-tab')).toHaveClass(/\bactive\b/);
+  await expect(page.locator('#slack-tab')).not.toHaveClass(/\bactive\b/);
+  await expect(page.locator('[data-valmsg-for="MattermostWebhookUrl"]')).toBeVisible();
+  await expect(page.locator('[data-valmsg-for="MattermostWebhookUrl"]')).toContainText('Paste the full webhook URL');
+
+  // The Slack tab carries no error and must not be the active tab — otherwise the same display:none
+  // bug could hide behind a different default-tab order.
+  await expect(page.locator('[data-valmsg-for="SlackWebhookUrl"]')).toHaveCount(0);
+
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
 // carry the server-owned folder data (Connected folders table + the hidden Folders.Folders[i]
 // inputs). The POST-bound ChatViewModel has DisplayFolders empty (get-only, never posted), so
 // without a rebuild the next Save — the user pasting the full URL as the error tells them to —

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -106,7 +106,7 @@ test('Add and remove a Mattermost webhook chat (channel-type parity with Slack)'
   // A brand-new chat defaults to the Slack tab (EditChat.cshtml:19-30), so switch to Mattermost
   // before filling its (currently hidden) webhook field.
   await page.getByRole('tab', { name: 'Mattermost' }).click();
-  await page.locator('#MattermostWebhookUrl').fill('https://hooks.mattermost.example/hooks/test');
+  await page.locator('#MattermostWebhookUrl').fill('https://hooks.mattermost.example/hooks/test-webhook-12345');
   await page.getByRole('button', { name: 'Save' }).click();
 
   // --- List: row carries data-has-mattermost="true" (drives the channelFilter select) ---
@@ -117,8 +117,9 @@ test('Add and remove a Mattermost webhook chat (channel-type parity with Slack)'
 
   // --- EditChat: webhook value persisted (masked, #1329), per-channel Remove button present ---
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  // The raw webhook is never rendered (#1329); the field shows host + first path segment + `••••`.
-  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://hooks.mattermost.example/hooks/••••');
+  // The raw webhook is never rendered (#1329); the field shows host + 8-char path prefix + `••••`
+  // + 4-char tail. Original was `/hooks/test-webhook-12345`.
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://hooks.mattermost.example/hooks/t••••2345');
   await expect(page.locator('#removeMattermost')).toBeVisible();
 
   // --- Remove Mattermost clears only the webhook, chat itself stays (parity with Slack test) ---
@@ -207,7 +208,8 @@ test('EditChat: Slack webhook is masked, raw URL is not in the page, and survive
   // --- Reopen EditChat: field shows the masked sentinel, not the raw URL ---
   const chatRow = page.locator('.chat-row').filter({ hasText: maskSlackChatName });
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+  // host + 8-char path prefix (`/service`) + `••••` + 4-char tail (`cret` from `…secret`).
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••cret');
 
   // The raw secret must not appear anywhere in the rendered HTML (covers input value attr + any
   // incidental rendering). This is the hard acceptance criterion from #1329.
@@ -219,14 +221,15 @@ test('EditChat: Slack webhook is masked, raw URL is not in the page, and survive
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(page).toHaveURL(/.*Notifications/);
   await page.locator('.chat-row').filter({ hasText: maskSlackChatName }).locator('.chat-action-btn[title="Edit"]').click();
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••cret');
 
   // --- Replace the webhook: clear, paste a new URL, save → mask reflects the new value ---
   await page.locator('#SlackWebhookUrl').fill(`https://hooks.slack.com/services/${rotatedSecret}`);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(page).toHaveURL(/.*Notifications/);
   await page.locator('.chat-row').filter({ hasText: maskSlackChatName }).locator('.chat-action-btn[title="Edit"]').click();
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+  // rotatedSecret also ends in `…secret`, so the visible tail is still `cret`.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••cret');
   expect(await page.content()).not.toContain(rotatedSecret);
 
   // --- Logout ---
@@ -252,7 +255,8 @@ test('EditChat: Mattermost webhook is masked and the raw URL is not in the page'
 
   const chatRow = page.locator('.chat-row').filter({ hasText: maskMattermostChatName });
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://mattermost.example.com/hooks/••••');
+  // host + 8-char path prefix (`/hooks/m`) + `••••` + 4-char tail (`cret` from `…secret`).
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://mattermost.example.com/hooks/m••••cret');
   expect(await page.content()).not.toContain(rawSecret);
 
   await page.getByRole('link', { name: 'Logout' }).click();

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -117,9 +117,9 @@ test('Add and remove a Mattermost webhook chat (channel-type parity with Slack)'
 
   // --- EditChat: webhook value persisted (masked, #1329), per-channel Remove button present ---
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  // The raw webhook is never rendered (#1329); the field shows host + 8-char path prefix + `••••`
-  // + 4-char tail. Original was `/hooks/test-webhook-12345`.
-  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://hooks.mattermost.example/hooks/t••••2345');
+  // The raw webhook is never rendered (#1329); only the last path segment is masked (head4 + `••••`
+  // + tail4). Original last segment was `test-webhook-12345` → `test` + `••••` + `2345`.
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://hooks.mattermost.example/hooks/test••••2345');
   await expect(page.locator('#removeMattermost')).toBeVisible();
 
   // --- Remove Mattermost clears only the webhook, chat itself stays (parity with Slack test) ---
@@ -208,8 +208,9 @@ test('EditChat: Slack webhook is masked, raw URL is not in the page, and survive
   // --- Reopen EditChat: field shows the masked sentinel, not the raw URL ---
   const chatRow = page.locator('.chat-row').filter({ hasText: maskSlackChatName });
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  // host + 8-char path prefix (`/service`) + `••••` + 4-char tail (`cret` from `…secret`).
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••cret');
+  // Only the last path segment is masked (head4 + `••••` + tail4). rawSecret=`mask-coverage-secret`
+  // → `mask` + `••••` + `cret`.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/mask••••cret');
 
   // The raw secret must not appear anywhere in the rendered HTML (covers input value attr + any
   // incidental rendering). This is the hard acceptance criterion from #1329.
@@ -221,15 +222,15 @@ test('EditChat: Slack webhook is masked, raw URL is not in the page, and survive
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(page).toHaveURL(/.*Notifications/);
   await page.locator('.chat-row').filter({ hasText: maskSlackChatName }).locator('.chat-action-btn[title="Edit"]').click();
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••cret');
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/mask••••cret');
 
   // --- Replace the webhook: clear, paste a new URL, save → mask reflects the new value ---
   await page.locator('#SlackWebhookUrl').fill(`https://hooks.slack.com/services/${rotatedSecret}`);
   await page.getByRole('button', { name: 'Save' }).click();
   await expect(page).toHaveURL(/.*Notifications/);
   await page.locator('.chat-row').filter({ hasText: maskSlackChatName }).locator('.chat-action-btn[title="Edit"]').click();
-  // rotatedSecret also ends in `…secret`, so the visible tail is still `cret`.
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••cret');
+  // rotatedSecret=`rotated-slack-secret` → `rota` + `••••` + `cret`.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/rota••••cret');
   expect(await page.content()).not.toContain(rotatedSecret);
 
   // --- Logout ---
@@ -255,8 +256,8 @@ test('EditChat: Mattermost webhook is masked and the raw URL is not in the page'
 
   const chatRow = page.locator('.chat-row').filter({ hasText: maskMattermostChatName });
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
-  // host + 8-char path prefix (`/hooks/m`) + `••••` + 4-char tail (`cret` from `…secret`).
-  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://mattermost.example.com/hooks/m••••cret');
+  // Only the last path segment is masked: rawSecret=`mattermost-mask-secret` → `matt` + `••••` + `cret`.
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://mattermost.example.com/hooks/matt••••cret');
   expect(await page.content()).not.toContain(rawSecret);
 
   await page.getByRole('link', { name: 'Logout' }).click();

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -18,6 +18,7 @@ const partialEditChatName = uniqueName('PartialEditChat');
 const folderBindingChatName = uniqueName('FolderBindingChat');
 const folderBindingFolderName = uniqueName('FolderBindingFldr');
 const dualChannelChatName = uniqueName('DualChannelChat');
+const emptyFieldChatName = uniqueName('EmptyFieldChat');
 
 test.afterEach(async ({ browser }) => {
   const page = await browser.newPage();
@@ -32,6 +33,7 @@ test.afterEach(async ({ browser }) => {
     await cleanup.chat(page, partialEditChatName);
     await cleanup.chat(page, folderBindingChatName);
     await cleanup.chat(page, dualChannelChatName);
+    await cleanup.chat(page, emptyFieldChatName);
     await cleanup.folder(page, folderBindingFolderName);
   } finally {
     await page.close();
@@ -313,6 +315,48 @@ test('EditChat: a partial edit of the masked webhook is rejected, stored value u
   await page.locator('.chat-row').filter({ hasText: partialEditChatName }).locator('.chat-action-btn[title="Edit"]').click();
   await expect(page.locator('#MattermostWebhookUrl')).toHaveValue(`https://${originalHost}/hooks/orig••••oken`);
   expect(await page.content()).not.toContain(editedHost);
+
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+
+
+// Regression for #1329 review: pre-PR, ToUpdate passed the posted value straight through, so an
+// empty field cleared the stored webhook (Chat.ApplyUpdate's `?? current` only checks null). After
+// ResolveWebhook mapped empty → null = "no change", deleting the field contents became a silent
+// no-op — the admin sees a success redirect while the old webhook stays live, exactly the silent-
+// rotation failure the partial-edit guard was added to prevent. The sanctioned path is Remove Slack
+// (ClearSlackWebhook), so the guard rejects empty with a pointer to that button.
+test('EditChat: clearing the webhook field is rejected, not silently ignored', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password } = testConfig;
+
+  // --- Login + create a Slack chat ---
+  await login(page, admin_user, admin_user_password, apiUrl);
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(emptyFieldChatName);
+  await page.locator('#SlackWebhookUrl').fill('https://hooks.slack.com/services/empty-field-secret');
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  // --- Reopen EditChat and clear the webhook field entirely ---
+  await page.locator('.chat-row').filter({ hasText: emptyFieldChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await page.locator('#SlackWebhookUrl').fill('');
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // --- The save is rejected: form stays on EditChat with an inline error pointing to Remove Slack.
+  // Before the guard, this redirected to the chats list and the old webhook stayed live silently.
+  await expect(page).toHaveURL(/EditChat/);
+  await expect(page.locator('[data-valmsg-for="SlackWebhookUrl"]')).toContainText('Use Remove Slack to delete the webhook');
+
+  // --- Reopen from the list (fresh GET) → stored webhook is unchanged: still masked from the
+  // ORIGINAL URL, the secret nowhere in the page.
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.locator('.chat-row').filter({ hasText: emptyFieldChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/empt••••cret');
+  expect(await page.content()).not.toContain('empty-field-secret');
 
   await page.getByRole('link', { name: 'Logout' }).click();
   await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -407,9 +407,11 @@ test('EditChat: a rejected webhook edit surfaces the error on the failing channe
   await expect(page.locator('[data-valmsg-for="MattermostWebhookUrl"]')).toBeVisible();
   await expect(page.locator('[data-valmsg-for="MattermostWebhookUrl"]')).toContainText('Paste the full webhook URL');
 
-  // The Slack tab carries no error and must not be the active tab — otherwise the same display:none
-  // bug could hide behind a different default-tab order.
-  await expect(page.locator('[data-valmsg-for="SlackWebhookUrl"]')).toHaveCount(0);
+  // The Slack field carries no error: ValidationMessageTagHelper always emits the <span> (only its
+  // inner text is conditional), so assert emptiness rather than count. This is the "the Slack tab
+  // has nothing to complain about" intent — without it the same display:none bug could hide behind a
+  // different default-tab order.
+  await expect(page.locator('[data-valmsg-for="SlackWebhookUrl"]')).toBeEmpty();
 
   await page.getByRole('link', { name: 'Logout' }).click();
   await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();

--- a/src/tests/Autotests/configuration/chats_edit.spec.ts
+++ b/src/tests/Autotests/configuration/chats_edit.spec.ts
@@ -14,6 +14,7 @@ const mattermostChatName = uniqueName('MMChat');
 const sendTestChatName = uniqueName('SendTestChat');
 const maskSlackChatName = uniqueName('MaskSlackChat');
 const maskMattermostChatName = uniqueName('MaskMattermostChat');
+const partialEditChatName = uniqueName('PartialEditChat');
 
 test.afterEach(async ({ browser }) => {
   const page = await browser.newPage();
@@ -25,6 +26,7 @@ test.afterEach(async ({ browser }) => {
     await cleanup.chat(page, sendTestChatName);
     await cleanup.chat(page, maskSlackChatName);
     await cleanup.chat(page, maskMattermostChatName);
+    await cleanup.chat(page, partialEditChatName);
   } finally {
     await page.close();
   }
@@ -259,6 +261,52 @@ test('EditChat: Mattermost webhook is masked and the raw URL is not in the page'
   // Only the last path segment is masked: rawSecret=`mattermost-mask-secret` → `matt` + `••••` + `cret`.
   await expect(page.locator('#MattermostWebhookUrl')).toHaveValue('https://mattermost.example.com/hooks/matt••••cret');
   expect(await page.content()).not.toContain(rawSecret);
+
+  await page.getByRole('link', { name: 'Logout' }).click();
+  await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+});
+
+
+// Covers #1329 review: a partial in-place edit of the masked value (e.g. changing only the host)
+// used to be silently discarded — IsMasked is a substring test, so ResolveWebhook treated the edited
+// mask as the unchanged sentinel and emitted null ("no change"), and the admin was redirected to the
+// chats list with no signal that their rotation attempt did nothing. The save must now be rejected
+// with a visible error, and the stored webhook must be untouched.
+test('EditChat: a partial edit of the masked webhook is rejected, stored value untouched', async ({ page }) => {
+  const { apiUrl, admin_user, admin_user_password } = testConfig;
+  const originalHost = 'mattermost.old.example';
+  const editedHost = 'mattermost.new.example';
+
+  // --- Login + create a Mattermost chat ---
+  await login(page, admin_user, admin_user_password, apiUrl);
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.getByRole('link', { name: 'Add new chat' }).click();
+  await page.locator('#Name').fill(partialEditChatName);
+  await page.getByRole('tab', { name: 'Mattermost' }).click();
+  await page.locator('#MattermostWebhookUrl').fill(`https://${originalHost}/hooks/original-secret-token`);
+  await page.getByRole('button', { name: 'Save' }).click();
+  await expect(page).toHaveURL(/.*Notifications/);
+
+  // --- Reopen and partially edit just the host of the masked value ---
+  const chatRow = page.locator('.chat-row').filter({ hasText: partialEditChatName });
+  await chatRow.locator('.chat-action-btn[title="Edit"]').click();
+  const masked = await page.locator('#MattermostWebhookUrl').inputValue();
+  await page.locator('#MattermostWebhookUrl').fill(masked.replace(originalHost, editedHost));
+  await page.getByRole('button', { name: 'Save' }).click();
+
+  // --- The save is rejected: form stays on EditChat (no redirect to the list) and an inline error
+  // is rendered next to the field. The "••••" in the edited value is what trips the guard.
+  await expect(page).toHaveURL(/EditChat/);
+  await expect(page.locator('[data-valmsg-for="MattermostWebhookUrl"]')).toContainText('Paste the full webhook URL');
+
+  // --- Reopen the same chat from the list (fresh GET) → the stored webhook is unchanged: still
+  // masked from the ORIGINAL host, the edited host nowhere in the page.
+  await page.getByRole('button', { name: 'Configuration' }).click();
+  await page.getByRole('link', { name: 'Chats' }).click();
+  await page.locator('.chat-row').filter({ hasText: partialEditChatName }).locator('.chat-action-btn[title="Edit"]').click();
+  await expect(page.locator('#MattermostWebhookUrl')).toHaveValue(`https://${originalHost}/hooks/orig••••oken`);
+  expect(await page.content()).not.toContain(editedHost);
 
   await page.getByRole('link', { name: 'Logout' }).click();
   await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -177,9 +177,9 @@ test('EditChat: per-channel Remove clears Slack webhook without deleting the cha
   await expect(chatRow).toBeVisible();
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
 
-  // EditChat should show the populated webhook and a "Remove Slack" button alongside the
-  // existing "Send test Slack message" button.
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/remove-test');
+  // EditChat should show the masked webhook (#1329 — host + first path segment + `••••`) and a
+  // "Remove Slack" button alongside the existing "Send test Slack message" button.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
   await expect(page.locator('#removeSlack')).toBeVisible();
 
   // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -177,9 +177,10 @@ test('EditChat: per-channel Remove clears Slack webhook without deleting the cha
   await expect(chatRow).toBeVisible();
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
 
-  // EditChat should show the masked webhook (#1329 — host + first path segment + `••••`) and a
-  // "Remove Slack" button alongside the existing "Send test Slack message" button.
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/••••');
+  // EditChat should show the masked webhook (#1329 — host + 8-char path prefix + `••••` + 4-char
+  // tail) and a "Remove Slack" button alongside the existing "Send test Slack message" button.
+  // Original was `/services/remove-test` → `/service` + `••••` + `test`.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••test');
   await expect(page.locator('#removeSlack')).toBeVisible();
 
   // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and

--- a/src/tests/Autotests/products/modify_folder_chat.spec.ts
+++ b/src/tests/Autotests/products/modify_folder_chat.spec.ts
@@ -177,10 +177,10 @@ test('EditChat: per-channel Remove clears Slack webhook without deleting the cha
   await expect(chatRow).toBeVisible();
   await chatRow.locator('.chat-action-btn[title="Edit"]').click();
 
-  // EditChat should show the masked webhook (#1329 — host + 8-char path prefix + `••••` + 4-char
-  // tail) and a "Remove Slack" button alongside the existing "Send test Slack message" button.
-  // Original was `/services/remove-test` → `/service` + `••••` + `test`.
-  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/service••••test');
+  // EditChat should show the masked webhook (#1329 — only the last path segment is masked:
+  // head4 + `••••` + tail4) and a "Remove Slack" button alongside the existing "Send test Slack
+  // message" button. Original last segment was `remove-test` → `remo` + `••••` + `test`.
+  await expect(page.locator('#SlackWebhookUrl')).toHaveValue('https://hooks.slack.com/services/remo••••test');
   await expect(page.locator('#removeSlack')).toBeVisible();
 
   // Click Remove Slack → confirmation modal → OK. The AJAX POST hits ClearSlackWebhook and

--- a/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
@@ -70,6 +70,59 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Contains("5678", masked);
         }
 
+        // Regression: a trailing slash used to defeat masking entirely. The old string-slicing took
+        // url.LastIndexOf('/'), found the trailing slash, and returned the full token verbatim with
+        // just a marker appended — the secret was in the page source and the input value attribute,
+        // exactly the leak #1329 closes. Segment-based masking (via Uri.Segments) walks back past the
+        // empty trailing segment to the real token and masks it.
+        [Fact]
+        public void Mask_TrailingSlash_MasksTheRealLastSegmentNotTheEmptyTail()
+        {
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/services/T0ABCDE/B0123456/abcXYZsecret/");
+
+            Assert.Equal("https://hooks.slack.com/services/T0ABCDE/B0123456/abcX••••cret", masked);
+        }
+
+        [Fact]
+        public void Mask_TrailingSlash_SecretTokenIsAbsentFromResult()
+        {
+            const string secret = "abcXYZsecret";
+
+            var masked = WebhookUrlMasker.Mask($"https://hooks.slack.com/services/T0ABCDE/B0123456/{secret}/");
+
+            Assert.DoesNotContain(secret, masked);
+        }
+
+        // Regression: a query string containing '/' used to move the split point past the token
+        // (`…/SECRETTOKEN?redirect=/x` masked the query, not the token). The query is now dropped
+        // from the display value entirely and the token segment is masked.
+        [Fact]
+        public void Mask_QueryStringWithSlash_MasksTheTokenNotTheQuery()
+        {
+            var masked = WebhookUrlMasker.Mask("https://host/hooks/SECRETTOKEN?redirect=/x");
+
+            Assert.Equal("https://host/hooks/SECR••••OKEN", masked);
+        }
+
+        [Fact]
+        public void Mask_Fragment_MasksTheTokenNotTheFragment()
+        {
+            var masked = WebhookUrlMasker.Mask("https://host/hooks/SECRETTOKEN#section");
+
+            Assert.Equal("https://host/hooks/SECR••••OKEN", masked);
+        }
+
+        // A path that is only root segments (`/`) collapses to authority + marker — same behavior as
+        // a URL with no path at all.
+        [Fact]
+        public void Mask_RootPathOnly_ShowsAuthorityAndMarker()
+        {
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/");
+
+            Assert.Equal("https://hooks.slack.com/••••", masked);
+            Assert.True(WebhookUrlMasker.IsMasked(masked));
+        }
+
         // A short last segment (≤ 8 chars = head+tail threshold) is shown verbatim per UX decision,
         // with the marker appended as a trailing sentinel so IsMasked stays true (otherwise the
         // round-tripped value would look like a fresh URL and overwrite the stored webhook on save).
@@ -82,14 +135,15 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.True(WebhookUrlMasker.IsMasked(masked));
         }
 
-        // A webhook URL with no path (no '/' after the host) gets the marker appended so IsMasked
-        // stays true; nothing recognition-worthy is leaked since there's no token to show.
+        // A webhook URL with no path (no '/' after the host) collapses to authority + marker. Uri
+        // still reports Segments=["/"] for the implicit root, so the slash appears before the marker;
+        // nothing recognition-worthy is leaked since there's no token to show.
         [Fact]
         public void Mask_UrlWithoutPath_AppendsMarker()
         {
             var masked = WebhookUrlMasker.Mask("https://hooks.slack.com");
 
-            Assert.Equal("https://hooks.slack.com••••", masked);
+            Assert.Equal("https://hooks.slack.com/••••", masked);
             Assert.True(WebhookUrlMasker.IsMasked(masked));
         }
 

--- a/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
@@ -1,0 +1,108 @@
+using HSMServer.Notifications;
+using Xunit;
+
+namespace HSMServer.Core.Tests.Notifications
+{
+    public class WebhookUrlMaskerTests
+    {
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("   ")]
+        public void Mask_NullOrEmpty_ReturnsNull(string url)
+        {
+            Assert.Null(WebhookUrlMasker.Mask(url));
+        }
+
+        [Fact]
+        public void Mask_SlackExample_KeepsSchemeHostAndFirstSegment_MasksRest()
+        {
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/services/T0ABCDE/B0123456/abcXYZsecret");
+
+            Assert.Equal("https://hooks.slack.com/services/••••", masked);
+        }
+
+        // The hard security requirement: the secret tail must not leak into the rendered mask.
+        [Fact]
+        public void Mask_SlackUrl_SecretTailIsAbsentFromResult()
+        {
+            const string secret = "abcXYZsecret";
+
+            var masked = WebhookUrlMasker.Mask($"https://hooks.slack.com/services/T0ABCDE/B0123456/{secret}");
+
+            Assert.DoesNotContain(secret, masked);
+            Assert.DoesNotContain("B0123456", masked);
+        }
+
+        [Fact]
+        public void Mask_MattermostExample_KeepsSchemeHostAndFirstSegment()
+        {
+            var masked = WebhookUrlMasker.Mask("https://mattermost.example.com/hooks/abcd1234efgh5678");
+
+            Assert.Equal("https://mattermost.example.com/hooks/••••", masked);
+        }
+
+        [Fact]
+        public void Mask_MattermostUrl_SecretTailIsAbsentFromResult()
+        {
+            const string secret = "abcd1234efgh5678";
+
+            var masked = WebhookUrlMasker.Mask($"https://mattermost.example.com/hooks/{secret}");
+
+            Assert.DoesNotContain(secret, masked);
+        }
+
+        // A webhook URL with no path segment still gets the marker, so the POST-sentinel detection in
+        // ToUpdate works uniformly (any masked value ends in `••••`).
+        [Fact]
+        public void Mask_UrlWithoutPath_StillAppendsMarker()
+        {
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com");
+
+            Assert.Equal("https://hooks.slack.com/••••", masked);
+        }
+
+        [Fact]
+        public void Mask_UrlWithOnlyRootPath_StillAppendsMarker()
+        {
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/");
+
+            Assert.Equal("https://hooks.slack.com/••••", masked);
+        }
+
+        // Weird/unparseable input must mask rather than throw — a stored webhook should never be
+        // unparseable, but the helper is a boundary and must degrade safely.
+        [Fact]
+        public void Mask_NonParseableInput_DoesNotThrowAndMasks()
+        {
+            var masked = WebhookUrlMasker.Mask("not-a-url-with-a-slash/and/secret/tail");
+
+            Assert.NotNull(masked);
+            Assert.Contains(WebhookUrlMasker.MaskMarker, masked);
+            Assert.DoesNotContain("secret", masked);
+        }
+
+        [Theory]
+        [InlineData("https://hooks.slack.com/services/••••")]
+        [InlineData("prefix••••suffix")]
+        public void IsMasked_ValueContainsMarker_ReturnsTrue(string url)
+        {
+            Assert.True(WebhookUrlMasker.IsMasked(url));
+        }
+
+        [Theory]
+        [InlineData("https://hooks.slack.com/services/real-url")]
+        [InlineData("https://mattermost.example.com/hooks/abcd1234")]
+        [InlineData("")]
+        public void IsMasked_RealUrlOrEmpty_ReturnsFalse(string url)
+        {
+            Assert.False(WebhookUrlMasker.IsMasked(url));
+        }
+
+        [Fact]
+        public void IsMasked_Null_ReturnsFalse()
+        {
+            Assert.False(WebhookUrlMasker.IsMasked(null));
+        }
+    }
+}

--- a/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
@@ -15,16 +15,18 @@ namespace HSMServer.Core.Tests.Notifications
         }
 
         [Fact]
-        public void Mask_SlackExample_KeepsSchemeHostAndFirstSegment_MasksRest()
+        public void Mask_SlackExample_KeepsHostPathPrefixAndTail()
         {
             var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/services/T0ABCDE/B0123456/abcXYZsecret");
 
-            Assert.Equal("https://hooks.slack.com/services/••••", masked);
+            // host verbatim + first 8 chars of PathAndQuery (`/service`) + marker + last 4 chars (`cret`).
+            Assert.Equal("https://hooks.slack.com/service••••cret", masked);
         }
 
-        // The hard security requirement: the secret tail must not leak into the rendered mask.
+        // The hard security requirement: the secret middle must not leak into the rendered mask.
+        // Both the path tail segment and the secret substring sit between the visible windows.
         [Fact]
-        public void Mask_SlackUrl_SecretTailIsAbsentFromResult()
+        public void Mask_SlackUrl_SecretMiddleIsAbsentFromResult()
         {
             const string secret = "abcXYZsecret";
 
@@ -32,42 +34,52 @@ namespace HSMServer.Core.Tests.Notifications
 
             Assert.DoesNotContain(secret, masked);
             Assert.DoesNotContain("B0123456", masked);
+            // The visible tail ("cret") is allowed — it's only the last 4 chars, not the full secret.
         }
 
         [Fact]
-        public void Mask_MattermostExample_KeepsSchemeHostAndFirstSegment()
+        public void Mask_MattermostExample_KeepsHostPathPrefixAndTail()
         {
             var masked = WebhookUrlMasker.Mask("https://mattermost.example.com/hooks/abcd1234efgh5678");
 
-            Assert.Equal("https://mattermost.example.com/hooks/••••", masked);
+            // host verbatim + first 8 chars of PathAndQuery (`/hooks/a`) + marker + last 4 chars (`5678`).
+            Assert.Equal("https://mattermost.example.com/hooks/a••••5678", masked);
         }
 
         [Fact]
-        public void Mask_MattermostUrl_SecretTailIsAbsentFromResult()
+        public void Mask_MattermostUrl_SecretMiddleIsAbsentFromResult()
         {
             const string secret = "abcd1234efgh5678";
 
             var masked = WebhookUrlMasker.Mask($"https://mattermost.example.com/hooks/{secret}");
 
+            // The full secret must not appear; only its 8-char path-inclusive prefix and 4-char tail
+            // are visible. `/hooks/a` + `••••` + `5678`.
             Assert.DoesNotContain(secret, masked);
+            Assert.Contains("5678", masked);
         }
 
-        // A webhook URL with no path segment still gets the marker, so the POST-sentinel detection in
-        // ToUpdate works uniformly (any masked value ends in `••••`).
+        // A webhook URL with no path collapses to host + marker — the marker MUST be present so the
+        // POST sentinel detection (IsMasked) works for every masked value, and an empty path has
+        // nothing recognition-worthy to expose anyway.
         [Fact]
-        public void Mask_UrlWithoutPath_StillAppendsMarker()
+        public void Mask_UrlWithoutPath_ShowsHostAndMarkerOnly()
         {
             var masked = WebhookUrlMasker.Mask("https://hooks.slack.com");
 
             Assert.Equal("https://hooks.slack.com/••••", masked);
+            Assert.True(WebhookUrlMasker.IsMasked(masked));
         }
 
+        // A short path (≤ prefix+tail threshold) is also collapsed to the marker — showing it
+        // verbatim would leak the whole short secret, and the marker must be present for IsMasked.
         [Fact]
-        public void Mask_UrlWithOnlyRootPath_StillAppendsMarker()
+        public void Mask_UrlWithShortPath_ShowsHostAndMarkerOnly()
         {
-            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/");
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/short");
 
             Assert.Equal("https://hooks.slack.com/••••", masked);
+            Assert.True(WebhookUrlMasker.IsMasked(masked));
         }
 
         // Weird/unparseable input must mask rather than throw — a stored webhook should never be
@@ -75,7 +87,7 @@ namespace HSMServer.Core.Tests.Notifications
         [Fact]
         public void Mask_NonParseableInput_DoesNotThrowAndMasks()
         {
-            var masked = WebhookUrlMasker.Mask("not-a-url-with-a-slash/and/secret/tail");
+            var masked = WebhookUrlMasker.Mask("not-a-url-with-a-slash/and/secret/tail-value");
 
             Assert.NotNull(masked);
             Assert.Contains(WebhookUrlMasker.MaskMarker, masked);

--- a/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
@@ -183,5 +183,78 @@ namespace HSMServer.Core.Tests.Notifications
         {
             Assert.False(WebhookUrlMasker.IsMasked(null));
         }
+
+
+        // ValidatePosted classifies a POSTed webhook value against the stored URL. The masked
+        // sentinel must match Mask(stored) EXACTLY — the field is a plain editable input pre-filled
+        // with the mask, so a partial edit (e.g. changing only the host) must be rejected, not
+        // silently dropped. ResolveWebhook treats any IsMasked value as "no change", and IsMasked is
+        // just a substring test, so the controller-side exact-match guard is the only thing standing
+        // between a rotation attempt and a silent no-op (#1329 review).
+
+        [Fact]
+        public void ValidatePosted_EmptyPosted_Allowed_NoChange()
+        {
+            Assert.Null(WebhookUrlMasker.ValidatePosted("", "https://hooks.slack.com/services/stored-secret-token"));
+        }
+
+        [Fact]
+        public void ValidatePosted_NullPosted_Allowed_NoChange()
+        {
+            Assert.Null(WebhookUrlMasker.ValidatePosted(null, "https://hooks.slack.com/services/stored-secret-token"));
+        }
+
+        [Fact]
+        public void ValidatePosted_PostedEqualsMaskOfStored_Allowed_NoChange()
+        {
+            const string stored = "https://hooks.slack.com/services/stored-secret-token";
+            var posted = WebhookUrlMasker.Mask(stored); // exactly what the GET rendered
+
+            Assert.Null(WebhookUrlMasker.ValidatePosted(posted, stored));
+        }
+
+        // The regression: admin sees the masked value, edits just the host, saves. Without the
+        // exact-match guard this is swallowed (IsMasked is true → ResolveWebhook → null → no change),
+        // and the rotation silently fails while the success redirect plays.
+        [Fact]
+        public void ValidatePosted_PartiallyEditedMask_Rejected()
+        {
+            const string stored = "https://mattermost.old.com/hooks/stored-secret-token";
+            var posted = WebhookUrlMasker.Mask(stored).Replace("mattermost.old.com", "mattermost.new.com");
+
+            var error = WebhookUrlMasker.ValidatePosted(posted, stored);
+
+            Assert.NotNull(error);
+            Assert.Contains("Paste the full webhook URL", error);
+        }
+
+        // A different partial edit — tweaking the visible prefix of the mask — is just as silently
+        // dropped without the guard.
+        [Fact]
+        public void ValidatePosted_EditedVisiblePrefix_Rejected()
+        {
+            const string stored = "https://hooks.slack.com/services/stored-secret-token";
+            // Mask is `…/stor••••token`; change the visible head `stor` → `XXXX`.
+            var posted = WebhookUrlMasker.Mask(stored).Replace("stor", "XXXX");
+
+            Assert.NotNull(WebhookUrlMasker.ValidatePosted(posted, stored));
+        }
+
+        // A fresh full URL paste is always acceptable at this layer — URL-shape validation runs in
+        // the controller after this returns null.
+        [Fact]
+        public void ValidatePosted_RealUrl_Allowed()
+        {
+            Assert.Null(WebhookUrlMasker.ValidatePosted("https://hooks.slack.com/services/brand-new-token", "https://hooks.slack.com/services/stored-secret-token"));
+        }
+
+        // New-chat path: no stored URL, so the sentinel can't match. Empty posted (the expected
+        // new-chat value) is allowed; a stray masked value would be rejected.
+        [Fact]
+        public void ValidatePosted_NoStoredUrl_EmptyAllowed_MaskedRejected()
+        {
+            Assert.Null(WebhookUrlMasker.ValidatePosted("", null));
+            Assert.NotNull(WebhookUrlMasker.ValidatePosted("https://host/hooks/abcd••••5678", null));
+        }
     }
 }

--- a/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
+++ b/src/tests/HSMServer.Core.Tests/Notifications/WebhookUrlMaskerTests.cs
@@ -14,17 +14,29 @@ namespace HSMServer.Core.Tests.Notifications
             Assert.Null(WebhookUrlMasker.Mask(url));
         }
 
+        // The canonical example from the review discussion: Mattermost-style URL where the last path
+        // segment is the secret token. Scheme + host + preceding path segments stay verbatim; only
+        // the last segment is reduced to head4 + `••••` + tail4.
         [Fact]
-        public void Mask_SlackExample_KeepsHostPathPrefixAndTail()
+        public void Mask_LocalhostMattermostExample_MasksOnlyLastSegment()
+        {
+            var masked = WebhookUrlMasker.Mask("http://localhost:8065/hooks/nuddbzeoztbau8juhobap348fw");
+
+            Assert.Equal("http://localhost:8065/hooks/nudd••••48fw", masked);
+        }
+
+        [Fact]
+        public void Mask_SlackMultiSegmentUrl_MasksOnlyLastSegment()
         {
             var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/services/T0ABCDE/B0123456/abcXYZsecret");
 
-            // host verbatim + first 8 chars of PathAndQuery (`/service`) + marker + last 4 chars (`cret`).
-            Assert.Equal("https://hooks.slack.com/service••••cret", masked);
+            // All three path segments before the last stay verbatim; only `abcXYZsecret` is masked.
+            Assert.Equal("https://hooks.slack.com/services/T0ABCDE/B0123456/abcX••••cret", masked);
         }
 
-        // The hard security requirement: the secret middle must not leak into the rendered mask.
-        // Both the path tail segment and the secret substring sit between the visible windows.
+        // The hard security requirement: the secret middle of the last segment must not leak into
+        // the rendered mask. Only the full `secret` token must be absent — preceding path segments
+        // (B0123456) are structural and intentionally visible per the new format.
         [Fact]
         public void Mask_SlackUrl_SecretMiddleIsAbsentFromResult()
         {
@@ -33,17 +45,16 @@ namespace HSMServer.Core.Tests.Notifications
             var masked = WebhookUrlMasker.Mask($"https://hooks.slack.com/services/T0ABCDE/B0123456/{secret}");
 
             Assert.DoesNotContain(secret, masked);
-            Assert.DoesNotContain("B0123456", masked);
-            // The visible tail ("cret") is allowed — it's only the last 4 chars, not the full secret.
+            // The visible head/tail of the last segment ("abcX", "cret") are allowed — they're only
+            // 4 chars each, not the full secret.
         }
 
         [Fact]
-        public void Mask_MattermostExample_KeepsHostPathPrefixAndTail()
+        public void Mask_MattermostUrl_MasksOnlyLastSegment()
         {
             var masked = WebhookUrlMasker.Mask("https://mattermost.example.com/hooks/abcd1234efgh5678");
 
-            // host verbatim + first 8 chars of PathAndQuery (`/hooks/a`) + marker + last 4 chars (`5678`).
-            Assert.Equal("https://mattermost.example.com/hooks/a••••5678", masked);
+            Assert.Equal("https://mattermost.example.com/hooks/abcd••••5678", masked);
         }
 
         [Fact]
@@ -53,49 +64,51 @@ namespace HSMServer.Core.Tests.Notifications
 
             var masked = WebhookUrlMasker.Mask($"https://mattermost.example.com/hooks/{secret}");
 
-            // The full secret must not appear; only its 8-char path-inclusive prefix and 4-char tail
-            // are visible. `/hooks/a` + `••••` + `5678`.
+            // The full secret must not appear; only its 4-char head and 4-char tail are visible.
             Assert.DoesNotContain(secret, masked);
+            Assert.Contains("abcd", masked);
             Assert.Contains("5678", masked);
         }
 
-        // A webhook URL with no path collapses to host + marker — the marker MUST be present so the
-        // POST sentinel detection (IsMasked) works for every masked value, and an empty path has
-        // nothing recognition-worthy to expose anyway.
+        // A short last segment (≤ 8 chars = head+tail threshold) is shown verbatim per UX decision,
+        // with the marker appended as a trailing sentinel so IsMasked stays true (otherwise the
+        // round-tripped value would look like a fresh URL and overwrite the stored webhook on save).
         [Fact]
-        public void Mask_UrlWithoutPath_ShowsHostAndMarkerOnly()
+        public void Mask_LastSegmentShortEnough_ShownVerbatimWithTrailingMarker()
         {
-            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com");
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/services/short");
 
-            Assert.Equal("https://hooks.slack.com/••••", masked);
+            Assert.Equal("https://hooks.slack.com/services/short••••", masked);
             Assert.True(WebhookUrlMasker.IsMasked(masked));
         }
 
-        // A short path (≤ prefix+tail threshold) is also collapsed to the marker — showing it
-        // verbatim would leak the whole short secret, and the marker must be present for IsMasked.
+        // A webhook URL with no path (no '/' after the host) gets the marker appended so IsMasked
+        // stays true; nothing recognition-worthy is leaked since there's no token to show.
         [Fact]
-        public void Mask_UrlWithShortPath_ShowsHostAndMarkerOnly()
+        public void Mask_UrlWithoutPath_AppendsMarker()
         {
-            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com/short");
+            var masked = WebhookUrlMasker.Mask("https://hooks.slack.com");
 
-            Assert.Equal("https://hooks.slack.com/••••", masked);
+            Assert.Equal("https://hooks.slack.com••••", masked);
             Assert.True(WebhookUrlMasker.IsMasked(masked));
         }
 
         // Weird/unparseable input must mask rather than throw — a stored webhook should never be
-        // unparseable, but the helper is a boundary and must degrade safely.
+        // unparseable, but the helper is a boundary and must degrade safely. It still slices at the
+        // last '/' so the trailing segment is masked.
         [Fact]
-        public void Mask_NonParseableInput_DoesNotThrowAndMasks()
+        public void Mask_NonParseableInputWithSlashes_DoesNotThrowAndMasksLastSegment()
         {
-            var masked = WebhookUrlMasker.Mask("not-a-url-with-a-slash/and/secret/tail-value");
+            var masked = WebhookUrlMasker.Mask("not-a-url/and/secret-tail-value-here");
 
             Assert.NotNull(masked);
             Assert.Contains(WebhookUrlMasker.MaskMarker, masked);
-            Assert.DoesNotContain("secret", masked);
+            Assert.DoesNotContain("secret-tail-value-here", masked);
         }
 
         [Theory]
-        [InlineData("https://hooks.slack.com/services/••••")]
+        [InlineData("https://hooks.slack.com/services/abcX••••cret")]
+        [InlineData("https://hooks.slack.com/services/short••••")]
         [InlineData("prefix••••suffix")]
         public void IsMasked_ValueContainsMarker_ReturnsTrue(string url)
         {
@@ -103,8 +116,8 @@ namespace HSMServer.Core.Tests.Notifications
         }
 
         [Theory]
-        [InlineData("https://hooks.slack.com/services/real-url")]
-        [InlineData("https://mattermost.example.com/hooks/abcd1234")]
+        [InlineData("https://hooks.slack.com/services/real-url-token")]
+        [InlineData("https://mattermost.example.com/hooks/abcd1234efgh5678")]
         [InlineData("")]
         public void IsMasked_RealUrlOrEmpty_ReturnsFalse(string url)
         {


### PR DESCRIPTION
## Summary

EditChat rendered the full Slack/Mattermost webhook URL in cleartext into `<input type="url">`, exposing the secret to every ProductManager of every bound folder (EditChat is gated on `ProductManager`, not just admins). This PR masks the display value so the raw webhook is never recoverable from the page, while keeping the admin able to recognize and replace it.

- New `WebhookUrlMasker` reduces the display value to `scheme://host` + first path segment + a fixed marker (`https://hooks.slack.com/services/••••`). The marker doubles as the POST sentinel.
- `ChatViewModel.ToUpdate` emits `null` ("no change") when the posted value is empty or masked; a real pasted URL overwrites. `Chat.ApplyUpdate` already does `?? current`, so null preserves the stored cleartext. No hidden field, no client-controlled comparison.
- `[Url]` removed from both props (the masked value fails `Uri.TryCreate`); URL-shape validation moved server-side into `NotificationsController.ValidateWebhooks`, keeping `chats_validation.spec.ts` ("invalid URL rejected") passing.
- `type="url"` → `type="text"` on both inputs (the masked value is no longer a real URL).

## Test plan

- [x] Unit: `WebhookUrlMaskerTests` — 16 cases pass (null/empty, Slack/Mattermost examples, secret-tail-absent, no-path, unparseable input, `IsMasked` true/false).
- [x] `dotnet build` HSMServer — 0 errors.
- [ ] Playwright (requires local server + seeded fixtures, not run in this session):
  - `chats_edit.spec.ts` — new masking test (Slack + Mattermost): reopen shows mask; `page.content()` does not contain the raw secret; save other fields → webhook survives; replace → mask reflects new value. Plus updated line 116 assertion to masked value.
  - `modify_folder_chat.spec.ts` line 182 — updated assertion to masked value.
  - `chats_validation.spec.ts` — re-run to confirm "invalid URL rejected" still passes with `[Url]` removed.
- [ ] Manual acceptance (matches #1329 criteria): open EditChat for a chat with a stored Slack webhook → field shows `https://hooks.slack.com/services/••••`; verify via view-source / Network response body / input `value` attr that the raw URL is absent; save Name/Description without touching the webhook → reopen shows same mask; type a new URL → save → reopen shows new mask, "Send test" still works.

## Out of scope (per issue)

- At-rest webhook encryption.
- Test-message flow (already uses stored cleartext server-side).
- Folder-binding / role-filter semantics.
- Telegram ChatId masking (non-secret numeric id).

Closes #1329

🤖 Generated with [Claude Code](https://claude.com/claude-code)