### PR TITLE
claude skills: land the trial configuration that missed the #1332 merge

### DIFF
--- a/.claude/plugins/matt/skills/setup-matt-pocock-skills/SKILL.md
+++ b/.claude/plugins/matt/skills/setup-matt-pocock-skills/SKILL.md
@@ -106,7 +106,7 @@ Then write the docs files using the seed templates in this skill folder as a sta
 - [issue-tracker-github.md](./issue-tracker-github.md) — GitHub issue tracker
 - [issue-tracker-gitlab.md](./issue-tracker-gitlab.md) — GitLab issue tracker
 - [issue-tracker-local.md](./issue-tracker-local.md) — local-markdown issue tracker
-- [triage-labels.md](./matt:triage-labels.md) — label mapping (only if `triage` is installed)
+- [triage-labels.md](./triage-labels.md) — label mapping (only if `triage` is installed)
 - [domain.md](./domain.md) — domain doc consumer rules + layout
 
 For "other" issue trackers, write `docs/agents/issue-tracker.md` from scratch using the user's description.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,3 +157,17 @@ When adding new functionality:
 - Public collector APIs, DTOs in `HSMSensorDataObjects`, C++ wrapper headers, and serialized storage formats are compatibility-sensitive.
 - Treat scheduler/lifecycle, storage key formats, alert delivery, notification routing, and long-running queues as high-risk areas.
 - Document intentional breaking changes explicitly in PR text and public docs.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues in `SoftFx/Hierarchical-Sensor-Monitoring`, via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical roles, each label string equal to its name, all present in the repo. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` at the repo root, ADRs under `docs/adr/`. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,58 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/matt:domain-modeling` skill (reached via `/matt:grill-with-docs` and `/matt:improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## This repo already has canonical docs
+
+HSM keeps AI-readable documentation in `aicontext/` (glossary at `aicontext/glossary.md`) and durable
+decisions under `docs/decisions/`. The layout below is the one these skills were written for, and both
+exist side by side for the duration of the skills trial — see `.claude/plugins/matt/README.md` for why,
+and what has to be decided at the end of it.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/matt:domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,47 @@
+# Issue tracker: GitHub
+
+Repo: `SoftFx/Hierarchical-Sensor-Monitoring` (public). `gh` infers it from the remote.
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/matt:triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/matt:wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -14,6 +14,6 @@ When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the 
 
 Edit the right-hand column to match whatever vocabulary you actually use.
 
-**Not yet created in this repo.** Of the five, only `wontfix` exists today. The other four have to be
-created before `/matt:triage` can apply them — `gh label create needs-triage`, and so on. Creating
-labels in a shared public repo is a maintainer decision, so this file records the intent and stops there.
+All five exist in the repo. `wontfix` was already there; `needs-triage`, `needs-info`,
+`ready-for-agent` and `ready-for-human` were created for the trial, so `/matt:triage` can apply them
+without inventing anything.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,19 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.
+
+**Not yet created in this repo.** Of the five, only `wontfix` exists today. The other four have to be
+created before `/matt:triage` can apply them — `gh label create needs-triage`, and so on. Creating
+labels in a shared public repo is a maintainer decision, so this file records the intent and stops there.


### PR DESCRIPTION
#1332 was merged at `e7cb29390`, three commits before the branch tip. This lands the remainder, rebuilt against the post-merge `master` where `CLAUDE.md` is now the canonical file.

## What was left behind

| Commit | Content |
| --- | --- |
| `675fbd051` | fixes `./matt:triage-labels.md` — the namespace rewrite matched a relative link path, since a leading dot is not a word character. One occurrence; the other 30 relative links were untouched |
| `8ea0d0261` | the output of `/matt:setup-matt-pocock-skills`: `docs/agents/issue-tracker.md`, `triage-labels.md`, `domain.md`, and the `## Agent skills` block |
| `21b2b5bf9` | the config files now say the five triage labels exist, because they were created |

Without the middle one the trial cannot actually start: `to-spec`, `to-tickets`, `triage`, `wayfinder` and `matt:code-review` all refuse to run without `docs/agents/issue-tracker.md`, which is exactly the file that missed the merge.

## Conflict resolution

`8ea0d0261` appended the `## Agent skills` block to what was then a three-line pointer. #1336 has since made `CLAUDE.md` the canonical 152 lines, so the cherry-pick conflicted. Resolved as planned in that commit's message: the canonical text stands, the block goes at the end. Nothing from either side was dropped — `CLAUDE.md` is now 174 lines, ending in the block.

## Configuration recorded

- **Issue tracker** — GitHub via `gh`; PRs deliberately left out of the triage surface. Wayfinder's map/child/blocking recipes come with the template.
- **Triage labels** — the five canonical roles. `wontfix` already existed; `needs-triage`, `needs-info`, `ready-for-agent` and `ready-for-human` were created in this repo, so `/matt:triage` applies an existing vocabulary rather than inventing one.
- **Domain docs** — the single-context layout the skills expect, with a note that `aicontext/` and `docs/decisions/` are this repo's canon and that both live side by side for the duration of the trial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
