### PR TITLE
chore(server): bump HSMDataCollector to 3.5.0

### DIFF
--- a/src/server/HSMServer.Core/HSMServer.Core.csproj
+++ b/src/server/HSMServer.Core/HSMServer.Core.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="HSMDataCollector.HSMDataCollector" Version="3.4.12" />
+    <PackageReference Include="HSMDataCollector.HSMDataCollector" Version="3.5.0" />
     <ProjectReference Include="..\..\api\HSMSensorDataObjects\HSMSensorDataObjects.csproj" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.0.5" />

--- a/src/server/HSMServer/HSMServer.csproj
+++ b/src/server/HSMServer/HSMServer.csproj
@@ -41,7 +41,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation.AspNetCore" Version="11.3.1" />
-    <PackageReference Include="HSMDataCollector.HSMDataCollector" Version="3.4.12" />
+    <PackageReference Include="HSMDataCollector.HSMDataCollector" Version="3.5.0" />
     <ProjectReference Include="..\..\api\HSMSensorDataObjects\HSMSensorDataObjects.csproj" />
     <PackageReference Include="HtmlSanitizer" Version="9.0.886" />
     <PackageReference Include="Markdig" Version="0.41.3" />


### PR DESCRIPTION
## Summary
- Bumps `HSMDataCollector.HSMDataCollector` from **3.4.12 → 3.5.0** in the two server projects only:
  - `src/server/HSMServer/HSMServer.csproj`
  - `src/server/HSMServer.Core/HSMServer.Core.csproj`
- Other consumers (`HSMPingModule`, `PerformanceTest` sandbox, `DataCollectorSendingFileTest`) are intentionally left untouched per request — server-only scope.
- 3.5.0 is the latest collector release published to NuGet with a corresponding release commit in this repo (`760e3bda1`, PR #1322). A `4.0.2` also exists on NuGet but has **no** release commit in the repo, so it is excluded as an unverified publication.

### What ships in collector 3.5.0
- Top-CPU sensors nest under `.computer` (#1318).
- Per-interface network speed sensors (rx/tx MB/sec) (#1189).
- C# log-quality fixes (quiet graceful-stop discard, HTTP code in single-command failure).

## Verification
- `dotnet build src/server/HSMServer/HSMServer.csproj -c Release` → **0 errors**, only pre-existing warnings (XML doc, xUnit analyzers). Package restore resolved 3.5.0 cleanly.

## Test plan
- [x] Server solution builds against 3.5.0
- [ ] CI green on this PR
- [ ] Smoke-test: server boots and a collector agent can still register/send values against the bumped server

🤖 Generated with [Claude Code](https://claude.com/claude-code)